### PR TITLE
fix(models): tighten P-mu diagnostic review follow-ups

### DIFF
--- a/docs/api/models/phase/Overview.md
+++ b/docs/api/models/phase/Overview.md
@@ -68,10 +68,10 @@ result = Models.run_phase_pipeline(
   - `first_order_boundary.csv`
   - `spinodal.csv`
   - `crossover_line.csv`
-- `phase_summary.json`
-- `pm_branch_scan.csv`
-- `pm_phase_summary.json`
-- `pm_vs_maxwell.csv`
+  - `phase_summary.json`
+  - `pm_branch_scan.csv`
+  - `pm_phase_summary.json`
+  - `pm_vs_maxwell.csv`
   - `phase_report.md`
 
 ## 常见使用模式

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -84,13 +84,7 @@ export resolve_phase_output_target, promote_phase_artifacts
 export CEPResult, PromotionResult, PhasePipelineResult
 export PM_BRANCH_STATUSES, PM_SEED_SOURCES, PM_ENDPOINT_CAUSES, PM_COMPARISON_STATUSES
 export PMSeedPair, normalize_pm_seed_pair, pm_next_seed_source
-export _pm_interpolate_transition_mu, _pm_extract_endpoints, _pm_has_bistable_window
-export _pm_compare_with_maxwell, _pm_pressure_crosscheck
-export _pm_accept_branch_point, _pm_check_branch_continuity
 export derive_pm_seed_pair, analyze_pm_branch_competition
-export _pm_branch_scan_fieldnames, _pm_branch_scan_record
-export _pm_maxwell_reference_from_rows
-export _pm_refine_transition_bracket
 export Integrals, cached_nodes, vacuum_integral, calculate_energy_sum, calculate_number_densities
 export Constants_PNJL
 export TmuScanConfig, TrhoScanConfig

--- a/src/models/entrypoints.jl
+++ b/src/models/entrypoints.jl
@@ -15,12 +15,6 @@ export solve_gap_and_meson_point
 export run_phase_pipeline, find_cep, build_phase_artifacts
 export resolve_phase_output_target, promote_phase_artifacts
 export normalize_pm_seed_pair, pm_next_seed_source, derive_pm_seed_pair, analyze_pm_branch_competition
-export _pm_branch_scan_fieldnames, _pm_branch_scan_record
-export _pm_maxwell_reference_from_rows
-export _pm_refine_transition_bracket
-export _pm_interpolate_transition_mu, _pm_extract_endpoints, _pm_has_bistable_window
-export _pm_compare_with_maxwell, _pm_pressure_crosscheck
-export _pm_accept_branch_point, _pm_check_branch_continuity
 export transport_workflow_module, meson_workflow_module
 export workflow_param_adapters_module
 export pnjl_module

--- a/src/models/phase/PMPhaseDiagnostic.jl
+++ b/src/models/phase/PMPhaseDiagnostic.jl
@@ -1,3 +1,11 @@
+function _pm_normalize_mev_grid(values, name::String)
+    values isa AbstractVector || throw(ArgumentError("$name must be an AbstractVector"))
+    normalized = collect(Float64, values)
+    isempty(normalized) && throw(ArgumentError("$name must not be empty"))
+    all(isfinite, normalized) || throw(ArgumentError("$name must contain only finite values"))
+    return normalized
+end
+
 function _pm_interpolate_transition_mu(rows)
     length(rows) >= 2 || return nothing
     left = rows[1]
@@ -394,19 +402,23 @@ function analyze_pm_branch_competition(;
         residual_accept_tol::Float64=1e-6,
         continuity_x_tol::Float64=0.25,
         continuity_rho_tol::Float64=0.15)
+    T_values_vec = _pm_normalize_mev_grid(T_values, "T_values")
+    mu_grid_vec = _pm_normalize_mev_grid(mu_grid, "mu_grid")
+    issorted(mu_grid_vec) || throw(ArgumentError("mu_grid must be sorted in ascending order"))
+
     branch_rows = NamedTuple[]
     temperature_summaries = NamedTuple[]
     comparison_rows = NamedTuple[]
 
-    for T_MeV in T_values
-        local_seed_pair = isnothing(seed_pair) ? derive_pm_seed_pair(T_MeV, mu_grid;
+    for T_MeV in T_values_vec
+        local_seed_pair = isnothing(seed_pair) ? derive_pm_seed_pair(T_MeV, mu_grid_vec;
             xi=xi,
             solver_backend=solver_backend,
             p_num=p_num,
             t_num=t_num,
             residual_accept_tol=residual_accept_tol) : normalize_pm_seed_pair(seed_pair)
 
-        rows = _pm_branch_rows_for_temperature(T_MeV, mu_grid, local_seed_pair;
+        rows = _pm_branch_rows_for_temperature(T_MeV, mu_grid_vec, local_seed_pair;
             xi=xi,
             solver_backend=solver_backend,
             p_num=p_num,

--- a/src/models/phase/PMPhaseSeeds.jl
+++ b/src/models/phase/PMPhaseSeeds.jl
@@ -1,8 +1,12 @@
+@inline function _pm_getfield_or_default(x, name::Symbol, default)
+    return hasproperty(x, name) ? getproperty(x, name) : default
+end
+
 function normalize_pm_seed_pair(seed_pair)
     hadron_seed0 = Float64.(collect(seed_pair.hadron_seed0))
     quark_seed0 = Float64.(collect(seed_pair.quark_seed0))
-    continuity_mode = get(seed_pair, :continuity_mode, :branch_local)
-    fallback_mode = get(seed_pair, :fallback_mode, :none)
+    continuity_mode = _pm_getfield_or_default(seed_pair, :continuity_mode, :branch_local)
+    fallback_mode = _pm_getfield_or_default(seed_pair, :fallback_mode, :none)
     return PMSeedPair(
         hadron_seed0=hadron_seed0,
         quark_seed0=quark_seed0,
@@ -64,6 +68,8 @@ function derive_pm_seed_pair(T_MeV::Real, mu_grid;
         residual_accept_tol::Float64=1e-6)
     mu_values = collect(Float64, mu_grid)
     isempty(mu_values) && throw(ArgumentError("mu_grid must not be empty"))
+    all(isfinite, mu_values) || throw(ArgumentError("mu_grid must contain only finite values"))
+    issorted(mu_values) || throw(ArgumentError("mu_grid must be sorted in ascending order"))
 
     hadron_seed = copy(HADRON_SEED_5)
     quark_seed = copy(QUARK_SEED_5)

--- a/tests/unit/models/test_pm_phase_diagnostic.jl
+++ b/tests/unit/models/test_pm_phase_diagnostic.jl
@@ -249,8 +249,9 @@ end
         solver_backend=:legacy,
         p_num=24,
         t_num=8,
-        output_dir=mktempdir(),
+        output_dir=tempname(),
     )
+
     @test_throws ArgumentError Models.analyze_pm_branch_competition(
         T_values=[130.9],
         mu_grid=[290.9, NaN],
@@ -258,7 +259,7 @@ end
         solver_backend=:legacy,
         p_num=24,
         t_num=8,
-        output_dir=mktempdir(),
+        output_dir=tempname(),
     )
 end
 

--- a/tests/unit/models/test_pm_phase_diagnostic.jl
+++ b/tests/unit/models/test_pm_phase_diagnostic.jl
@@ -29,6 +29,16 @@ end
     @test seed_pair.continuity_mode == :branch_local
     @test seed_pair.fallback_mode == :none
 
+    struct_seed_pair = Models.PMSeedPair(
+        hadron_seed0=[7.0, 8.0],
+        quark_seed0=[9.0, 10.0],
+        continuity_mode=:branch_local,
+        fallback_mode=:none,
+    )
+    normalized_struct = Models.normalize_pm_seed_pair(struct_seed_pair)
+    @test normalized_struct.hadron_seed0 == [7.0, 8.0]
+    @test normalized_struct.quark_seed0 == [9.0, 10.0]
+
     @test isdefined(Models, :pm_next_seed_source)
     @test Models.pm_next_seed_source(true, :hadron) == :previous_same_branch
     @test Models.pm_next_seed_source(false, :hadron) == :seed0
@@ -228,4 +238,33 @@ end
     @test refined[1].mu_MeV == 291.10
     @test refined[end].mu_MeV == 291.20
     @test refined[2].mu_MeV == 291.11
+end
+
+@testset "PM phase diagnostic input contract" begin
+    @test_throws ArgumentError Models.derive_pm_seed_pair(130.9, [291.2, 291.0, 291.1])
+    @test_throws ArgumentError Models.analyze_pm_branch_competition(
+        T_values=130.9,
+        mu_grid=[290.9, 291.0],
+        xi=0.0,
+        solver_backend=:legacy,
+        p_num=24,
+        t_num=8,
+        output_dir=mktempdir(),
+    )
+    @test_throws ArgumentError Models.analyze_pm_branch_competition(
+        T_values=[130.9],
+        mu_grid=[290.9, NaN],
+        xi=0.0,
+        solver_backend=:legacy,
+        p_num=24,
+        t_num=8,
+        output_dir=mktempdir(),
+    )
+end
+
+@testset "PM helper exports stay internal" begin
+    @test !Base.isexported(Models, :_pm_interpolate_transition_mu)
+    @test !Base.isexported(Models, :_pm_branch_scan_fieldnames)
+    @test !Base.isexported(Models, :_pm_maxwell_reference_from_rows)
+    @test !Base.isexported(Models, :_pm_refine_transition_bracket)
 end


### PR DESCRIPTION
## Summary
- fix `PMSeedPair` normalization so derived seed structs work without `get(...)` errors and enforce ascending finite `mu_grid` inputs
- validate `analyze_pm_branch_competition(...)` inputs early and keep underscore-prefixed PM helpers out of the exported public surface
- clean up the phase overview artifact list formatting to match the intended Markdown structure

## Test Plan
- [x] `julia --project=. -e 'ENV[\"UNIT_FILES\"]=\"models/test_pm_phase_diagnostic.jl\"; include(\"tests/unit/runtests.jl\")'`
- [x] `julia --project=. tests/integration/models/test_pm_phase_diagnostic_smoke.jl`
- [x] `julia --project=. scripts/dev/check_docs_consistency.jl`

## Context
- follow-up patch for PR #7 after merge
- addresses the Copilot review threads that were discussed and resolved