### PR TITLE
refactor(relaxtime): extract kernel helper boundaries and lock unit contracts

### DIFF
--- a/src/relaxtime/AverageScatteringRate.jl
+++ b/src/relaxtime/AverageScatteringRate.jl
@@ -830,6 +830,61 @@ function number_density(flavor::Symbol, m::Float64, μ::Float64, T::Float64, Φ:
 end
 
 # -------------------- 平均散射率主函数 --------------------
+
+@inline function _resolve_auto_threshold_subtraction(
+    threshold_subtraction::Bool,
+    mi::Float64,
+    mj::Float64,
+    mc::Float64,
+    md::Float64,
+)::Bool
+    if (mi^2 + mj^2) > (mc^2 + md^2)
+        return true
+    end
+    return threshold_subtraction
+end
+
+@inline function _resolve_sigma_support_bounds(
+    mi::Float64,
+    mj::Float64,
+    mc::Float64,
+    md::Float64,
+    sigma_cutoff::Union{Nothing,Float64},
+    p_grid::Union{Nothing,Vector{Float64}},
+    p_w::Union{Nothing,Vector{Float64}},
+)::Tuple{Float64,Float64,Float64}
+    has_finite_p_cut = (p_grid !== nothing && p_w !== nothing)
+    Λ = if sigma_cutoff !== nothing
+        sigma_cutoff
+    elseif has_finite_p_cut
+        maximum(p_grid)
+    else
+        NaN
+    end
+
+    s_bo = max((mi + mj)^2, (mc + md)^2)
+    s_up = if !isnan(Λ)
+        min((sqrt(mi^2 + Λ^2) + sqrt(mj^2 + Λ^2))^2,
+            (sqrt(mc^2 + Λ^2) + sqrt(md^2 + Λ^2))^2)
+    else
+        Inf
+    end
+    return Λ, s_bo, s_up
+end
+
+@inline function _ensure_default_angle_grids(
+    cos_grid::Union{Nothing,Vector{Float64}},
+    cos_w::Union{Nothing,Vector{Float64}},
+    phi_grid::Union{Nothing,Vector{Float64}},
+    phi_w::Union{Nothing,Vector{Float64}},
+    angle_nodes::Int,
+    phi_nodes::Int,
+)
+    cos_grid === nothing && ((cos_grid, cos_w) = _cached_interval_grid(-1.0, 1.0, angle_nodes))
+    phi_grid === nothing && ((phi_grid, phi_w) = _cached_interval_grid(0.0, TWO_PI, phi_nodes))
+    return cos_grid, cos_w, phi_grid, phi_w
+end
+
 """
     average_scattering_rate(process, quark_params, thermo_params, K_coeffs; kwargs...)
 
@@ -888,12 +943,7 @@ function average_scattering_rate(
     # Build the finalized σ-cache strategy by default.
     # 如果指定了 sigma_cutoff，则使用有限截断的 w0cdf 设计
     if cs_cache === nothing
-        # force-enable threshold subtraction for processes where initial total mass
-        # (mi^2 + mj^2) is greater than final total mass (mc^2 + md^2).
-        thr_for_build = threshold_subtraction
-        if (mi^2 + mj^2) > (mc^2 + md^2)
-            thr_for_build = true
-        end
+        thr_for_build = _resolve_auto_threshold_subtraction(threshold_subtraction, mi, mj, mc, md)
         cs_cache = build_w0cdf_pchip_cache(
             process,
             quark_params,
@@ -949,28 +999,9 @@ function _average_scattering_rate_semi_infinite(
         p_vals, quadrature_wts = _cached_semi_infinite_momentum_grid(p_nodes, scale)
     end
 
-    # If numerator uses a finite cutoff grid, optionally apply the same s-domain cuts as Fortran:
-    #   s_bo = max((mi+mj)^2, (mc+md)^2) * (1+1e-3)
-    #   s_up = min((Ei_max+Ej_max)^2, (Ec_max+Ed_max)^2) with Ei_max = sqrt(mi^2+Λ^2)
-    has_finite_p_cut = (p_grid !== nothing && p_w !== nothing)
-    # 使用 sigma_cutoff 参数（如果提供）来确定 s 范围，否则从动量网格推断
-    Λ = if sigma_cutoff !== nothing
-        sigma_cutoff
-    elseif has_finite_p_cut
-        maximum(p_vals)
-    else
-        NaN
-    end
-    s_bo = max((mi + mj)^2, (mc + md)^2)
-    s_up = if !isnan(Λ)
-        min((sqrt(mi^2 + Λ^2) + sqrt(mj^2 + Λ^2))^2,
-            (sqrt(mc^2 + Λ^2) + sqrt(md^2 + Λ^2))^2)
-    else
-        Inf
-    end
-    # 使用完整积分区间 [-1,1] 和 [0,2π]
-    cos_grid === nothing && ((cos_grid, cos_w) = _cached_interval_grid(-1.0, 1.0, angle_nodes))
-    phi_grid === nothing && ((phi_grid, phi_w) = _cached_interval_grid(0.0, TWO_PI, phi_nodes))
+    # 使用 sigma_cutoff 参数（如果提供）来确定 s 范围，否则从动量网格推断。
+    Λ, s_bo, s_up = _resolve_sigma_support_bounds(mi, mj, mc, md, sigma_cutoff, p_grid, p_w)
+    cos_grid, cos_w, phi_grid, phi_w = _ensure_default_angle_grids(cos_grid, cos_w, phi_grid, phi_w, angle_nodes, phi_nodes)
 
     # 数密度（用于归一化）
     # - 默认：半无穷积分 [0,∞)

--- a/src/relaxtime/RelaxationTime.jl
+++ b/src/relaxtime/RelaxationTime.jl
@@ -128,6 +128,74 @@ end
     return _get_rate(rates, resolved_key)
 end
 
+@inline function _density_map(densities::NamedTuple)
+    return (
+        u=density_value(densities, :u),
+        d=density_value(densities, :d),
+        s=density_value(densities, :s),
+        ubar=density_value(densities, :ubar),
+        dbar=density_value(densities, :dbar),
+        sbar=density_value(densities, :sbar),
+    )
+end
+
+@inline function _rate_map(rates::NamedTuple)
+    return (
+        uu=rate_value(rates, :uu_to_uu),
+        ud=rate_value(rates, :ud_to_ud),
+        us=rate_value(rates, :us_to_us),
+        udbar=rate_value(rates, :udbar_to_udbar),
+        dubar=rate_value(rates, :dubar_to_dubar),
+        uubar=rate_value(rates, :uubar_to_uubar),
+        uubar_ddbar=rate_value(rates, :uubar_to_ddbar),
+        usbar=rate_value(rates, :usbar_to_usbar),
+        subar=rate_value(rates, :subar_to_subar),
+        uubar_ssbar=rate_value(rates, :uubar_to_ssbar),
+        ss=rate_value(rates, :ss_to_ss),
+        ssbar_uubar=rate_value(rates, :ssbar_to_uubar),
+        ssbar=rate_value(rates, :ssbar_to_ssbar),
+        ubardbar=rate_value(rates, :ubardbar_to_ubardbar),
+        ubarubar=rate_value(rates, :ubarubar_to_ubarubar),
+        ubarsbar=rate_value(rates, :ubarsbar_to_ubarsbar),
+        sbarsbar=rate_value(rates, :sbarsbar_to_sbarsbar),
+    )
+end
+
+@inline function _species_omega_u(n, w)
+    return n.u * (w.uu + w.ud) +
+           n.ubar * (w.uubar + w.uubar_ddbar + w.uubar_ssbar + w.udbar) +
+           n.s * w.us +
+           n.sbar * w.usbar
+end
+
+@inline function _species_omega_s(n, w)
+    return 2.0 * n.u * w.us +
+           2.0 * n.ubar * w.usbar +
+           n.s * w.ss +
+           n.sbar * (w.ssbar + 2.0 * w.ssbar_uubar)
+end
+
+@inline function _species_omega_ubar(n, w)
+    return n.u * (w.uubar + w.uubar_ddbar + w.uubar_ssbar + w.dubar) +
+           n.ubar * (w.ubardbar + w.ubarubar) +
+           n.s * w.subar +
+           n.sbar * w.ubarsbar
+end
+
+@inline function _species_omega_sbar(n, w)
+    return 2.0 * n.u * w.usbar +
+           2.0 * n.ubar * w.ubarsbar +
+           n.sbar * w.sbarsbar +
+           n.s * (w.ssbar + 2.0 * w.ssbar_uubar)
+end
+
+@inline function _warn_and_clamp_nonnegative(omega_u::Real, omega_s::Real, omega_ubar::Real, omega_sbar::Real)
+    if omega_u < -1e-12 || omega_s < -1e-12 || omega_ubar < -1e-12 || omega_sbar < -1e-12
+        @warn "negative relaxation rate encountered; clamping to 0" omega_u=omega_u omega_s=omega_s omega_ubar=omega_ubar omega_sbar=omega_sbar
+    end
+    return max(omega_u, 0.0), max(omega_s, 0.0), max(omega_ubar, 0.0), max(omega_sbar, 0.0)
+end
+
 @inline function rate_value(rates, key::Symbol)
     return _rate_value_core(normalize_symbol_mapping_input(rates, "rates"), key)
 end
@@ -303,69 +371,21 @@ function _relaxation_rates_core(
     densities::NamedTuple,
     rates::NamedTuple,
 )::NamedTuple
-    n_u = density_value(densities, :u)
-    n_d = density_value(densities, :d)
-    n_s = density_value(densities, :s)
-    n_ubar = density_value(densities, :ubar)
-    n_dbar = density_value(densities, :dbar)
-    n_sbar = density_value(densities, :sbar)
+    n = _density_map(densities)
+    w = _rate_map(rates)
 
-    w_uu = rate_value(rates, :uu_to_uu)
-    w_ud = rate_value(rates, :ud_to_ud)
-    w_us = rate_value(rates, :us_to_us)
-    w_udbar = rate_value(rates, :udbar_to_udbar)
-    w_dubar = rate_value(rates, :dubar_to_dubar)
-    w_uubar = rate_value(rates, :uubar_to_uubar)
-    w_uubar_ddbar = rate_value(rates, :uubar_to_ddbar)
-    w_usbar = rate_value(rates, :usbar_to_usbar)
-    w_subar = rate_value(rates, :subar_to_subar)
-    w_uubar_ssbar = rate_value(rates, :uubar_to_ssbar)
-    w_ss = rate_value(rates, :ss_to_ss)
-    w_ssbar_uubar = rate_value(rates, :ssbar_to_uubar)
-    w_ssbar = rate_value(rates, :ssbar_to_ssbar)
-
-    # Additional rates for antiquark relaxation times
-    w_ubardbar = rate_value(rates, :ubardbar_to_ubardbar)
-    w_ubarubar = rate_value(rates, :ubarubar_to_ubarubar)
-    w_ubarsbar = rate_value(rates, :ubarsbar_to_ubarsbar)
-    w_sbarsbar = rate_value(rates, :sbarsbar_to_sbarsbar)
-
-    # u quark (shared with d by isospin symmetry)
-    omega_u = n_u * (w_uu + w_ud) +
-              n_ubar * (w_uubar + w_uubar_ddbar + w_uubar_ssbar + w_udbar) +
-              n_s * w_us +
-              n_sbar * w_usbar
-
-    # s quark
-    omega_s = 2.0 * n_u * w_us +
-              2.0 * n_ubar * w_usbar +
-              n_s * w_ss +
-              n_sbar * (w_ssbar + 2.0 * w_ssbar_uubar)
-
+    omega_u = _species_omega_u(n, w)
+    omega_s = _species_omega_s(n, w)
     # anti-u (shared with anti-d)
     # Matches Fortran: tau_lb = 1 / (
     #   n_u*(w6+w7+w9+wa5) + n_ub*(wa1+wa2) + n_s*wa6 + n_sb*wa3 )
-    omega_ubar = n_u * (w_uubar + w_uubar_ddbar + w_uubar_ssbar + w_dubar) +
-                 n_ubar * (w_ubardbar + w_ubarubar) +
-                 n_s * w_subar +
-                 n_sbar * w_ubarsbar
-
+    omega_ubar = _species_omega_ubar(n, w)
     # anti-s
     # Matches Fortran: tau_sb = 1 / (
     #   2*n_u*w8 + 2*n_ub*wa3 + n_sb*wa4 + n_s*(w11+2*w10) )
-    omega_sbar = 2.0 * n_u * w_usbar +
-                 2.0 * n_ubar * w_ubarsbar +
-                 n_sbar * w_sbarsbar +
-                 n_s * (w_ssbar + 2.0 * w_ssbar_uubar)
+    omega_sbar = _species_omega_sbar(n, w)
 
-    # 数值保护：平均速率应非负；若出现明显负值，提示但仍钳制到 0。
-    if omega_u < -1e-12 || omega_s < -1e-12 || omega_ubar < -1e-12 || omega_sbar < -1e-12
-        @warn "negative relaxation rate encountered; clamping to 0" omega_u=omega_u omega_s=omega_s omega_ubar=omega_ubar omega_sbar=omega_sbar
-    end
-    omega_u = max(omega_u, 0.0)
-    omega_s = max(omega_s, 0.0)
-    omega_ubar = max(omega_ubar, 0.0)
-    omega_sbar = max(omega_sbar, 0.0)
+    omega_u, omega_s, omega_ubar, omega_sbar = _warn_and_clamp_nonnegative(omega_u, omega_s, omega_ubar, omega_sbar)
 
     return (
         u = omega_u,

--- a/tests/unit/relaxtime/test_average_scattering_rate.jl
+++ b/tests/unit/relaxtime/test_average_scattering_rate.jl
@@ -10,15 +10,35 @@ end
 using Main.AverageScatteringRate
 using Main.ParameterTypes: QuarkParams, ThermoParams
 using Main.GaussLegendre: gauleg
+using Main.TotalCrossSection: total_cross_section
+using Main.OneLoopIntegrals: A
+using Main.EffectiveCouplings: calculate_G_from_A, calculate_effective_couplings
+using Main.Constants_PNJL: G_fm2, K_fm5
 
 # 构造简化参数，降低节点以加快单测
 const QUARK_PARAMS = (
     m = (u = 1.52, d = 1.52, s = 2.50),
-    μ = (u = 0.3, d = 0.3, s = 0.0)
+    μ = (u = 0.3, d = 0.3, s = 0.0),
+    A = (u = 0.2, d = 0.2, s = 0.2)
 )
 const THERMO_ISO = (T = 0.15, Φ = 0.5, Φbar = 0.5, ξ = 0.0)
 const THERMO_ANISO = (T = 0.15, Φ = 0.5, Φbar = 0.5, ξ = 0.2)
-const K_COEFFS = (K_σπ=2.0, K_σK=2.0, K_σ=3.0, K_δπ=1.5, K_δK=1.5)
+const K_COEFFS = begin
+    nodes_p, weights_p = gauleg(0.0, 20.0, 16)
+    A_u = A(QUARK_PARAMS.m.u, QUARK_PARAMS.μ.u, THERMO_ISO.T, THERMO_ISO.Φ, THERMO_ISO.Φbar, nodes_p, weights_p)
+    A_s = A(QUARK_PARAMS.m.s, QUARK_PARAMS.μ.s, THERMO_ISO.T, THERMO_ISO.Φ, THERMO_ISO.Φbar, nodes_p, weights_p)
+    G_u = calculate_G_from_A(A_u, QUARK_PARAMS.m.u)
+    G_s = calculate_G_from_A(A_s, QUARK_PARAMS.m.s)
+    calculate_effective_couplings(G_fm2, K_fm5, G_u, G_s)
+end
+
+function reference_sigma(process::Symbol, s::Float64)
+    return total_cross_section(process, s, QUARK_PARAMS, THERMO_ISO, K_COEFFS; n_points=4)
+end
+
+function cache_sigma(cache::CrossSectionCache, s::Float64)
+    return AverageScatteringRate.get_sigma(cache, s, QUARK_PARAMS, THERMO_ISO, K_COEFFS; n_points=4)
+end
 
 function constant_sigma_cache(process::Symbol; sigma::Float64=1.0)
     cache = CrossSectionCache(process)
@@ -102,6 +122,187 @@ end
     @test AverageScatteringRate.interpolate_sigma(cache, 10.0) == 1.0
     @test AverageScatteringRate.interpolate_sigma(cache, 20.0) == 3.0
     @test AverageScatteringRate.interpolate_sigma(cache, 15.0) ≈ 2.0 atol=1e-12
+end
+
+@testset "CrossSectionCache out-of-support contract" begin
+    cache = CrossSectionCache(:uu_to_uu)
+    AverageScatteringRate.insert_sigma!(cache, 10.0, 1.0)
+    AverageScatteringRate.insert_sigma!(cache, 20.0, 3.0)
+
+    @test AverageScatteringRate.interpolate_sigma(cache, 9.999) === nothing
+    @test AverageScatteringRate.interpolate_sigma(cache, 20.001) === nothing
+
+    @test cache_sigma(cache, 9.999) == 0.0
+    @test cache_sigma(cache, 20.001) == 0.0
+end
+
+@testset "threshold injection invariants: trigger, sorted, unique" begin
+    sparse_grid = [10.8, 12.5]
+    cache_triggered = CrossSectionCache(:uu_to_uu)
+    precompute_cross_section!(
+        cache_triggered,
+        sparse_grid,
+        QUARK_PARAMS,
+        THERMO_ISO,
+        K_COEFFS;
+        n_points=4,
+        threshold_subtraction=true,
+        asym_window=0.5,
+        asym_fit_min_points=32,
+        asym_extra_points=12,
+    )
+
+    @test length(cache_triggered.s_vals) > length(sparse_grid)
+    @test cache_triggered.s_vals == sort(cache_triggered.s_vals)
+    @test all(isfinite, cache_triggered.s_vals)
+    @test all(isfinite, cache_triggered.sigma_vals)
+    @test length(unique(cache_triggered.s_vals)) == length(cache_triggered.s_vals)
+
+    dense_grid = collect(range(9.45, stop=9.85, length=8))
+    cache_not_triggered = CrossSectionCache(:uu_to_uu)
+    precompute_cross_section!(
+        cache_not_triggered,
+        dense_grid,
+        QUARK_PARAMS,
+        THERMO_ISO,
+        K_COEFFS;
+        n_points=4,
+        threshold_subtraction=true,
+        asym_window=0.5,
+        asym_fit_min_points=1,
+        asym_extra_points=12,
+    )
+
+    @test length(cache_not_triggered.s_vals) == length(dense_grid)
+end
+
+@testset "adaptive refinement improves under-resolved interpolation" begin
+    process = :uubar_to_uubar
+    s_th = (QUARK_PARAMS.m.u + QUARK_PARAMS.m.u)^2
+    coarse_grid = [s_th + 0.01, s_th + 0.04, s_th + 0.15]
+
+    coarse_cache = CrossSectionCache(process)
+    precompute_cross_section!(
+        coarse_cache,
+        coarse_grid,
+        QUARK_PARAMS,
+        THERMO_ISO,
+        K_COEFFS;
+        n_points=4,
+        threshold_subtraction=false,
+    )
+
+    refined_cache = CrossSectionCache(process)
+    precompute_cross_section!(
+        refined_cache,
+        coarse_grid,
+        QUARK_PARAMS,
+        THERMO_ISO,
+        K_COEFFS;
+        n_points=4,
+        threshold_subtraction=true,
+        asym_window=0.2,
+        asym_fit_min_points=16,
+        asym_extra_points=20,
+    )
+
+    validation_s = [s_th + δ for δ in (1e-4, 5e-4, 1e-3, 2e-3, 5e-3, 8e-3, 0.012, 0.02, 0.03, 0.06, 0.10)]
+    err_coarse = [abs(cache_sigma(coarse_cache, s) - reference_sigma(process, s)) for s in validation_s]
+    err_refined = [abs(cache_sigma(refined_cache, s) - reference_sigma(process, s)) for s in validation_s]
+
+    @test maximum(err_refined) < 0.9 * maximum(err_coarse)
+    @test refined_cache.s_vals == sort(refined_cache.s_vals)
+    @test all(isfinite, refined_cache.s_vals)
+    @test all(isfinite, refined_cache.sigma_vals)
+end
+
+@testset "average_scattering_rate struct/NamedTuple equivalence keeps compatibility path" begin
+    cache = constant_sigma_cache(:uu_to_uu; sigma=1.0)
+    q_struct = QuarkParams(QUARK_PARAMS)
+    t_iso_struct = ThermoParams(THERMO_ISO)
+    t_aniso_struct = ThermoParams(THERMO_ANISO)
+
+    ω_nt_iso = average_scattering_rate(
+        :uu_to_uu,
+        QUARK_PARAMS,
+        THERMO_ISO,
+        K_COEFFS;
+        p_nodes=4,
+        angle_nodes=2,
+        phi_nodes=2,
+        cs_cache=cache,
+        n_sigma_points=4,
+    )
+    ω_struct_iso = average_scattering_rate(
+        :uu_to_uu,
+        q_struct,
+        t_iso_struct,
+        K_COEFFS;
+        p_nodes=4,
+        angle_nodes=2,
+        phi_nodes=2,
+        cs_cache=cache,
+        n_sigma_points=4,
+    )
+
+    ω_nt_aniso = average_scattering_rate(
+        :uu_to_uu,
+        QUARK_PARAMS,
+        THERMO_ANISO,
+        K_COEFFS;
+        p_nodes=4,
+        angle_nodes=2,
+        phi_nodes=2,
+        cs_cache=cache,
+        n_sigma_points=4,
+    )
+    ω_struct_aniso = average_scattering_rate(
+        :uu_to_uu,
+        q_struct,
+        t_aniso_struct,
+        K_COEFFS;
+        p_nodes=4,
+        angle_nodes=2,
+        phi_nodes=2,
+        cs_cache=cache,
+        n_sigma_points=4,
+    )
+
+    @test isapprox(ω_struct_iso, ω_nt_iso; rtol=1e-12, atol=0.0)
+    @test isapprox(ω_struct_aniso, ω_nt_aniso; rtol=1e-12, atol=0.0)
+end
+
+@testset "design_w0cdf_s_grid struct/NamedTuple equivalence" begin
+    q_struct = QuarkParams(QUARK_PARAMS)
+    t_struct = ThermoParams(THERMO_ISO)
+
+    s_grid_nt = AverageScatteringRate.design_w0cdf_s_grid(
+        :uu_to_uu,
+        QUARK_PARAMS,
+        THERMO_ISO;
+        N=12,
+        p_nodes=4,
+        angle_nodes=2,
+        phi_nodes=2,
+        p_cutoff=6.0,
+    )
+
+    s_grid_struct = AverageScatteringRate.design_w0cdf_s_grid(
+        :uu_to_uu,
+        q_struct,
+        t_struct;
+        N=12,
+        p_nodes=4,
+        angle_nodes=2,
+        phi_nodes=2,
+        p_cutoff=6.0,
+    )
+
+    @test length(s_grid_nt) == length(s_grid_struct)
+    @test isapprox(first(s_grid_nt), first(s_grid_struct); rtol=1e-12, atol=0.0)
+    @test isapprox(last(s_grid_nt), last(s_grid_struct); rtol=1e-12, atol=0.0)
+    @test all(isfinite, s_grid_nt)
+    @test all(isfinite, s_grid_struct)
 end
 
 @testset "number_density default grid matches explicit grids" begin
@@ -206,3 +407,57 @@ end
     @test isapprox(ω_default, ω_explicit; rtol=1e-12, atol=0.0)
 end
 
+@testset "average_scattering_rate default density grids match explicit density grids" begin
+    cache = constant_sigma_cache(:uu_to_uu; sigma=1.0)
+    p_nodes = 4
+    angle_nodes = 2
+    phi_nodes = 2
+    density_p_nodes = 6
+    scale = 10.0
+
+    t_grid, t_w = gauleg(0.0, 1.0, density_p_nodes)
+    density_p_grid = Float64[]
+    density_p_w = Float64[]
+    for (t, wt) in zip(t_grid, t_w)
+        if t >= 0.9999
+            continue
+        end
+        inv_gap = 1.0 / (1.0 - t)
+        push!(density_p_grid, scale * t * inv_gap)
+        push!(density_p_w, wt * scale * inv_gap^2)
+    end
+
+    ω_default_density = average_scattering_rate(
+        :uu_to_uu,
+        QUARK_PARAMS,
+        THERMO_ISO,
+        K_COEFFS;
+        p_nodes=p_nodes,
+        angle_nodes=angle_nodes,
+        phi_nodes=phi_nodes,
+        density_p_nodes=density_p_nodes,
+        scale=scale,
+        density_scale=scale,
+        cs_cache=cache,
+        n_sigma_points=4,
+    )
+
+    ω_explicit_density = average_scattering_rate(
+        :uu_to_uu,
+        QUARK_PARAMS,
+        THERMO_ISO,
+        K_COEFFS;
+        p_nodes=p_nodes,
+        angle_nodes=angle_nodes,
+        phi_nodes=phi_nodes,
+        density_p_grid=density_p_grid,
+        density_p_w=density_p_w,
+        scale=scale,
+        density_scale=scale,
+        cs_cache=cache,
+        n_sigma_points=4,
+    )
+
+    @test isfinite(ω_default_density)
+    @test isapprox(ω_default_density, ω_explicit_density; rtol=1e-12, atol=0.0)
+end

--- a/tests/unit/relaxtime/test_relaxation_time.jl
+++ b/tests/unit/relaxtime/test_relaxation_time.jl
@@ -67,6 +67,19 @@ end
     @test RelaxationTime.rate_value(rates_dict, :sbarsbar_to_sbarsbar) == RATES_SAMPLE.ss_to_ss
 end
 
+@testset "relaxation_rates warns and clamps negative totals" begin
+    densities = (u=1.0, d=1.0, s=1.0, ubar=1.0, dbar=1.0, sbar=1.0)
+    rates_negative = (; (k => -abs(v) for (k, v) in pairs(RATES_SAMPLE))...)
+
+    @test_logs (:warn, r"negative relaxation rate encountered; clamping to 0") begin
+        tau_inv = relaxation_rates(densities, rates_negative)
+        @test tau_inv.u >= 0.0
+        @test tau_inv.s >= 0.0
+        @test tau_inv.ubar >= 0.0
+        @test tau_inv.sbar >= 0.0
+    end
+end
+
 @testset "relaxation adapters normalize Dict inputs" begin
     densities_dict = Dict{Symbol, Float64}(pairs(DENSITIES_SAMPLE))
     rates_dict = Dict{Symbol, Float64}(pairs(RATES_SAMPLE))
@@ -83,6 +96,17 @@ end
     )
     @test result.tau_inv == EXPECTED_TAU_INV
     @test result.tau == EXPECTED_TAU
+end
+
+@testset "relaxation_rates accepts integer-compatible inputs" begin
+    densities_int = Dict{Symbol, Int}(k => Int(round(v)) for (k, v) in pairs(DENSITIES_SAMPLE))
+    rates_int = Dict{Symbol, Int}(k => Int(round(v)) for (k, v) in pairs(RATES_SAMPLE))
+
+    tau_inv = relaxation_rates(densities_int, rates_int)
+    @test tau_inv.u == EXPECTED_TAU_INV.u
+    @test tau_inv.s == EXPECTED_TAU_INV.s
+    @test tau_inv.ubar == EXPECTED_TAU_INV.ubar
+    @test tau_inv.sbar == EXPECTED_TAU_INV.sbar
 end
 
 @testset "relaxation_times uses provided rates" begin
@@ -133,4 +157,3 @@ end
     @test res_struct.tau == res_nt.tau
     @test res_struct.rates == res_nt.rates
 end
-


### PR DESCRIPTION
## Scope
- Keep the first `relaxtime` follow-up strictly within core-kernel refinement.
- In-scope files:
  - `src/relaxtime/AverageScatteringRate.jl`
  - `src/relaxtime/RelaxationTime.jl`
  - `tests/unit/relaxtime/test_average_scattering_rate.jl`
  - `tests/unit/relaxtime/test_relaxation_time.jl`
- Out of scope: scripts/workflows/output regeneration.

## What Changed
- `AverageScatteringRate`: extracted inline control flow into internal helpers (`threshold` auto-resolution, sigma support-bound resolution, default angle-grid resolution) without changing branch semantics.
- `RelaxationTime`: extracted density/rate/species aggregation helpers and centralized warn+clamp path; fixed compatibility by widening helper inputs from `Float64` to `Real`.
- Added and strengthened unit contracts:
  - cache out-of-support returns `0.0` (no edge clamping)
  - threshold injection invariants (trigger/sorted/unique)
  - adaptive refinement improves under-resolved interpolation error
  - struct/NamedTuple compatibility paths
  - default-grid vs explicit-grid equivalence (including density grid)
  - warn+clamp contract and integer-compatible inputs for `relaxation_rates`

## Verification Evidence
- `julia --project=. -e 'include("tests/unit/relaxtime/test_average_scattering_rate.jl")'` PASS
- `julia --project=. -e 'include("tests/unit/relaxtime/test_relaxation_time.jl")'` PASS
- `julia --project=. -e 'ENV["UNIT_FILES"]="relaxtime/test_average_scattering_rate.jl,relaxtime/test_relaxation_time.jl"; include("tests/unit/runtests.jl")'` PASS (`76/76`)

## Baseline Drift Note (Deferred)
- The spec mentions `resonance-layer` injection invariants, but current `main` baseline in this branch has no independent resonance-layer injection entrypoint to test directly.
- To keep this PR behavior-preserving and avoid scope creep, this item is marked **deferred** in this round.
- Follow-up will add resonance-layer capability and dedicated contract tests in a separate PR.

## Regression Gate Decision
- Planned probe regression file `tests/regression/relaxtime/test_tau_xi_probe_regression.jl` is absent in this branch baseline, so this gate is recorded as **N/A (baseline absent)** for this PR.