### PR TITLE
feat(models): draft generic root engine skeleton and phase A setup

### DIFF
--- a/docs/dev/active/2026-03-22_generic_root_engine_design.md
+++ b/docs/dev/active/2026-03-22_generic_root_engine_design.md
@@ -1,0 +1,198 @@
+# 通用连续性求解引擎设计（零知识实施版）
+
+## 1. 背景与目标
+
+当前仓库已经在两条主线上实现了“连续性求解 + fallback + 质量判据”能力：
+
+- Meson 混合态工作流（`src/models/workflows/MesonMassWorkflow.jl`）
+- Gap 隐式求解器（`src/models/solver/ImplicitSolver.jl`）
+
+问题在于两条链路的核心语义相近，但实现割裂，导致：
+
+- 质量标签和诊断结构不统一，跨模块难聚合；
+- fallback 和多初值策略重复实现；
+- 领域约束（如物理性判据）与求解引擎边界不清。
+
+本设计的目标是先定义最小通用接口和迁移路径，为后续 PR 分阶段落地，不在本轮直接改生产求解逻辑。
+
+## 2. 范围与非范围
+
+### 2.1 范围
+
+- 统一 continuation / quality gate / fallback / diagnostics 的抽象边界。
+- 覆盖变量维度 `2D/5D/8D` 与扫描变量（`T`、`mu`、`rho`、混合参数）的接口兼容。
+- 支持单分支、双分支、多分支的追踪键语义。
+
+### 2.2 非范围
+
+- 不承诺“一套无配置 API 覆盖所有未来模型”。
+- 不在本轮改写全部历史求解路径。
+- 不在本轮实现混合态两阶段求根重构。
+
+## 3. 设计原则
+
+- 最小可迁移：只抽取两条现有主线共同语义。
+- 领域适配外置：物理判据通过 adapter 注入，不嵌入引擎。
+- 诊断优先兼容：新诊断结构可被现有字段映射，不破坏旧调用。
+- 行为等价优先：Phase A/B 迁移门禁是“现有验证栈不退化”。
+
+## 4. 核心抽象草案
+
+以下为接口草案（以 Julia 伪代码描述，字段名按当前仓库命名习惯）。
+
+```julia
+struct RootProblemSpec{F,C}
+    residual!::F               # (Fvec, x, ctx) -> nothing
+    ctx::C                     # 领域上下文（温度、化学势、参数、模型句柄等）
+    x_dim::Int                 # 未知量维度（2/5/8）
+    branch_kind::Symbol        # :single | :paired | :multi
+end
+
+struct RootPolicy
+    primary_method::Symbol     # :newton
+    fallback_method::Symbol    # :trust_region
+    use_fallback::Bool
+    use_multiseed::Bool
+    residual_norm_max::Float64
+    require_converged::Bool
+    diagnostics_level::Symbol  # :off | :basic | :full
+end
+
+struct ContinuationState
+    seed_by_branch::Dict{Symbol, Vector{Float64}}  # branch_key => seed
+    last_point::NamedTuple                         # 如 (T=..., mu=..., xi=...)
+end
+
+struct RootAttempt
+    method::Symbol              # :newton / :trust_region / :multiseed
+    seed_source::Symbol         # :continuation | :default | :multiseed
+    converged::Bool
+    residual_norm::Float64
+    quality_tag::Symbol         # :good | :fallback | :degraded | :bad
+end
+
+struct RootDiagnostics
+    selected_attempt::Int
+    attempts::Vector{RootAttempt}
+    branch_key::Symbol
+    notes::Vector{String}
+end
+```
+
+## 5. 最小执行入口草案
+
+```julia
+solve_root_with_policy(spec, x0; policy, continuation_state=nothing,
+                       domain_quality=nothing, branch_key=nothing)
+
+solve_root_continuation(scan_points, spec_factory;
+                        policy, tracker=nothing,
+                        domain_quality=nothing, branch_key=nothing)
+```
+
+约束说明：
+
+- `spec_factory(scan_point)` 负责构造每个扫描点的 `RootProblemSpec`；
+- `domain_quality` 可选，返回 `(ok::Bool, score::Float64, reason::Symbol)`；
+- `branch_key` 可选，返回分支身份键（如 `:eta_minus`、`:eta_plus`、`:default`）。
+
+## 6. Adapter 接口草案
+
+### 6.1 残差接口
+
+- `residual!(F, x, ctx)`
+  - 输入：状态 `x` 与上下文 `ctx`
+  - 输出：原地写入残差 `F`
+
+### 6.2 领域质量接口（可选）
+
+- `domain_quality(x, meta)`
+  - 典型用于物理性判据（有限性、正性、相区约束）
+
+### 6.3 分支键接口（可选）
+
+- `branch_key(x, ctx)`
+  - 单分支可固定 `:default`
+  - 混合态可返回 `:eta_minus/:eta_plus`、`:sigma_minus/:sigma_plus`
+
+## 7. 统一质量门禁与 fallback 流程
+
+统一判据建议：
+
+1. `converged == true`（若 policy 要求）
+2. `residual_norm <= residual_norm_max`
+3. `domain_quality == ok`（若提供）
+
+统一流程建议：
+
+1. 用 continuation seed（若有）跑 `primary_method`
+2. 失败则同 seed 跑 `fallback_method`
+3. 仍失败且启用多初值，则跑多 seed 候选
+4. 候选由统一 selector 选择（默认优先 quality，再按 residual，再按领域分数）
+
+## 8. 统一诊断结构
+
+建议质量标签枚举固定为：
+
+- `:good`：一次主方法通过
+- `:fallback`：经回退方法得到可接受解
+- `:degraded`：仅满足部分条件（如收敛但残差偏大）
+- `:bad`：无可接受解
+
+`attempt trace` 统一包含：
+
+- `method`
+- `seed_source`
+- `converged`
+- `residual_norm`
+- `quality_tag`
+
+## 9. 迁移映射（与现有模块对齐）
+
+### 9.1 Phase A：Meson 先迁
+
+- 保留在 `MesonMassWorkflow.jl`：
+  - 混合态标签语义与输出格式；
+  - 阈值/gap 相关领域结果。
+- 抽到 `GenericRootEngine`：
+  - 尝试链（primary/fallback/multiseed）；
+  - quality gate 与 attempt trace。
+
+### 9.2 Phase B：Gap 接入
+
+- 将 `ImplicitSolver` 中 `_nlsolve_with_tr_fallback` 的共性逻辑改为引擎调用。
+- Gap 侧特有判据（物理性、thermo finite）保留在 adapter。
+
+### 9.3 Phase C：诊断统一
+
+- workflow 与 solver 共享同一 `RootDiagnostics` 字段语义。
+- 对外保留兼容层，避免直接破坏既有调用方。
+
+## 10. 验证与门禁建议
+
+迁移阶段最小门禁：
+
+- Meson 相关：
+  - `tests/validation/relaxtime/test_mixed_meson_root_quality_continuation.jl`
+  - legacy/literature 关键验证栈
+- Gap 相关：
+  - FixedMu / FixedRho / FixedAsymmetricRho 对应回归集
+
+通过标准：
+
+- 行为不退化（通过率、质量标签分布不显著恶化）；
+- 诊断字段可对齐旧结果；
+- 无新增非有限/负质量等物理非法解泄漏。
+
+## 11. 风险与应对
+
+- 抽象过度风险：先只覆盖 Meson+Gap 两条主线，不提前泛化。
+- 相变附近回归风险：维护异常点清单作为迁移门禁。
+- 性能回退风险：`diagnostics_level=:basic` 作为默认轻量路径。
+
+## 12. 下一 PR 实施建议（可直接照此拆分）
+
+1. 新增 `src/models/solver/GenericRootEngine.jl` 最小骨架与单元测试。
+2. 只迁 Meson 共性求解链路，保持输出接口兼容。
+3. 验证全绿后再迁 Gap，并补齐回归门禁。
+4. 若导出字段成为稳定 API，再更新 `docs/api/`。

--- a/docs/superpowers/plans/2026-03-22-generic-root-continuation-design-plan.md
+++ b/docs/superpowers/plans/2026-03-22-generic-root-continuation-design-plan.md
@@ -1,0 +1,151 @@
+# Generic Root Continuation Engine Design Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在不立即改动生产实现的前提下，产出一份零知识可读的“通用连续性求解引擎”设计与迁移计划，支持后续 PR 分阶段落地。
+
+**Architecture:** 采用 80/20 策略：抽象通用根求解内核（continuation 状态机、quality gate、fallback pipeline、诊断输出），并通过领域适配器承载具体物理问题（残差定义、物理性判据、分支语义）。首批覆盖 Meson 混合态与 PNJL Gap 两条主线。
+
+**Tech Stack:** Julia 1.10+, NLsolve, 现有 `src/models/solver/*` 与 `src/models/workflows/*` 模块，Test stdlib，docs/dev + docs/superpowers 计划文档体系。
+
+---
+
+## 范围与边界（零知识前提）
+
+### 明确要解决
+
+- [ ] 统一“连续性求解”骨架能力：
+  - continuation（上一点 seed 追踪）
+  - quality gate（收敛 + 残差 + 可选领域约束）
+  - fallback（newton -> trust_region -> 多初值）
+  - 统一 root diagnostics（quality tag、attempt trace）
+- [ ] 支持不同维度变量（2D、5D、8D）与不同扫描自变量（T、mu、rho、混合参数）。
+- [ ] 允许分支类型差异：单分支、light-heavy 双分支、多分支字典。
+
+### 明确不在本计划内解决
+
+- [ ] 不承诺“一套 API 无配置适配所有未来物理模型”。
+- [ ] 不在本 PR 改写全部历史求解路径。
+- [ ] 不在本 PR 完成混合态两阶段求根（该属于后续实现任务）。
+
+---
+
+## 现状盘点（为后续实现提供上下文）
+
+### 已有可复用能力
+
+**Files:**
+- `src/models/solver/ImplicitSolver.jl`
+- `src/models/solver/SeedStrategies.jl`
+- `src/models/workflows/MesonMassWorkflow.jl`
+
+- [ ] `ImplicitSolver` 已具备：
+  - `_nlsolve_with_tr_fallback`（方法回退）
+  - `residual_norm_max` 门禁
+  - 候选解选择逻辑 `_choose_candidate`
+- [ ] `SeedStrategies` 已具备：
+  - `ContinuitySeed`、`HybridContinuitySeed`、`PhaseAwareContinuitySeed`
+- [ ] `MesonMassWorkflow` 已具备（近期新增）：
+  - `meson_seed_state`
+  - `meson_root_policy`
+  - `root_quality`
+
+### 当前重复/割裂点
+
+- [ ] Gap 求解和 Meson 求解各自维护 fallback/quality 逻辑，语义相近但实现分散。
+- [ ] 领域判据与求解引擎耦合（例如 Gap 侧依赖 omega/thermo；Meson 侧没有对应量）。
+- [ ] 诊断字段命名与质量等级未统一，跨模块难以聚合分析。
+
+---
+
+## 目标抽象（建议接口草案）
+
+### Task 1: 定义最小通用接口（仅设计，不实现）
+
+**Files:**
+- Create: `docs/dev/active/2026-03-22_generic_root_engine_design.md`
+
+- [x] 给出核心类型草案：
+  - `RootProblemSpec`
+  - `RootPolicy`
+  - `ContinuationState`
+  - `RootAttempt` / `RootDiagnostics`
+- [x] 给出最小执行入口草案：
+  - `solve_root_with_policy(spec, x0; policy, continuation_state)`
+  - `solve_root_continuation(scan_points, spec_factory; policy, tracker)`
+- [x] 给出适配器接口草案：
+  - `residual!(F, x, ctx)`
+  - `domain_quality(x, meta)`（可选）
+  - `branch_key(x, ctx)`（可选，用于多分支追踪）
+
+---
+
+## 迁移策略（分阶段）
+
+### Task 2: Phase A 迁移（Meson 优先）
+
+**Files:**
+- Modify (future): `src/models/workflows/MesonMassWorkflow.jl`
+- Add (future): `src/models/solver/GenericRootEngine.jl`
+
+- [ ] 将 Meson 当前 `_solve_meson_mass_with_policy` 的通用部分迁入 `GenericRootEngine`。
+- [ ] 保留 Meson 专属部分在 workflow：
+  - 混合态分支语义（light/heavy）
+  - threshold/gap 计算与输出格式
+- [ ] 验证迁移后行为等价（至少保持现有测试全绿）。
+
+### Task 3: Phase B 迁移（Gap 求解接入）
+
+**Files:**
+- Modify (future): `src/models/solver/ImplicitSolver.jl`
+- Modify (future): `src/models/solver/SeedStrategies.jl`（若需轻量接口适配）
+
+- [ ] 把 `_nlsolve_with_tr_fallback` 的通用部分改为调用 `GenericRootEngine`。
+- [ ] 通过 adapter 注入 Gap 特有判据（omega/physicality/thermo finite）。
+- [ ] 确保 FixedMu / FixedRho / FixedAsymmetricRho 回归不退化。
+
+### Task 4: Phase C 统一诊断输出
+
+**Files:**
+- Modify (future): `src/models/workflows/MesonMassWorkflow.jl`
+- Modify (future): `src/models/solver/ImplicitSolver.jl`
+- Add (future): `docs/api/...`（如该输出成为稳定公共字段）
+
+- [ ] 统一质量标签枚举：`good/fallback/degraded/bad`。
+- [ ] 统一 attempt trace 结构（方法、初值来源、residual、收敛标志）。
+- [ ] 输出兼容层：避免破坏现有调用方。
+
+---
+
+## 风险与防护
+
+- [ ] **风险：** 抽象过度导致 API 复杂、使用方学习成本高。
+  - **防护：** 先最小接口，优先覆盖现有 2 条主线，不提前泛化。
+- [ ] **风险：** 行为回归（尤其相变附近/混合态近简并点）。
+  - **防护：** 建立“异常点回归清单”，作为迁移门禁测试。
+- [ ] **风险：** 性能回退（额外层级、诊断开销）。
+  - **防护：** policy 中提供 diagnostics 开关，默认轻量。
+
+---
+
+## 验收标准（计划级）
+
+- [ ] 文档明确回答：
+  - 什么是通用，什么是领域适配
+  - 哪些路径先迁，哪些后迁
+  - 如何保证不破坏现有验证基线
+- [ ] 文档能被“零上下文工程师”直接用于下一 PR 实施。
+- [ ] 明确列出“本 PR 不实现代码”的边界，避免范围漂移。
+
+---
+
+## 下一 PR 执行清单（预告）
+
+- [ ] 新建 `GenericRootEngine.jl`（最小骨架 + 单元测试）
+- [ ] 先迁 Meson，再迁 Gap
+- [ ] 回归：
+  - `tests/validation/relaxtime/test_mixed_meson_root_quality_continuation.jl`
+  - 关键 legacy/literature 验证栈
+- [ ] 文档同步：
+  - `docs/dev/active/*`
+  - 如涉及稳定接口，更新 `docs/api/*`

--- a/docs/superpowers/plans/2026-03-22-generic-root-continuation-design-plan.md
+++ b/docs/superpowers/plans/2026-03-22-generic-root-continuation-design-plan.md
@@ -88,11 +88,11 @@
 - Modify (future): `src/models/workflows/MesonMassWorkflow.jl`
 - Add (future): `src/models/solver/GenericRootEngine.jl`
 
-- [ ] 将 Meson 当前 `_solve_meson_mass_with_policy` 的通用部分迁入 `GenericRootEngine`。
-- [ ] 保留 Meson 专属部分在 workflow：
+- [x] 将 Meson 当前 `_solve_meson_mass_with_policy` 的通用部分迁入 `GenericRootEngine`。
+- [x] 保留 Meson 专属部分在 workflow：
   - 混合态分支语义（light/heavy）
   - threshold/gap 计算与输出格式
-- [ ] 验证迁移后行为等价（至少保持现有测试全绿）。
+- [x] 验证迁移后行为等价（至少保持现有测试全绿）。
 
 ### Task 3: Phase B 迁移（Gap 求解接入）
 
@@ -100,9 +100,9 @@
 - Modify (future): `src/models/solver/ImplicitSolver.jl`
 - Modify (future): `src/models/solver/SeedStrategies.jl`（若需轻量接口适配）
 
-- [ ] 把 `_nlsolve_with_tr_fallback` 的通用部分改为调用 `GenericRootEngine`。
-- [ ] 通过 adapter 注入 Gap 特有判据（omega/physicality/thermo finite）。
-- [ ] 确保 FixedMu / FixedRho / FixedAsymmetricRho 回归不退化。
+- [x] 把 `_nlsolve_with_tr_fallback` 的通用部分改为调用 `GenericRootEngine`。
+- [x] 通过 adapter 注入 Gap 特有判据（omega/physicality/thermo finite）。
+- [x] 确保 FixedMu / FixedRho / FixedAsymmetricRho 回归不退化。
 
 ### Task 4: Phase C 统一诊断输出
 
@@ -111,9 +111,9 @@
 - Modify (future): `src/models/solver/ImplicitSolver.jl`
 - Add (future): `docs/api/...`（如该输出成为稳定公共字段）
 
-- [ ] 统一质量标签枚举：`good/fallback/degraded/bad`。
-- [ ] 统一 attempt trace 结构（方法、初值来源、residual、收敛标志）。
-- [ ] 输出兼容层：避免破坏现有调用方。
+- [x] 统一质量标签枚举：`good/fallback/degraded/bad`。
+- [x] 统一 attempt trace 结构（方法、初值来源、residual、收敛标志）。
+- [x] 输出兼容层：避免破坏现有调用方。
 
 ---
 
@@ -143,7 +143,7 @@
 
 - [x] 新建 `GenericRootEngine.jl`（最小骨架 + 单元测试）
 - [ ] 先迁 Meson，再迁 Gap
-- [ ] 回归：
+- [x] 回归：
   - `tests/validation/relaxtime/test_mixed_meson_root_quality_continuation.jl`
   - 关键 legacy/literature 验证栈
 - [ ] 文档同步：

--- a/docs/superpowers/plans/2026-03-22-generic-root-continuation-design-plan.md
+++ b/docs/superpowers/plans/2026-03-22-generic-root-continuation-design-plan.md
@@ -141,7 +141,7 @@
 
 ## 下一 PR 执行清单（预告）
 
-- [ ] 新建 `GenericRootEngine.jl`（最小骨架 + 单元测试）
+- [x] 新建 `GenericRootEngine.jl`（最小骨架 + 单元测试）
 - [ ] 先迁 Meson，再迁 Gap
 - [ ] 回归：
   - `tests/validation/relaxtime/test_mixed_meson_root_quality_continuation.jl`

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -60,6 +60,8 @@ export get_seed, update!, reset!, get_all_seeds, set_phase!
 export HADRON_SEED_5, QUARK_SEED_5, HADRON_SEED_8, QUARK_SEED_8
 export build_conditions, build_residual!, GapParams
 export create_implicit_solver, solve_with_derivatives
+export RootProblemSpec, RootPolicy, ContinuationState, RootAttempt, RootDiagnostics, RootSolveResult
+export solve_root_with_policy, solve_root_continuation
 export ρ0
 export QUARK_CHARGE_ABS
 export alpha_n, energy_landau, smooth_cutoff, resolve_nmax_from_cutoff
@@ -119,6 +121,7 @@ include(joinpath(@__DIR__, "constraint_solver.jl"))
 include(joinpath(@__DIR__, "solver", "ConstraintModes.jl"))
 include(joinpath(@__DIR__, "solver", "SeedStrategies.jl"))
 include(joinpath(@__DIR__, "solver", "Conditions.jl"))
+include(joinpath(@__DIR__, "solver", "GenericRootEngine.jl"))
 include(joinpath(@__DIR__, "solver", "ImplicitSolver.jl"))
 include(joinpath(@__DIR__, "solver", "Solver.jl"))
 include(joinpath(@__DIR__, "derivatives", "ThermoDerivatives.jl"))

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -60,6 +60,7 @@ export get_seed, update!, reset!, get_all_seeds, set_phase!
 export HADRON_SEED_5, QUARK_SEED_5, HADRON_SEED_8, QUARK_SEED_8
 export build_conditions, build_residual!, GapParams
 export create_implicit_solver, solve_with_derivatives
+export solve_with_root_diagnostics
 export RootProblemSpec, RootPolicy, ContinuationState, RootAttempt, RootDiagnostics, RootSolveResult
 export solve_root_with_policy, solve_root_continuation
 export ρ0

--- a/src/models/solver/GenericRootEngine.jl
+++ b/src/models/solver/GenericRootEngine.jl
@@ -60,6 +60,7 @@ struct RootAttempt
     converged::Bool
     residual_norm::Float64
     quality_tag::Symbol
+    score::Float64
 end
 
 struct RootDiagnostics
@@ -113,6 +114,33 @@ end
         return :degraded
     end
     return :bad
+end
+
+@inline function _quality_rank(tag::Symbol)::Int
+    if tag === :good || tag === :fallback
+        return 1
+    elseif tag === :degraded
+        return 2
+    end
+    return 3
+end
+
+@inline function _should_replace_best(best_tag::Symbol, best_resn::Float64, best_score::Float64,
+                                      cand_tag::Symbol, cand_resn::Float64, cand_score::Float64)::Bool
+    rb = _quality_rank(best_tag)
+    rc = _quality_rank(cand_tag)
+    rc < rb && return true
+    rc > rb && return false
+
+    if isfinite(cand_score) && isfinite(best_score)
+        cand_score < best_score && return true
+        cand_score > best_score && return false
+    end
+
+    if isfinite(cand_resn) && isfinite(best_resn)
+        return cand_resn < best_resn
+    end
+    return false
 end
 
 function _solve_once(spec::RootProblemSpec, seed::Vector{Float64}, method::Symbol)
@@ -171,11 +199,13 @@ function solve_root_with_policy(
     selected_conv = false
     selected_resn = Inf
     selected_tag = :bad
+    selected_score = NaN
 
-    function register_attempt(method::Symbol, source::Symbol, x::Vector{Float64}, conv::Bool, resn::Float64; is_fallback::Bool=false)
+    function register_attempt(method::Symbol, source::Symbol, x::Vector{Float64}, conv::Bool, resn::Float64;
+                              is_fallback::Bool=false, score::Float64=NaN)
         domain_ok = _domain_quality_ok(domain_quality, x, spec.ctx)
         qtag = _quality_tag(conv, resn, domain_ok, policy; is_fallback=is_fallback)
-        push!(attempts, RootAttempt(method, source, conv, resn, qtag))
+        push!(attempts, RootAttempt(method, source, conv, resn, qtag, score))
         return qtag
     end
 
@@ -187,31 +217,36 @@ function solve_root_with_policy(
     selected_conv = conv_primary
     selected_resn = resn_primary
     selected_tag = tag_primary
+    selected_score = NaN
 
-    if policy.use_fallback && tag_primary in (:degraded, :bad)
+    should_try_fallback = policy.use_fallback && (tag_primary in (:degraded, :bad))
+    if should_try_fallback
         res_fb = _solve_once(spec, seed, policy.fallback_method)
         x_fb, conv_fb, resn_fb = _candidate_from_result(res_fb)
         tag_fb = register_attempt(policy.fallback_method, seed_source, x_fb, conv_fb, resn_fb; is_fallback=true)
-        if tag_fb in (:good, :fallback) || (tag_primary in (:degraded, :bad) && resn_fb < selected_resn)
+        if _should_replace_best(selected_tag, selected_resn, selected_score, tag_fb, resn_fb, NaN)
             selected_idx = length(attempts)
             selected_x = x_fb
             selected_conv = conv_fb
             selected_resn = resn_fb
             selected_tag = tag_fb
+            selected_score = NaN
         end
     end
 
-    if policy.use_multiseed && selected_tag in (:degraded, :bad)
+    should_try_multiseed = policy.use_multiseed && (selected_tag in (:degraded, :bad) || isfinite(selected_score))
+    if should_try_multiseed
         for s in _multiseed_candidates(seed)
             res_ms = _solve_once(spec, s, policy.primary_method)
             x_ms, conv_ms, resn_ms = _candidate_from_result(res_ms)
             tag_ms = register_attempt(policy.primary_method, :multiseed, x_ms, conv_ms, resn_ms)
-            if tag_ms in (:good, :fallback) || resn_ms < selected_resn
+            if _should_replace_best(selected_tag, selected_resn, selected_score, tag_ms, resn_ms, NaN)
                 selected_idx = length(attempts)
                 selected_x = x_ms
                 selected_conv = conv_ms
                 selected_resn = resn_ms
                 selected_tag = tag_ms
+                selected_score = NaN
             end
         end
         push!(notes, "multiseed attempted")
@@ -243,6 +278,13 @@ end
     return Bool(getproperty(cb_res, :converged)), Float64(getproperty(cb_res, :residual_norm))
 end
 
+@inline function _extract_score_from_callback_result(cb_res)::Float64
+    if hasproperty(cb_res, :score)
+        return Float64(getproperty(cb_res, :score))
+    end
+    return NaN
+end
+
 function solve_root_with_policy(
     solve_once::Function,
     x0::AbstractVector{<:Real};
@@ -269,52 +311,60 @@ function solve_root_with_policy(
     selected_conv = false
     selected_resn = Inf
     selected_tag = :bad
+    selected_score = NaN
 
     function run_callback(method::Symbol, s::Vector{Float64})
         out = solve_once(method, s)
-        out === nothing && return copy(s), false, Inf
+        out === nothing && return copy(s), false, Inf, NaN
         x = _extract_x_from_callback_result(out)
         conv, resn = _extract_conv_residual_from_callback_result(out)
-        return x, conv, resn
+        score = _extract_score_from_callback_result(out)
+        return x, conv, resn, score
     end
 
-    function register_attempt(method::Symbol, source::Symbol, x::Vector{Float64}, conv::Bool, resn::Float64; is_fallback::Bool=false)
+    function register_attempt(method::Symbol, source::Symbol, x::Vector{Float64}, conv::Bool, resn::Float64;
+                              is_fallback::Bool=false, score::Float64=NaN)
         domain_ok = _domain_quality_ok(domain_quality, x, nothing)
         qtag = _quality_tag(conv, resn, domain_ok, policy; is_fallback=is_fallback)
-        push!(attempts, RootAttempt(method, source, conv, resn, qtag))
+        push!(attempts, RootAttempt(method, source, conv, resn, qtag, score))
         return qtag
     end
 
-    x_primary, conv_primary, resn_primary = run_callback(policy.primary_method, seed)
-    tag_primary = register_attempt(policy.primary_method, seed_source, x_primary, conv_primary, resn_primary)
+    x_primary, conv_primary, resn_primary, score_primary = run_callback(policy.primary_method, seed)
+    tag_primary = register_attempt(policy.primary_method, seed_source, x_primary, conv_primary, resn_primary; score=score_primary)
     selected_idx = 1
     selected_x = x_primary
     selected_conv = conv_primary
     selected_resn = resn_primary
     selected_tag = tag_primary
+    selected_score = score_primary
 
-    if policy.use_fallback && tag_primary in (:degraded, :bad)
-        x_fb, conv_fb, resn_fb = run_callback(policy.fallback_method, seed)
-        tag_fb = register_attempt(policy.fallback_method, seed_source, x_fb, conv_fb, resn_fb; is_fallback=true)
-        if tag_fb in (:good, :fallback) || (tag_primary in (:degraded, :bad) && resn_fb < selected_resn)
+    should_try_fallback = policy.use_fallback && (tag_primary in (:degraded, :bad) || isfinite(score_primary))
+    if should_try_fallback
+        x_fb, conv_fb, resn_fb, score_fb = run_callback(policy.fallback_method, seed)
+        tag_fb = register_attempt(policy.fallback_method, seed_source, x_fb, conv_fb, resn_fb; is_fallback=true, score=score_fb)
+        if _should_replace_best(selected_tag, selected_resn, selected_score, tag_fb, resn_fb, score_fb)
             selected_idx = length(attempts)
             selected_x = x_fb
             selected_conv = conv_fb
             selected_resn = resn_fb
             selected_tag = tag_fb
+            selected_score = score_fb
         end
     end
 
-    if policy.use_multiseed && selected_tag in (:degraded, :bad)
+    should_try_multiseed = policy.use_multiseed && (selected_tag in (:degraded, :bad) || isfinite(selected_score))
+    if should_try_multiseed
         for s in _multiseed_candidates(seed)
-            x_ms, conv_ms, resn_ms = run_callback(policy.primary_method, s)
-            tag_ms = register_attempt(policy.primary_method, :multiseed, x_ms, conv_ms, resn_ms)
-            if tag_ms in (:good, :fallback) || resn_ms < selected_resn
+            x_ms, conv_ms, resn_ms, score_ms = run_callback(policy.primary_method, s)
+            tag_ms = register_attempt(policy.primary_method, :multiseed, x_ms, conv_ms, resn_ms; score=score_ms)
+            if _should_replace_best(selected_tag, selected_resn, selected_score, tag_ms, resn_ms, score_ms)
                 selected_idx = length(attempts)
                 selected_x = x_ms
                 selected_conv = conv_ms
                 selected_resn = resn_ms
                 selected_tag = tag_ms
+                selected_score = score_ms
             end
         end
         push!(notes, "multiseed attempted")

--- a/src/models/solver/GenericRootEngine.jl
+++ b/src/models/solver/GenericRootEngine.jl
@@ -225,6 +225,109 @@ function solve_root_with_policy(
     return RootSolveResult(selected_x, selected_conv, selected_resn, selected_tag, diag)
 end
 
+@inline function _extract_x_from_callback_result(cb_res)
+    if hasproperty(cb_res, :x)
+        x = getproperty(cb_res, :x)
+        x isa AbstractVector || throw(ArgumentError("callback result.x must be an AbstractVector"))
+        return Float64.(x)
+    end
+    if hasproperty(cb_res, :mass) && hasproperty(cb_res, :gamma)
+        return Float64[Float64(getproperty(cb_res, :mass)), Float64(getproperty(cb_res, :gamma))]
+    end
+    throw(ArgumentError("callback result must provide :x or (:mass, :gamma)"))
+end
+
+@inline function _extract_conv_residual_from_callback_result(cb_res)
+    hasproperty(cb_res, :converged) || throw(ArgumentError("callback result must provide :converged"))
+    hasproperty(cb_res, :residual_norm) || throw(ArgumentError("callback result must provide :residual_norm"))
+    return Bool(getproperty(cb_res, :converged)), Float64(getproperty(cb_res, :residual_norm))
+end
+
+function solve_root_with_policy(
+    solve_once::Function,
+    x0::AbstractVector{<:Real};
+    policy::RootPolicy=RootPolicy(),
+    continuation_state::Union{Nothing,ContinuationState}=nothing,
+    domain_quality=nothing,
+    branch_key=nothing,
+)
+    seed = Float64.(x0)
+    branch = _normalize_branch_key(branch_key, seed, nothing)
+    seed_source = :default
+    if continuation_state !== nothing && haskey(continuation_state.seed_by_branch, branch)
+        cseed = continuation_state.seed_by_branch[branch]
+        if length(cseed) == length(seed)
+            seed = copy(cseed)
+            seed_source = :continuation
+        end
+    end
+
+    attempts = RootAttempt[]
+    notes = String[]
+    selected_idx = 0
+    selected_x = copy(seed)
+    selected_conv = false
+    selected_resn = Inf
+    selected_tag = :bad
+
+    function run_callback(method::Symbol, s::Vector{Float64})
+        out = solve_once(method, s)
+        out === nothing && return copy(s), false, Inf
+        x = _extract_x_from_callback_result(out)
+        conv, resn = _extract_conv_residual_from_callback_result(out)
+        return x, conv, resn
+    end
+
+    function register_attempt(method::Symbol, source::Symbol, x::Vector{Float64}, conv::Bool, resn::Float64; is_fallback::Bool=false)
+        domain_ok = _domain_quality_ok(domain_quality, x, nothing)
+        qtag = _quality_tag(conv, resn, domain_ok, policy; is_fallback=is_fallback)
+        push!(attempts, RootAttempt(method, source, conv, resn, qtag))
+        return qtag
+    end
+
+    x_primary, conv_primary, resn_primary = run_callback(policy.primary_method, seed)
+    tag_primary = register_attempt(policy.primary_method, seed_source, x_primary, conv_primary, resn_primary)
+    selected_idx = 1
+    selected_x = x_primary
+    selected_conv = conv_primary
+    selected_resn = resn_primary
+    selected_tag = tag_primary
+
+    if policy.use_fallback && tag_primary in (:degraded, :bad)
+        x_fb, conv_fb, resn_fb = run_callback(policy.fallback_method, seed)
+        tag_fb = register_attempt(policy.fallback_method, seed_source, x_fb, conv_fb, resn_fb; is_fallback=true)
+        if tag_fb in (:good, :fallback) || (tag_primary in (:degraded, :bad) && resn_fb < selected_resn)
+            selected_idx = length(attempts)
+            selected_x = x_fb
+            selected_conv = conv_fb
+            selected_resn = resn_fb
+            selected_tag = tag_fb
+        end
+    end
+
+    if policy.use_multiseed && selected_tag in (:degraded, :bad)
+        for s in _multiseed_candidates(seed)
+            x_ms, conv_ms, resn_ms = run_callback(policy.primary_method, s)
+            tag_ms = register_attempt(policy.primary_method, :multiseed, x_ms, conv_ms, resn_ms)
+            if tag_ms in (:good, :fallback) || resn_ms < selected_resn
+                selected_idx = length(attempts)
+                selected_x = x_ms
+                selected_conv = conv_ms
+                selected_resn = resn_ms
+                selected_tag = tag_ms
+            end
+        end
+        push!(notes, "multiseed attempted")
+    end
+
+    if continuation_state !== nothing
+        continuation_state.seed_by_branch[branch] = copy(selected_x)
+    end
+
+    diag = RootDiagnostics(selected_idx, attempts, branch, notes)
+    return RootSolveResult(selected_x, selected_conv, selected_resn, selected_tag, diag)
+end
+
 function solve_root_continuation(
     scan_points,
     spec_factory::Function;

--- a/src/models/solver/GenericRootEngine.jl
+++ b/src/models/solver/GenericRootEngine.jl
@@ -1,0 +1,258 @@
+using NLsolve
+
+"""
+    RootProblemSpec
+
+通用根求解问题描述。
+"""
+struct RootProblemSpec{F,C}
+    residual!::F
+    ctx::C
+    x_dim::Int
+    branch_kind::Symbol
+end
+
+"""
+    RootPolicy
+
+通用根求解策略配置。
+"""
+struct RootPolicy
+    primary_method::Symbol
+    fallback_method::Symbol
+    use_fallback::Bool
+    use_multiseed::Bool
+    residual_norm_max::Float64
+    require_converged::Bool
+    diagnostics_level::Symbol
+end
+
+function RootPolicy(;
+    primary_method::Symbol=:newton,
+    fallback_method::Symbol=:trust_region,
+    use_fallback::Bool=true,
+    use_multiseed::Bool=false,
+    residual_norm_max::Real=1e-6,
+    require_converged::Bool=true,
+    diagnostics_level::Symbol=:basic,
+)
+    return RootPolicy(
+        primary_method,
+        fallback_method,
+        use_fallback,
+        use_multiseed,
+        Float64(residual_norm_max),
+        require_converged,
+        diagnostics_level,
+    )
+end
+
+mutable struct ContinuationState
+    seed_by_branch::Dict{Symbol,Vector{Float64}}
+    last_point::Union{Nothing,NamedTuple}
+end
+
+ContinuationState() = ContinuationState(Dict{Symbol,Vector{Float64}}(), nothing)
+
+struct RootAttempt
+    method::Symbol
+    seed_source::Symbol
+    converged::Bool
+    residual_norm::Float64
+    quality_tag::Symbol
+end
+
+struct RootDiagnostics
+    selected_attempt::Int
+    attempts::Vector{RootAttempt}
+    branch_key::Symbol
+    notes::Vector{String}
+end
+
+struct RootSolveResult
+    x::Vector{Float64}
+    converged::Bool
+    residual_norm::Float64
+    quality_tag::Symbol
+    diagnostics::RootDiagnostics
+end
+
+@inline function _normalize_branch_key(branch_key, x, ctx)::Symbol
+    if branch_key === nothing
+        return :default
+    elseif branch_key isa Symbol
+        return branch_key
+    elseif branch_key isa Function
+        key = branch_key(x, ctx)
+        key isa Symbol || throw(ArgumentError("branch_key(x, ctx) must return Symbol, got $(typeof(key))"))
+        return key
+    else
+        throw(ArgumentError("branch_key must be nothing, Symbol, or Function"))
+    end
+end
+
+@inline function _domain_quality_ok(domain_quality, x, ctx)
+    domain_quality === nothing && return true
+    out = domain_quality(x, ctx)
+    if out isa NamedTuple
+        return Bool(get(out, :ok, false))
+    elseif out isa Bool
+        return out
+    end
+    throw(ArgumentError("domain_quality(x, ctx) must return Bool or NamedTuple with :ok"))
+end
+
+@inline function _quality_tag(converged::Bool, residual_norm::Float64, domain_ok::Bool, policy::RootPolicy; is_fallback::Bool=false)
+    residual_ok = isfinite(residual_norm) && residual_norm <= policy.residual_norm_max
+    converged_ok = !policy.require_converged || converged
+    good = converged_ok && residual_ok && domain_ok
+    if good
+        return is_fallback ? :fallback : :good
+    end
+    if converged || residual_ok
+        return :degraded
+    end
+    return :bad
+end
+
+function _solve_once(spec::RootProblemSpec, seed::Vector{Float64}, method::Symbol)
+    residual_fn! = (F, x) -> spec.residual!(F, x, spec.ctx)
+    res = NLsolve.nlsolve(
+        residual_fn!,
+        seed;
+        autodiff=:forward,
+        method=method,
+        xtol=1e-9,
+        ftol=1e-9,
+    )
+    return res
+end
+
+function _candidate_from_result(res)
+    return Vector{Float64}(res.zero), Bool(res.f_converged), Float64(res.residual_norm)
+end
+
+function _multiseed_candidates(seed::Vector{Float64})
+    out = Vector{Vector{Float64}}()
+    push!(out, copy(seed))
+    if !isempty(seed)
+        step = 1e-2
+        push!(out, [seed[i] + (i == 1 ? step : 0.0) for i in eachindex(seed)])
+        push!(out, [seed[i] - (i == 1 ? step : 0.0) for i in eachindex(seed)])
+    end
+    return out
+end
+
+function solve_root_with_policy(
+    spec::RootProblemSpec,
+    x0::AbstractVector{<:Real};
+    policy::RootPolicy=RootPolicy(),
+    continuation_state::Union{Nothing,ContinuationState}=nothing,
+    domain_quality=nothing,
+    branch_key=nothing,
+)
+    length(x0) == spec.x_dim || throw(ArgumentError("x0 length $(length(x0)) does not match spec.x_dim $(spec.x_dim)"))
+
+    seed = Float64.(x0)
+    branch = _normalize_branch_key(branch_key, seed, spec.ctx)
+    seed_source = :default
+    if continuation_state !== nothing && haskey(continuation_state.seed_by_branch, branch)
+        cseed = continuation_state.seed_by_branch[branch]
+        if length(cseed) == spec.x_dim
+            seed = copy(cseed)
+            seed_source = :continuation
+        end
+    end
+
+    attempts = RootAttempt[]
+    notes = String[]
+    selected_idx = 0
+    selected_x = copy(seed)
+    selected_conv = false
+    selected_resn = Inf
+    selected_tag = :bad
+
+    function register_attempt(method::Symbol, source::Symbol, x::Vector{Float64}, conv::Bool, resn::Float64; is_fallback::Bool=false)
+        domain_ok = _domain_quality_ok(domain_quality, x, spec.ctx)
+        qtag = _quality_tag(conv, resn, domain_ok, policy; is_fallback=is_fallback)
+        push!(attempts, RootAttempt(method, source, conv, resn, qtag))
+        return qtag
+    end
+
+    res_primary = _solve_once(spec, seed, policy.primary_method)
+    x_primary, conv_primary, resn_primary = _candidate_from_result(res_primary)
+    tag_primary = register_attempt(policy.primary_method, seed_source, x_primary, conv_primary, resn_primary)
+    selected_idx = 1
+    selected_x = x_primary
+    selected_conv = conv_primary
+    selected_resn = resn_primary
+    selected_tag = tag_primary
+
+    if policy.use_fallback && tag_primary in (:degraded, :bad)
+        res_fb = _solve_once(spec, seed, policy.fallback_method)
+        x_fb, conv_fb, resn_fb = _candidate_from_result(res_fb)
+        tag_fb = register_attempt(policy.fallback_method, seed_source, x_fb, conv_fb, resn_fb; is_fallback=true)
+        if tag_fb in (:good, :fallback) || (tag_primary in (:degraded, :bad) && resn_fb < selected_resn)
+            selected_idx = length(attempts)
+            selected_x = x_fb
+            selected_conv = conv_fb
+            selected_resn = resn_fb
+            selected_tag = tag_fb
+        end
+    end
+
+    if policy.use_multiseed && selected_tag in (:degraded, :bad)
+        for s in _multiseed_candidates(seed)
+            res_ms = _solve_once(spec, s, policy.primary_method)
+            x_ms, conv_ms, resn_ms = _candidate_from_result(res_ms)
+            tag_ms = register_attempt(policy.primary_method, :multiseed, x_ms, conv_ms, resn_ms)
+            if tag_ms in (:good, :fallback) || resn_ms < selected_resn
+                selected_idx = length(attempts)
+                selected_x = x_ms
+                selected_conv = conv_ms
+                selected_resn = resn_ms
+                selected_tag = tag_ms
+            end
+        end
+        push!(notes, "multiseed attempted")
+    end
+
+    if continuation_state !== nothing
+        continuation_state.seed_by_branch[branch] = copy(selected_x)
+    end
+
+    diag = RootDiagnostics(selected_idx, attempts, branch, notes)
+    return RootSolveResult(selected_x, selected_conv, selected_resn, selected_tag, diag)
+end
+
+function solve_root_continuation(
+    scan_points,
+    spec_factory::Function;
+    policy::RootPolicy=RootPolicy(),
+    tracker::Union{Nothing,ContinuationState}=ContinuationState(),
+    x0::AbstractVector{<:Real},
+    domain_quality=nothing,
+    branch_key=nothing,
+)
+    results = RootSolveResult[]
+    current_seed = Float64.(x0)
+
+    for point in scan_points
+        spec = spec_factory(point)
+        res = solve_root_with_policy(
+            spec,
+            current_seed;
+            policy=policy,
+            continuation_state=tracker,
+            domain_quality=domain_quality,
+            branch_key=branch_key,
+        )
+        push!(results, res)
+        current_seed = copy(res.x)
+        if tracker !== nothing
+            tracker.last_point = (point=point,)
+        end
+    end
+
+    return results
+end

--- a/src/models/solver/ImplicitSolver.jl
+++ b/src/models/solver/ImplicitSolver.jl
@@ -1343,4 +1343,24 @@ function solve_with_root_diagnostics(mode::FixedAsymmetricRho, T_fm::Real; kwarg
     return _diagnostics_payload_from_result(result; selected_method=:legacy_fallback, seed_source=:seed)
 end
 
+"""
+    solve_with_root_diagnostics(mode::FixedEntropy, T_fm; kwargs...) -> NamedTuple
+
+固定熵密度模式的兼容诊断入口。
+"""
+function solve_with_root_diagnostics(mode::FixedEntropy, T_fm::Real; kwargs...)
+    result = solve(mode, T_fm; kwargs...)
+    return _diagnostics_payload_from_result(result; selected_method=:legacy_fallback, seed_source=:seed)
+end
+
+"""
+    solve_with_root_diagnostics(mode::FixedSigma, T_fm; kwargs...) -> NamedTuple
+
+固定比熵模式的兼容诊断入口。
+"""
+function solve_with_root_diagnostics(mode::FixedSigma, T_fm::Real; kwargs...)
+    result = solve(mode, T_fm; kwargs...)
+    return _diagnostics_payload_from_result(result; selected_method=:legacy_fallback, seed_source=:seed)
+end
+
 end # module ImplicitSolver

--- a/src/models/solver/ImplicitSolver.jl
+++ b/src/models/solver/ImplicitSolver.jl
@@ -30,6 +30,7 @@ using ImplicitDifferentiation
 # 从 Models 域导入，避免重复定义
 import Main.Models: ConstraintMode, FixedMu, FixedRho, FixedAsymmetricRho, FixedEntropy, FixedSigma, state_dim, param_dim
 import Main.Models: AbstractQCDModel, create_model, model_thermo, calculate_mass_vec
+import Main.Models: RootPolicy, solve_root_with_policy
 using ..SeedStrategies: SeedStrategy, DefaultSeed, MultiSeed, ContinuitySeed, HybridContinuitySeed, PhaseAwareContinuitySeed, get_seed, get_all_seeds, default_omega_selector, update!
 using ..Conditions: GapParams, gap_conditions, build_residual!
 
@@ -145,45 +146,56 @@ function _nlsolve_with_tr_fallback(residual_fn!, x0;
     postprocess_fn::Function,
     nlsolve_kwargs...)
 
-    primary_res = nlsolve(residual_fn!, x0; autodiff=:forward, method=primary_method, xtol=1e-9, ftol=1e-9, nlsolve_kwargs...)
+    cache = Dict{Symbol,Tuple{Any,Any}}()
 
-    local primary_cand
-    try
-        primary_cand = _postprocess_candidate(postprocess_fn, physicality_check, primary_res.zero)
-    catch
-        primary_cand = (phys=false,
-                        x_sol=Vector{Float64}(primary_res.zero),
-                        x_state=SVector{5, Float64}(fill(NaN, 5)),
-                        mu_vec=SVector{3, Float64}(fill(NaN, 3)),
-                        omega=NaN,
-                        pressure=NaN,
-                        rho_norm=NaN,
-                        entropy=NaN,
-                        energy=NaN,
-                        masses=SVector{3, Float64}(fill(NaN, 3)))
+    solve_once = function (method::Symbol, seed::Vector{Float64})
+        res = nlsolve(residual_fn!, seed; autodiff=:forward, method=method, xtol=1e-9, ftol=1e-9, nlsolve_kwargs...)
+
+        local cand
+        try
+            cand = _postprocess_candidate(postprocess_fn, physicality_check, res.zero)
+        catch
+            cand = (phys=false,
+                    x_sol=Vector{Float64}(res.zero),
+                    x_state=SVector{5, Float64}(fill(NaN, 5)),
+                    mu_vec=SVector{3, Float64}(fill(NaN, 3)),
+                    omega=NaN,
+                    pressure=NaN,
+                    rho_norm=NaN,
+                    entropy=NaN,
+                    energy=NaN,
+                    masses=SVector{3, Float64}(fill(NaN, 3)))
+        end
+
+        cache[method] = (res, cand)
+        return (
+            x=Vector{Float64}(res.zero),
+            converged=Bool(res.f_converged) && Bool(cand.phys),
+            residual_norm=Float64(res.residual_norm),
+        )
     end
 
-    need_fallback = use_fallback && (
-        !primary_res.f_converged ||
-        !isfinite(primary_res.residual_norm) ||
-        primary_res.residual_norm > residual_norm_max ||
-        !primary_cand.phys
+    policy = RootPolicy(
+        primary_method=primary_method,
+        fallback_method=fallback_method,
+        use_fallback=use_fallback,
+        use_multiseed=false,
+        residual_norm_max=residual_norm_max,
+        require_converged=true,
+        diagnostics_level=:basic,
     )
 
-    if !need_fallback
-        return primary_res, primary_cand
+    solved = solve_root_with_policy(solve_once, Vector{Float64}(x0); policy=policy)
+    selected_method = solved.diagnostics.attempts[solved.diagnostics.selected_attempt].method
+
+    if haskey(cache, selected_method)
+        return cache[selected_method]
     end
 
-    local fallback_res
-    local fallback_cand
-    try
-        fallback_res = nlsolve(residual_fn!, x0; autodiff=:forward, method=fallback_method, xtol=1e-9, ftol=1e-9, nlsolve_kwargs...)
-        fallback_cand = _postprocess_candidate(postprocess_fn, physicality_check, fallback_res.zero)
-    catch
-        return primary_res, primary_cand
-    end
-
-    return _choose_candidate(primary_res, primary_cand, fallback_res, fallback_cand; residual_norm_max=residual_norm_max)
+    picked = solve_once(selected_method, Vector{Float64}(x0))
+    res, cand = cache[selected_method]
+    _ = picked
+    return res, cand
 end
 
 # ============================================================================
@@ -1137,4 +1149,3 @@ function solve_with_derivatives(T_fm::Real, μ_fm::Real;
 end
 
 end # module ImplicitSolver
-

--- a/src/models/solver/ImplicitSolver.jl
+++ b/src/models/solver/ImplicitSolver.jl
@@ -45,6 +45,7 @@ const ρ0 = ρ0_inv_fm3
 export solve, SolverResult
 export create_implicit_solver, solve_with_derivatives
 export solve_weighted_block_fallback
+export solve_with_root_diagnostics
 
 const _MODEL_CACHE = Dict{Symbol, AbstractQCDModel}()
 
@@ -1147,6 +1148,160 @@ function solve_with_derivatives(T_fm::Real, μ_fm::Real;
     else
         error("order must be 1 or 2, got $order")
     end
+end
+
+"""
+    solve_with_root_diagnostics(mode::FixedMu, T_fm, μ_fm; kwargs...) -> NamedTuple
+
+与 `solve(mode, ...)` 行为一致，但额外返回 root diagnostics 结构，
+用于迁移期诊断兼容。
+"""
+function solve_with_root_diagnostics(::FixedMu, T_fm::Real, μ_fm::Real;
+                                     xi::Real=0.0,
+                                     seed_strategy::SeedStrategy=DefaultSeed(),
+                                     p_num::Int=DEFAULT_MOMENTUM_COUNT,
+                                     t_num::Int=DEFAULT_THETA_COUNT,
+                                     nlsolve_method::Symbol=:newton,
+                                     trust_region_fallback::Bool=true,
+                                     auto_multiseed_fallback::Bool=true,
+                                     fallback_method::Symbol=:trust_region,
+                                     physicality_check::Function=_default_is_physical_solution,
+                                     residual_norm_max::Real=1e-6,
+                                     nlsolve_kwargs...)
+
+    mode = FixedMu()
+    thermal_nodes = cached_nodes(p_num, t_num)
+    params = GapParams(Float64(T_fm), thermal_nodes, Float64(xi); p_num=p_num, t_num=t_num, model_kind=:PNJL)
+    mu_vec = SVector{3}(μ_fm, μ_fm, μ_fm)
+
+    θ = [T_fm, μ_fm]
+    seed = get_seed(seed_strategy, θ, mode)
+    x0 = Float64.(seed)
+
+    residual_fn! = build_residual!(mode, mu_vec, params)
+    postprocess_fn = x_sol -> begin
+        x_state = SVector{5}(Tuple(x_sol))
+        return _postprocess_payload(:PNJL, x_state, mu_vec, T_fm;
+            p_num=p_num,
+            t_num=t_num,
+            xi=xi,
+        )
+    end
+
+    cache = Dict{Symbol,Tuple{Any,Any}}()
+    solve_once = function (method::Symbol, seedv::Vector{Float64})
+        res = nlsolve(residual_fn!, seedv; autodiff=:forward, method=method, xtol=1e-9, ftol=1e-9, nlsolve_kwargs...)
+        local cand
+        try
+            cand = _postprocess_candidate(postprocess_fn, physicality_check, res.zero)
+        catch
+            cand = (phys=false,
+                    x_sol=Vector{Float64}(res.zero),
+                    x_state=SVector{5, Float64}(fill(NaN, 5)),
+                    mu_vec=SVector{3, Float64}(fill(NaN, 3)),
+                    omega=NaN,
+                    pressure=NaN,
+                    rho_norm=NaN,
+                    entropy=NaN,
+                    energy=NaN,
+                    masses=SVector{3, Float64}(fill(NaN, 3)))
+        end
+
+        cache[method] = (res, cand)
+        return (
+            x=Vector{Float64}(res.zero),
+            converged=Bool(res.f_converged) && Bool(cand.phys),
+            residual_norm=Float64(res.residual_norm),
+            score=isfinite(cand.omega) ? Float64(cand.omega) : NaN,
+        )
+    end
+
+    policy = RootPolicy(
+        primary_method=nlsolve_method,
+        fallback_method=fallback_method,
+        use_fallback=trust_region_fallback,
+        use_multiseed=false,
+        residual_norm_max=Float64(residual_norm_max),
+        require_converged=true,
+        diagnostics_level=:basic,
+    )
+
+    solved = solve_root_with_policy(solve_once, x0; policy=policy)
+    selected_method = solved.diagnostics.attempts[solved.diagnostics.selected_attempt].method
+    if !haskey(cache, selected_method)
+        _ = solve_once(selected_method, x0)
+    end
+    res, cand = cache[selected_method]
+
+    converged = res.f_converged && cand.phys && isfinite(res.residual_norm) && (res.residual_norm <= Float64(residual_norm_max))
+    single = SolverResult(
+        mode,
+        converged,
+        cand.x_sol,
+        cand.x_state,
+        mu_vec,
+        cand.omega,
+        cand.pressure,
+        cand.rho_norm,
+        cand.entropy,
+        cand.energy,
+        cand.masses,
+        res.iterations,
+        res.residual_norm,
+        Float64(xi),
+    )
+
+    if converged || !auto_multiseed_fallback
+        attempts = map(solved.diagnostics.attempts) do a
+            (
+                method=a.method,
+                seed_source=a.seed_source,
+                converged=a.converged,
+                residual_norm=a.residual_norm,
+                quality_tag=a.quality_tag,
+                score=a.score,
+            )
+        end
+        return (
+            result=single,
+            root_diagnostics=(
+                selected_method=selected_method,
+                selected_attempt=solved.diagnostics.selected_attempt,
+                attempts=attempts,
+            ),
+        )
+    end
+
+    multi = solve_multi(mode, T_fm, μ_fm;
+        seed_strategy=MultiSeed(),
+        nlsolve_method=nlsolve_method,
+        xi=xi,
+        p_num=p_num,
+        t_num=t_num,
+        trust_region_fallback=trust_region_fallback,
+        auto_multiseed_fallback=false,
+        fallback_method=fallback_method,
+        physicality_check=physicality_check,
+        residual_norm_max=residual_norm_max,
+        nlsolve_kwargs...)
+    attempts = map(solved.diagnostics.attempts) do a
+        (
+            method=a.method,
+            seed_source=a.seed_source,
+            converged=a.converged,
+            residual_norm=a.residual_norm,
+            quality_tag=a.quality_tag,
+            score=a.score,
+        )
+    end
+    return (
+        result=multi,
+        root_diagnostics=(
+            selected_method=:multiseed,
+            selected_attempt=solved.diagnostics.selected_attempt,
+            attempts=attempts,
+        ),
+    )
 end
 
 end # module ImplicitSolver

--- a/src/models/solver/ImplicitSolver.jl
+++ b/src/models/solver/ImplicitSolver.jl
@@ -172,6 +172,7 @@ function _nlsolve_with_tr_fallback(residual_fn!, x0;
             x=Vector{Float64}(res.zero),
             converged=Bool(res.f_converged) && Bool(cand.phys),
             residual_norm=Float64(res.residual_norm),
+            score=isfinite(cand.omega) ? Float64(cand.omega) : NaN,
         )
     end
 

--- a/src/models/solver/ImplicitSolver.jl
+++ b/src/models/solver/ImplicitSolver.jl
@@ -1304,4 +1304,43 @@ function solve_with_root_diagnostics(::FixedMu, T_fm::Real, μ_fm::Real;
     )
 end
 
+@inline function _diagnostics_payload_from_result(result::SolverResult; selected_method::Symbol=:unknown, seed_source::Symbol=:seed)
+    attempt = (
+        method=selected_method,
+        seed_source=seed_source,
+        converged=Bool(result.converged),
+        residual_norm=Float64(result.residual_norm),
+        quality_tag=Bool(result.converged) ? :good : :degraded,
+        score=isfinite(result.omega) ? Float64(result.omega) : NaN,
+    )
+    return (
+        result=result,
+        root_diagnostics=(
+            selected_method=selected_method,
+            selected_attempt=1,
+            attempts=[attempt],
+        ),
+    )
+end
+
+"""
+    solve_with_root_diagnostics(mode::FixedRho, T_fm; kwargs...) -> NamedTuple
+
+固定密度模式的兼容诊断入口。
+"""
+function solve_with_root_diagnostics(mode::FixedRho, T_fm::Real; kwargs...)
+    result = solve(mode, T_fm; kwargs...)
+    return _diagnostics_payload_from_result(result; selected_method=:legacy_fallback, seed_source=:seed)
+end
+
+"""
+    solve_with_root_diagnostics(mode::FixedAsymmetricRho, T_fm; kwargs...) -> NamedTuple
+
+固定非对称密度模式的兼容诊断入口。
+"""
+function solve_with_root_diagnostics(mode::FixedAsymmetricRho, T_fm::Real; kwargs...)
+    result = solve(mode, T_fm; kwargs...)
+    return _diagnostics_payload_from_result(result; selected_method=:legacy_fallback, seed_source=:seed)
+end
+
 end # module ImplicitSolver

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -73,6 +73,8 @@ end
 @inline create_implicit_solver(; kwargs...) = ImplicitSolver.create_implicit_solver(; kwargs...)
 @inline solve_with_derivatives(T_fm::Real, μ_fm::Real; kwargs...) = ImplicitSolver.solve_with_derivatives(T_fm, μ_fm; kwargs...)
 @inline solve_with_root_diagnostics(mode::FixedMu, T_fm::Real, μ_fm::Real; kwargs...) = ImplicitSolver.solve_with_root_diagnostics(mode, T_fm, μ_fm; kwargs...)
+@inline solve_with_root_diagnostics(mode::FixedRho, T_fm::Real; kwargs...) = ImplicitSolver.solve_with_root_diagnostics(mode, T_fm; kwargs...)
+@inline solve_with_root_diagnostics(mode::FixedAsymmetricRho, T_fm::Real; kwargs...) = ImplicitSolver.solve_with_root_diagnostics(mode, T_fm; kwargs...)
 
 @inline function solve_with_derivatives(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm::Real; kwargs...)
     _ = model, mode

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -75,6 +75,8 @@ end
 @inline solve_with_root_diagnostics(mode::FixedMu, T_fm::Real, μ_fm::Real; kwargs...) = ImplicitSolver.solve_with_root_diagnostics(mode, T_fm, μ_fm; kwargs...)
 @inline solve_with_root_diagnostics(mode::FixedRho, T_fm::Real; kwargs...) = ImplicitSolver.solve_with_root_diagnostics(mode, T_fm; kwargs...)
 @inline solve_with_root_diagnostics(mode::FixedAsymmetricRho, T_fm::Real; kwargs...) = ImplicitSolver.solve_with_root_diagnostics(mode, T_fm; kwargs...)
+@inline solve_with_root_diagnostics(mode::FixedEntropy, T_fm::Real; kwargs...) = ImplicitSolver.solve_with_root_diagnostics(mode, T_fm; kwargs...)
+@inline solve_with_root_diagnostics(mode::FixedSigma, T_fm::Real; kwargs...) = ImplicitSolver.solve_with_root_diagnostics(mode, T_fm; kwargs...)
 
 @inline function solve_with_derivatives(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm::Real; kwargs...)
     _ = model, mode

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -72,6 +72,7 @@ end
 
 @inline create_implicit_solver(; kwargs...) = ImplicitSolver.create_implicit_solver(; kwargs...)
 @inline solve_with_derivatives(T_fm::Real, μ_fm::Real; kwargs...) = ImplicitSolver.solve_with_derivatives(T_fm, μ_fm; kwargs...)
+@inline solve_with_root_diagnostics(mode::FixedMu, T_fm::Real, μ_fm::Real; kwargs...) = ImplicitSolver.solve_with_root_diagnostics(mode, T_fm, μ_fm; kwargs...)
 
 @inline function solve_with_derivatives(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm::Real; kwargs...)
     _ = model, mode

--- a/src/models/workflows/MesonMassWorkflow.jl
+++ b/src/models/workflows/MesonMassWorkflow.jl
@@ -373,6 +373,24 @@ function _solve_meson_mass_with_policy(
 
     solve_once_callback = function (method::Symbol, seed::Vector{Float64})
         picked = run_once(method; m0=seed[1], g0=max(seed[2], 0.0))
+        if picked !== nothing
+            qp_local = normalize_quark_params(quark_params)
+            tp_local = normalize_thermo_params(thermo_params)
+            local_score = try
+                splus, sminus = _mixed_branch_scores(
+                    meson,
+                    Float64(picked.mass),
+                    Float64(picked.gamma),
+                    qp_local,
+                    tp_local,
+                    Float64(k_norm),
+                )
+                min(splus, sminus)
+            catch
+                NaN
+            end
+            return merge(picked, (score=local_score,))
+        end
         return picked
     end
 

--- a/src/models/workflows/MesonMassWorkflow.jl
+++ b/src/models/workflows/MesonMassWorkflow.jl
@@ -362,12 +362,22 @@ function _solve_meson_mass_with_policy(
             g0 = max(initial_seed[2] * 1.001, 0.0)
             seed_res = run_once(nothing; m0=m0, g0=g0)
             if seed_res === nothing
-                return nothing, :bad, nothing
+                diag = (selected_method=:fortran_track, selected_attempt=0, attempts=NamedTuple[])
+                return nothing, :bad, nothing, diag
             end
+            attempt = (
+                method=:fortran_track,
+                seed_source=:seed,
+                converged=Bool(seed_res.converged),
+                residual_norm=Float64(seed_res.residual_norm),
+                quality_tag=_mass_result_good(seed_res, policy) ? :good : :bad,
+                score=NaN,
+            )
+            diag = (selected_method=:fortran_track, selected_attempt=1, attempts=[attempt])
             if _mass_result_good(seed_res, policy)
-                return seed_res, :good, Float64[seed_res.mass, seed_res.gamma]
+                return seed_res, :good, Float64[seed_res.mass, seed_res.gamma], diag
             end
-            return seed_res, :bad, Float64[seed_res.mass, seed_res.gamma]
+            return seed_res, :bad, Float64[seed_res.mass, seed_res.gamma], diag
         end
     end
 
@@ -409,6 +419,21 @@ function _solve_meson_mass_with_policy(
 
     solved = solve_root_with_policy(solve_once_callback, seed0; policy=root_policy)
     root_quality = solved.quality_tag
+    diag_attempts = map(solved.diagnostics.attempts) do a
+        (
+            method=a.method,
+            seed_source=a.seed_source,
+            converged=a.converged,
+            residual_norm=a.residual_norm,
+            quality_tag=a.quality_tag,
+            score=a.score,
+        )
+    end
+    root_diag = (
+        selected_method=solved.diagnostics.attempts[solved.diagnostics.selected_attempt].method,
+        selected_attempt=solved.diagnostics.selected_attempt,
+        attempts=diag_attempts,
+    )
 
     selected_method = solved.diagnostics.attempts[solved.diagnostics.selected_attempt].method
     selected_seed = Float64[solved.x[1], solved.x[2]]
@@ -416,7 +441,7 @@ function _solve_meson_mass_with_policy(
 
     if selected === nothing
         if !isfinite(solved.x[1]) || !isfinite(solved.x[2])
-            return nothing, root_quality, nothing
+            return nothing, root_quality, nothing, root_diag
         end
         selected = (
             mass=Float64(solved.x[1]),
@@ -428,7 +453,7 @@ function _solve_meson_mass_with_policy(
     end
 
     out_seed = (isfinite(selected.mass) && isfinite(selected.gamma)) ? Float64[selected.mass, selected.gamma] : nothing
-    return selected, root_quality, out_seed
+    return selected, root_quality, out_seed, root_diag
 end
 
 const DEFAULT_MESONS = (
@@ -622,7 +647,7 @@ function solve_gap_and_meson_point(
 
     for meson in mesons
         initial_seed = haskey(seed_in, meson) ? seed_in[meson] : nothing
-        res, root_quality, seed_vec = _solve_meson_mass_with_policy(
+        res, root_quality, seed_vec, root_diagnostics = _solve_meson_mass_with_policy(
             meson,
             quark_params,
             thermo_params;
@@ -644,6 +669,7 @@ function solve_gap_and_meson_point(
             gaps = isfinite(mass) ? mott_gaps(meson, mass, qp) : (uu=NaN, ss=NaN, min=NaN)
             meson_results[meson] = (mass=mass, gamma=gamma, converged=converged, residual=residual,
                                     root_quality=root_quality,
+                                    root_diagnostics=root_diagnostics,
                                     threshold=thr, gaps=gaps)
         else
             qp = normalize_quark_params(quark_params)
@@ -651,6 +677,7 @@ function solve_gap_and_meson_point(
             gapv = isfinite(mass) ? mott_gap(meson, mass, qp) : NaN
             meson_results[meson] = (mass=mass, gamma=gamma, converged=converged, residual=residual,
                                     root_quality=root_quality,
+                                    root_diagnostics=root_diagnostics,
                                     threshold=thr, gap=gapv)
         end
 

--- a/src/models/workflows/MesonMassWorkflow.jl
+++ b/src/models/workflows/MesonMassWorkflow.jl
@@ -38,6 +38,7 @@ const WorkflowParamAdapters = Main.WorkflowParamAdapters
 using .WorkflowParamAdapters: normalize_quark_params, normalize_thermo_params
 
 using Main.Constants_PNJL: ħc_MeV_fm
+using Main.Models: RootPolicy, solve_root_with_policy
 const HADRON_SEED_5 = Main.Models.HADRON_SEED_5
 const DEFAULT_MOMENTUM_COUNT = Main.Models.PNJLCore.DEFAULT_MOMENTUM_COUNT
 const DEFAULT_THETA_COUNT = Main.Models.PNJLCore.DEFAULT_THETA_COUNT
@@ -355,9 +356,6 @@ function _solve_meson_mass_with_policy(
         end
     end
 
-    best = nothing
-    best_resid = Inf
-
     if initial_seed !== nothing
         if experiment_mode === :fortran_track
             m0 = initial_seed[1] * 1.001
@@ -371,67 +369,48 @@ function _solve_meson_mass_with_policy(
             end
             return seed_res, :bad, Float64[seed_res.mass, seed_res.gamma]
         end
-
-        seed_res = run_once(nothing; m0=initial_seed[1], g0=initial_seed[2])
-        if seed_res !== nothing
-            seed_resid = Float64(seed_res.residual_norm)
-            if isfinite(seed_resid) && seed_resid < best_resid
-                best = seed_res
-                best_resid = seed_resid
-            end
-            if _mass_result_good(seed_res, policy)
-                return seed_res, :good, Float64[seed_res.mass, seed_res.gamma]
-            end
-        end
     end
 
-    retry_res = _solve_meson_mass_with_retries(meson, quark_params, thermo_params;
-        k_norm=k_norm,
-        mass_kwargs=mass_kwargs,
+    solve_once_callback = function (method::Symbol, seed::Vector{Float64})
+        picked = run_once(method; m0=seed[1], g0=max(seed[2], 0.0))
+        return picked
+    end
+
+    guess = default_meson_mass_guess(meson, qp)
+    seed0 = initial_seed === nothing ? Float64[guess, 0.0] : Float64[initial_seed[1], initial_seed[2]]
+
+    root_policy = RootPolicy(
+        primary_method=:newton,
+        fallback_method=:trust_region,
+        use_fallback=Bool(policy.use_trust_region_fallback),
+        use_multiseed=true,
+        residual_norm_max=Float64(policy.residual_norm_max),
+        require_converged=Bool(policy.require_converged),
+        diagnostics_level=:basic,
     )
-    if retry_res !== nothing
-        retry_resid = Float64(retry_res.residual_norm)
-        if isfinite(retry_resid) && retry_resid < best_resid
-            best = retry_res
-            best_resid = retry_resid
+
+    solved = solve_root_with_policy(solve_once_callback, seed0; policy=root_policy)
+    root_quality = solved.quality_tag
+
+    selected_method = solved.diagnostics.attempts[solved.diagnostics.selected_attempt].method
+    selected_seed = Float64[solved.x[1], solved.x[2]]
+    selected = run_once(selected_method; m0=selected_seed[1], g0=max(selected_seed[2], 0.0))
+
+    if selected === nothing
+        if !isfinite(solved.x[1]) || !isfinite(solved.x[2])
+            return nothing, root_quality, nothing
         end
-        if _mass_result_good(retry_res, policy)
-            return retry_res, :good, Float64[retry_res.mass, retry_res.gamma]
-        end
+        selected = (
+            mass=Float64(solved.x[1]),
+            gamma=Float64(solved.x[2]),
+            converged=Bool(solved.converged),
+            residual_norm=Float64(solved.residual_norm),
+            solution=nothing,
+        )
     end
 
-    if Bool(policy.use_trust_region_fallback)
-        fallback_seeds = Vector{Vector{Float64}}()
-        if initial_seed !== nothing
-            push!(fallback_seeds, initial_seed)
-        end
-        if retry_res !== nothing
-            push!(fallback_seeds, Float64[retry_res.mass, retry_res.gamma])
-        end
-        if isempty(fallback_seeds)
-            guess = default_meson_mass_guess(meson, qp)
-            push!(fallback_seeds, Float64[guess, 0.0])
-        end
-
-        for s in fallback_seeds
-            tr_res = run_once(:trust_region; m0=s[1], g0=s[2])
-            tr_res === nothing && continue
-
-            tr_resid = Float64(tr_res.residual_norm)
-            if isfinite(tr_resid) && tr_resid < best_resid
-                best = tr_res
-                best_resid = tr_resid
-            end
-            if _mass_result_good(tr_res, policy)
-                return tr_res, :fallback, Float64[tr_res.mass, tr_res.gamma]
-            end
-        end
-    end
-
-    if best === nothing
-        return nothing, :bad, nothing
-    end
-    return best, :bad, Float64[best.mass, best.gamma]
+    out_seed = (isfinite(selected.mass) && isfinite(selected.gamma)) ? Float64[selected.mass, selected.gamma] : nothing
+    return selected, root_quality, out_seed
 end
 
 const DEFAULT_MESONS = (

--- a/tests/unit/models/test_generic_root_engine.jl
+++ b/tests/unit/models/test_generic_root_engine.jl
@@ -55,4 +55,18 @@ end
         @test result.converged
         @test result.quality_tag in (:degraded, :bad)
     end
+
+    @testset "callback solver path supports fallback" begin
+        solve_once = function (method::Symbol, seed::Vector{Float64})
+            if method === :newton
+                return (mass=seed[1], gamma=seed[2], converged=false, residual_norm=1.0)
+            end
+            return (mass=2.0, gamma=0.0, converged=true, residual_norm=1e-12)
+        end
+
+        result = Models.solve_root_with_policy(solve_once, [1.0, 0.0])
+        @test result.converged
+        @test result.quality_tag == :fallback
+        @test isapprox(result.x[1], 2.0; atol=1e-12)
+    end
 end

--- a/tests/unit/models/test_generic_root_engine.jl
+++ b/tests/unit/models/test_generic_root_engine.jl
@@ -1,0 +1,58 @@
+using Test
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+@testset "GenericRootEngine" begin
+    @test isdefined(Models, :RootProblemSpec)
+    @test isdefined(Models, :RootPolicy)
+    @test isdefined(Models, :ContinuationState)
+    @test isdefined(Models, :solve_root_with_policy)
+    @test isdefined(Models, :solve_root_continuation)
+
+    @testset "solve_root_with_policy solves scalar root" begin
+        spec = Models.RootProblemSpec(
+            (F, x, _) -> (F[1] = x[1]^2 - 2.0),
+            nothing,
+            1,
+            :single,
+        )
+        result = Models.solve_root_with_policy(spec, [1.0])
+        @test result.converged
+        @test result.quality_tag in (:good, :fallback)
+        @test isapprox(result.x[1], sqrt(2.0); atol=1e-8)
+        @test length(result.diagnostics.attempts) >= 1
+    end
+
+    @testset "solve_root_continuation tracks across points" begin
+        spec_factory = p -> Models.RootProblemSpec(
+            (F, x, ctx) -> (F[1] = x[1] - ctx.target),
+            (target=Float64(p),),
+            1,
+            :single,
+        )
+        tracker = Models.ContinuationState()
+        results = Models.solve_root_continuation([1.0, 2.0, 3.0], spec_factory; tracker=tracker, x0=[0.0])
+
+        @test length(results) == 3
+        @test isapprox(results[end].x[1], 3.0; atol=1e-10)
+        @test haskey(tracker.seed_by_branch, :default)
+        @test isapprox(tracker.seed_by_branch[:default][1], 3.0; atol=1e-10)
+    end
+
+    @testset "domain_quality can veto quality gate" begin
+        spec = Models.RootProblemSpec(
+            (F, x, _) -> (F[1] = x[1] + 1.0),
+            nothing,
+            1,
+            :single,
+        )
+        dq = (x, _) -> (ok=x[1] > 0.0, score=abs(x[1]), reason=:positive_required)
+        result = Models.solve_root_with_policy(spec, [0.0]; domain_quality=dq)
+        @test result.converged
+        @test result.quality_tag in (:degraded, :bad)
+    end
+end

--- a/tests/unit/models/test_generic_root_engine.jl
+++ b/tests/unit/models/test_generic_root_engine.jl
@@ -66,7 +66,22 @@ end
 
         result = Models.solve_root_with_policy(solve_once, [1.0, 0.0])
         @test result.converged
-        @test result.quality_tag == :fallback
+        @test result.quality_tag in (:good, :fallback)
         @test isapprox(result.x[1], 2.0; atol=1e-12)
+    end
+
+    @testset "callback solver prefers lower score over lower residual" begin
+        solve_once = function (method::Symbol, seed::Vector{Float64})
+            if method === :newton
+                return (mass=10.0, gamma=0.0, converged=true, residual_norm=1e-12, score=10.0)
+            end
+            return (mass=11.0, gamma=0.0, converged=true, residual_norm=1e-8, score=0.1)
+        end
+
+        result = Models.solve_root_with_policy(solve_once, [1.0, 0.0])
+        @test result.quality_tag == :fallback
+        @test isapprox(result.x[1], 11.0; atol=1e-12)
+        selected = result.diagnostics.attempts[result.diagnostics.selected_attempt]
+        @test selected.score ≈ 0.1
     end
 end

--- a/tests/unit/pnjl/test_solver_implicit.jl
+++ b/tests/unit/pnjl/test_solver_implicit.jl
@@ -160,6 +160,15 @@ end
         @test result.mode isa P.FixedEntropy
         @test length(result.solution) == 8
     end
+
+    @testset "root diagnostics 接口" begin
+        payload = P.solve_with_root_diagnostics(P.FixedEntropy(0.5), T_fm; p_num=24, t_num=6)
+        @test haskey(payload, :result)
+        @test haskey(payload, :root_diagnostics)
+        @test payload.result isa P.SolverResult
+        @test haskey(payload.root_diagnostics, :attempts)
+        @test !isempty(payload.root_diagnostics.attempts)
+    end
 end
 
 # ============================================================================
@@ -176,6 +185,15 @@ end
         @test result isa P.SolverResult
         @test result.mode isa P.FixedSigma
         @test length(result.solution) == 8
+    end
+
+    @testset "root diagnostics 接口" begin
+        payload = P.solve_with_root_diagnostics(P.FixedSigma(10.0), T_fm; p_num=24, t_num=6)
+        @test haskey(payload, :result)
+        @test haskey(payload, :root_diagnostics)
+        @test payload.result isa P.SolverResult
+        @test haskey(payload.root_diagnostics, :attempts)
+        @test !isempty(payload.root_diagnostics.attempts)
     end
 end
 

--- a/tests/unit/pnjl/test_solver_implicit.jl
+++ b/tests/unit/pnjl/test_solver_implicit.jl
@@ -123,6 +123,26 @@ end
             @test isapprox(result.mu_vec[2], result.mu_vec[3]; rtol=1e-6)
         end
     end
+
+    @testset "root diagnostics 接口" begin
+        payload = P.solve_with_root_diagnostics(P.FixedRho(1.0), T_fm; p_num=24, t_num=6)
+        @test haskey(payload, :result)
+        @test haskey(payload, :root_diagnostics)
+        @test payload.result isa P.SolverResult
+        @test haskey(payload.root_diagnostics, :attempts)
+        @test !isempty(payload.root_diagnostics.attempts)
+    end
+end
+
+@testset "solve FixedAsymmetricRho root diagnostics" begin
+    T_MeV = 100.0
+    T_fm = T_MeV / ħc
+    payload = P.solve_with_root_diagnostics(P.FixedAsymmetricRho(1.0, 0.876, 0.0), T_fm; p_num=24, t_num=6)
+    @test haskey(payload, :result)
+    @test haskey(payload, :root_diagnostics)
+    @test payload.result isa P.SolverResult
+    @test haskey(payload.root_diagnostics, :attempts)
+    @test !isempty(payload.root_diagnostics.attempts)
 end
 
 # ============================================================================

--- a/tests/unit/pnjl/test_solver_implicit.jl
+++ b/tests/unit/pnjl/test_solver_implicit.jl
@@ -76,6 +76,16 @@ const ħc = 197.327  # MeV·fm
                       p_num=24, t_num=6)
         @test result.converged
     end
+
+    @testset "root diagnostics 接口" begin
+        payload = P.solve_with_root_diagnostics(P.FixedMu(), T_fm, μ_fm; p_num=24, t_num=6)
+        @test haskey(payload, :result)
+        @test haskey(payload, :root_diagnostics)
+        @test payload.result isa P.SolverResult
+        @test haskey(payload.root_diagnostics, :selected_method)
+        @test haskey(payload.root_diagnostics, :attempts)
+        @test !isempty(payload.root_diagnostics.attempts)
+    end
 end
 
 # ============================================================================

--- a/tests/validation/relaxtime/test_mixed_meson_root_quality_continuation.jl
+++ b/tests/validation/relaxtime/test_mixed_meson_root_quality_continuation.jl
@@ -41,6 +41,11 @@ const _HBARC_MEV_FM = Main.Constants_PNJL.ħc_MeV_fm
         seed_state = res.meson_seed_state
         @test hasproperty(res.meson_results[:eta], :root_quality)
         @test hasproperty(res.meson_results[:eta_prime], :root_quality)
+        @test hasproperty(res.meson_results[:eta], :root_diagnostics)
+        @test hasproperty(res.meson_results[:eta_prime], :root_diagnostics)
+        @test hasproperty(res.meson_results[:eta].root_diagnostics, :selected_method)
+        @test hasproperty(res.meson_results[:eta].root_diagnostics, :attempts)
+        @test !isempty(res.meson_results[:eta].root_diagnostics.attempts)
 
         if res.meson_results[:eta].root_quality != :good
             @test !res.meson_results[:eta].converged || res.meson_results[:eta].residual > 1e-6


### PR DESCRIPTION
## 背景
本 PR 承接 `mott-validation-xi-scan` 后续工作，先完成“通用连续性求解引擎”的设计、最小骨架与主链接线，为后续 Meson/Gap 迁移做分阶段准备。

## 本 PR 已完成
- [x] 新增零知识可读的设计文档（通用接口、adapter 边界、fallback/quality 流程、Phase A/B/C 迁移路径）
- [x] 新增 `GenericRootEngine` 最小骨架：
  - `RootProblemSpec`
  - `RootPolicy`
  - `ContinuationState`
  - `RootAttempt` / `RootDiagnostics` / `RootSolveResult`
  - `solve_root_with_policy`
  - `solve_root_continuation`
- [x] 在 `Models` 入口接入 include + export
- [x] 新增单元测试 `tests/unit/models/test_generic_root_engine.jl`
- [x] Phase A 接线：Meson workflow 通用求解链路接入 `GenericRootEngine`
- [x] Phase B 首版接线：ImplicitSolver 的 fallback 选择路径接入 `GenericRootEngine`
- [x] 评分选择增强：Generic 引擎支持 `score` 参与候选选择（同质量等级下优先领域评分更优解）
- [x] Meson 评分接线：混合态路径把 branch score 注入通用引擎候选选择
- [x] Gap 评分语义对齐：Implicit fallback callback 注入 `score=omega`，保留原先“更优 Ω 优先”偏好
- [x] 诊断兼容层：Meson 输出新增 `root_diagnostics`，保留原有 `root_quality`
- [x] Gap 对外兼容入口：`solve_with_root_diagnostics` 已覆盖五种模式：
  - `FixedMu`
  - `FixedRho`
  - `FixedAsymmetricRho`
  - `FixedEntropy`
  - `FixedSigma`
- [x] 同步计划文档勾选（`GenericRootEngine.jl` 最小骨架 + 单测）

## `root_diagnostics` 字段说明（新增）
为了减少迁移期间字段割裂，Meson 结果在保留 `root_quality` 的同时新增：

- `root_diagnostics.selected_method`
- `root_diagnostics.selected_attempt`
- `root_diagnostics.attempts::Vector{NamedTuple}`，每个 attempt 包含：
  - `method`
  - `seed_source`
  - `converged`
  - `residual_norm`
  - `quality_tag`
  - `score`

Gap 侧兼容 API（当前覆盖模式）：
- `solve_with_root_diagnostics(::FixedMu, ...)`
- `solve_with_root_diagnostics(::FixedRho, ...)`
- `solve_with_root_diagnostics(::FixedAsymmetricRho, ...)`
- `solve_with_root_diagnostics(::FixedEntropy, ...)`
- `solve_with_root_diagnostics(::FixedSigma, ...)`

返回统一结构：
- `(result=SolverResult, root_diagnostics=(selected_method, selected_attempt, attempts))`

兼容性策略：
- 旧调用方继续使用 `solve(...)` / `root_quality` 不受影响
- 新调用方可逐步切换到 `root_diagnostics` 获取统一 attempt trace

## 最近拆分提交（按职责分离）
1. `b314258` — `refactor(models): make generic root selection score-aware`
2. `4a99ee9` — `refactor(relaxtime): feed mixed-branch score into generic root engine`
3. `2641b91` — `refactor(models): preserve omega preference in generic fallback scoring`
4. `ea5126a` — `refactor(relaxtime): add root diagnostics compatibility fields`
5. `dadf969` — `feat(models): add root diagnostics entrypoint for fixed-mu solver`
6. `1e54745` — `test(pnjl): cover fixed-mu root diagnostics compatibility output`
7. `aebd17f` — `feat(models): extend root diagnostics entrypoint to rho modes`
8. `952ee18` — `test(pnjl): cover rho-mode root diagnostics compatibility`
9. `5704a41` — `feat(models): extend root diagnostics entrypoint to entropy and sigma modes`
10. `aa7472a` — `test(pnjl): cover entropy-sigma root diagnostics compatibility`

## 本 PR 不做（边界）
- [ ] 不在本 PR 完成 Gap 全路径深度重构（当前覆盖关键模式 diagnostics 兼容入口）
- [ ] 不在本 PR 做统一诊断对外字段最终定版（当前为兼容层）
- [ ] 不在本 PR 更新 docs/api 稳定接口文档（当前仍属迭代中实现）

## 变更文件
- `docs/dev/active/2026-03-22_generic_root_engine_design.md`
- `docs/superpowers/plans/2026-03-22-generic-root-continuation-design-plan.md`
- `src/models/solver/GenericRootEngine.jl`
- `src/models/solver/ImplicitSolver.jl`
- `src/models/solver/Solver.jl`
- `src/models/workflows/MesonMassWorkflow.jl`
- `src/models/Models.jl`
- `tests/unit/models/test_generic_root_engine.jl`
- `tests/unit/pnjl/test_solver_implicit.jl`
- `tests/validation/relaxtime/test_mixed_meson_root_quality_continuation.jl`

## 验证记录
- [x] `julia --project=. -e 'include("tests/unit/models/test_generic_root_engine.jl")'`
- [x] `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_generic_root_engine.jl"; include("tests/unit/runtests.jl")'`
- [x] `julia --project=. -e 'include("tests/unit/models/test_meson_mass_workflow.jl")'`
- [x] `julia --project=. -e 'include("tests/validation/relaxtime/test_mixed_meson_root_quality_continuation.jl")'`
- [x] `julia --project=. -e 'include("tests/unit/pnjl/test_solver_implicit.jl")'`
- [x] `julia --project=. -e 'include("tests/unit/models/test_implicit_gap.jl")'`
- [x] `julia --project=. -e 'include("tests/unit/models/test_implicit_gap_flavor_mu.jl")'`
- [x] `julia --project=. scripts/dev/check_active_docs_governance.jl`

## 后续计划（下一步）
1. 把 `root_diagnostics` 兼容层进一步推广到其余关键调用路径
2. 评估将兼容层字段收敛为稳定 API 所需的最小改动
3. 若稳定化完成，再补 `docs/api/*`