### PR TITLE
fix(regression): clarify optional fixture skips and align AGENTS entrypoint guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ Repository guidance for coding agents working in `Julia_RelaxTime`.
 - Root `Project.toml` declares Julia `1.10` compatibility.
 - This repo is include-driven, not a standard packaged `src/PackageName.jl` layout.
 - Prefer unified entrypoints exposed through `Models` and `src/models/entrypoints.jl`.
-- Treat `src/pnjl/PNJL.jl` as a compatibility layer unless an existing caller already depends on it.
+- `src/pnjl/PNJL.jl` 已从主线移除；若历史文档仍提及该路径，应按“兼容层历史说明”理解，不作为当前实现入口。
+- 统一入口请使用 `Models` 与 `src/models/entrypoints.jl`。
 - Default user-facing communication language is Chinese.
 
 ## Repo Rules From Copilot / Cursor

--- a/tests/regression/runtests.jl
+++ b/tests/regression/runtests.jl
@@ -2,6 +2,14 @@ using Test
 
 const REGRESSION_DIR = @__DIR__
 
+const EXPECTED_OPTIONAL_FIXTURE_SKIPS = [
+    (
+        name = "tau xi probe regression fixtures",
+        file = "tests/regression/relaxtime/test_tau_xi_probe_regression.jl",
+        reason = "缺少 data/outputs/results/relaxtime/scan/_xi_probe_T190_summary.csv 或 _xi_probe_T200_summary.csv 时会触发 @test_skip",
+    ),
+]
+
 const SMOKE_FILES = [
     joinpath(REGRESSION_DIR, "njl", "test_njl_gap_fixedpoint_regression.jl"),
     joinpath(REGRESSION_DIR, "rpnjl", "test_rpnjl_gap_fixedpoint_regression.jl"),
@@ -42,7 +50,19 @@ function _include_regression_dir(dir::String)
     end
 end
 
+function _print_expected_regression_skips()
+    isempty(EXPECTED_OPTIONAL_FIXTURE_SKIPS) && return
+    println("[regression] 预期可选跳过项（用于解释 summary 中的 Broken 计数）:")
+    for item in EXPECTED_OPTIONAL_FIXTURE_SKIPS
+        println("  - $(item.name)")
+        println("    file: $(item.file)")
+        println("    reason: $(item.reason)")
+    end
+end
+
 @testset "Regression" begin
+    _print_expected_regression_skips()
+
     selected = _selected_regression_files()
 
     if selected !== nothing


### PR DESCRIPTION
## Summary
- make regression smoke output explicitly list expected optional fixture skips so `Broken=1` is explainable and non-ambiguous
- align AGENTS entrypoint guidance with current mainline architecture (`Models` + `src/models/entrypoints.jl`) after legacy `src/pnjl/PNJL.jl` removal

## Why
- reduce false alarms during smoke review by distinguishing expected fixture-absent skips from real regressions
- prevent contributor confusion from stale entrypoint instructions and keep onboarding/agent guidance consistent with code reality

## Validation
- `julia --project=. -e 'ENV[\"REGRESSION_PROFILE\"]=\"smoke\"; include(\"tests/regression/runtests.jl\")'`
- `julia --project=. scripts/dev/check_docs_consistency.jl`
- `julia --project=. scripts/dev/check_active_docs_governance.jl`