### PR TITLE
docs: internalize gas-liquid/rotation formula foundations and MFA Omega workflow

### DIFF
--- a/docs/reference/formula/models/README.md
+++ b/docs/reference/formula/models/README.md
@@ -1,0 +1,27 @@
+# Models 公式索引（主线内化版）
+
+本目录用于沉淀 `Models` 相关公式文档，强调三点：
+
+- 与当前仓库的单位/命名口径一致（内部自然单位，外部输入显式 `*_MeV`）。
+- 公式不做“原样搬运”，而是提炼成可直接映射到本仓库实现与测试的表达。
+- 对尚未落地的模型能力，先给出“理论定义 + 迁移接口约束”，避免与现有主线冲突。
+
+## 当前主题
+
+- `njl/NJL_core.md`：NJL 核心公式与能隙方程。
+- `pnjl/Omega_各向同性.md`：PNJL 各向同性巨热力学势。
+- `pnjl/Omega_RS各向异性.md`：PNJL 动量各向异性热项改造。
+- `rpnjl/rPNJL_core.md`：含矢量相互作用的 rPNJL 核心关系。
+- `pnjl_magnetic/PNJL_magnetic_core.md`：外磁场 PNJL 核心关系。
+
+## 本批新增（PR1）
+
+- `gas_liquid/GasLiquid_RMF_CoreEquations.md`：Gas-Liquid (RMF/Walecka) 核心方程与约束求解口径。
+- `rotation/Rotation_PNJL_CoreEquations.md`：Rotation-PNJL 在 `T-mu-omega` 语义下的最小公式集。
+- `shared/Lagrangian_to_GrandPotential_MFA_Workflow.md`：从拉氏量到巨热力学势的统一平均场推导流程。
+
+## 使用建议
+
+- 若先做文档后做代码：优先使用 `shared/` 文档统一符号，再按模型主题实现。
+- 若做 API 文档：将稳定入口同步到 `docs/api/models/*`，本目录保留理论与公式层。
+- 若发现公式与代码不一致：以代码为准修正文档，并记录偏差原因与修订日期。

--- a/docs/reference/formula/models/gas_liquid/GasLiquid_RMF_CoreEquations.md
+++ b/docs/reference/formula/models/gas_liquid/GasLiquid_RMF_CoreEquations.md
@@ -1,0 +1,133 @@
+# Gas-Liquid (RMF/Walecka) 核心公式（面向 Julia_RelaxTime 内化）
+
+## 1. 适用范围与定位
+
+本文档提炼 legacy `Function_Gas_Liquid` 中对当前主线最有迁移价值的核心：
+
+- 质子-中子双组分相对论平均场（RMF）
+- 自洽场方程 + 约束方程联立求解
+- 压强与高阶导数（用于涨落量）
+
+不保留 legacy 中“脚本即长时运行”的形态，统一转为“模型函数 + workflow 调用”。
+
+## 2. 基本自由度与单位
+
+- 费米子：`p, n`（质子、 中子）
+- 介子平均场：`sigma, omega, rho, delta`
+- 内部单位：自然单位（`fm^-1`）
+- 外部接口若使用 MeV，需显式转换：`x_inv_fm = x_MeV / hbarc_MeV_fm`
+
+## 3. 有效质量与单粒子能量
+
+设质子/中子有效质量为：
+
+```math
+M_p^* = M_N - g_\sigma\sigma - g_\delta\delta,
+\qquad
+M_n^* = M_N - g_\sigma\sigma + g_\delta\delta.
+```
+
+单粒子能量：
+
+```math
+E_i^*(p) = \sqrt{p^2 + (M_i^*)^2}, \quad i\in\{p,n\}.
+```
+
+有效化学势（平均场近似）：
+
+```math
+\mu_p^* = \mu_p - g_\omega\omega - g_\rho\rho,
+\qquad
+\mu_n^* = \mu_n - g_\omega\omega + g_\rho\rho.
+```
+
+## 4. 分布函数与密度
+
+```math
+f_i = \frac{1}{\exp((E_i^* - \mu_i^*)/T)+1},
+\qquad
+\bar f_i = \frac{1}{\exp((E_i^* + \mu_i^*)/T)+1}.
+```
+
+数密度与标量密度：
+
+```math
+\rho_i = 2\int\frac{d^3p}{(2\pi)^3}(f_i-\bar f_i),
+\qquad
+\rho_{s,i} = 2\int\frac{d^3p}{(2\pi)^3}\frac{M_i^*}{E_i^*}(f_i+\bar f_i).
+```
+
+## 5. 平均场方程（最小闭环）
+
+推荐以“残差联立”形式实现，不在文档里绑定某个求解器：
+
+```math
+R_\sigma = m_\sigma^2\sigma + b\,\sigma^2 + c\,\sigma^3 - g_\sigma(\rho_{s,p}+\rho_{s,n}) = 0,
+```
+
+```math
+R_\delta = m_\delta^2\delta - g_\delta(\rho_{s,p}-\rho_{s,n}) = 0,
+```
+
+```math
+R_\omega = m_\omega^2\omega - g_\omega(\rho_p+\rho_n) = 0,
+```
+
+```math
+R_\rho = m_\rho^2\rho - g_\rho(\rho_p-\rho_n) = 0.
+```
+
+## 6. 约束模式（建议与 Models 统一）
+
+为与当前 `Models.solve_constraint` 生态兼容，建议优先支持：
+
+- `FixedMu`：给定 `(T, mu_p, mu_n)`
+- `FixedRho`：给定 `(T, rho_B)`，其中 `rho_B=(rho_p+rho_n)/2`
+- `FixedAsymRho`：给定 `(T, rho_B, alpha)`，`alpha=(rho_n-rho_p)/(rho_n+rho_p)`
+
+等价残差可写为：
+
+```math
+R_{\rho_B}=\rho_B^{calc}-\rho_B^{target}=0,
+\qquad
+R_\alpha=\alpha^{calc}-\alpha^{target}=0.
+```
+
+## 7. 压强与热力学导数（用于涨落）
+
+压强定义保持主线口径：
+
+```math
+P = -\Omega.
+```
+
+迁移阶段建议先保留“原始导数定义”，再决定 AD 或有限差分实现：
+
+```math
+\chi_1 = \frac{\partial P}{\partial \mu_B},
+\chi_2 = \frac{\partial^2 P}{\partial \mu_B^2},
+\chi_3 = \frac{\partial^3 P}{\partial \mu_B^3},
+\chi_4 = \frac{\partial^4 P}{\partial \mu_B^4}.
+```
+
+并可构造观测比值：
+
+```math
+\kappa\sigma^2 = \chi_4/\chi_2,
+\qquad
+S\sigma = \chi_3/\chi_2.
+```
+
+## 8. 与仓库实现的映射建议
+
+- 公式层：本页
+- 代码层（计划）：`src/models/variants/gas_liquid/`
+- 测试层（计划）：
+  - `tests/unit/models/test_gas_liquid_model.jl`
+  - `tests/integration/models/test_gas_liquid_workflow_smoke.jl`
+
+## 9. 迁移注意事项
+
+- 先实现“最小可运行核”，不要一次迁入全部高阶扫描脚本。
+- 明确 `rho_B` 归一化口径（不同文献常见 `1/2` 或 `1/3` 差异）。
+- 保留对初值敏感性的诊断字段，避免把收敛失败静默吞掉。

--- a/docs/reference/formula/models/rotation/Rotation_PNJL_CoreEquations.md
+++ b/docs/reference/formula/models/rotation/Rotation_PNJL_CoreEquations.md
@@ -1,0 +1,84 @@
+# Rotation-PNJL 核心公式（T-mu-omega 最小可运行口径）
+
+## 1. 适用范围与定位
+
+本文档提炼 legacy rotation 文档中的关键内容，服务于“先适配壳、后增强”的迁移策略：
+
+- 最小变量集：`(phi, Phi, PhiBar)`
+- 最小控制参量：`(T, mu, omega)`
+- 最小输出：`pressure, rho, entropy, energy`
+
+## 2. 有效能量与旋转修正
+
+在 rotation 近似中，单粒子能量可写为：
+
+```math
+E_{rot}(p,n;M,\omega)=\sqrt{p^2+M^2}-(n+1/2)\,\omega,
+```
+
+其中 `n` 是与旋转相关的离散模标签（具体截断与权重由数值离散决定）。
+
+## 3. PNJL 有效势与对数项
+
+巨热力学势沿用 PNJL 结构，但把热项中的能量替换为 `E_rot`：
+
+```math
+\Omega_{rot}
+=\Omega_{cond}(\phi)
++U(\Phi,\bar\Phi;T)
+\;+
+\Omega_{vac}(M)
+\;+
+\Omega_{th}(E_{rot},\mu,T,\Phi,\bar\Phi).
+```
+
+对应热项中两类对数核：
+
+```math
+\mathcal Q_1^{rot}=\ln\!\left(1+3\Phi e^{-(E_{rot}-\mu)/T}+3\bar\Phi e^{-2(E_{rot}-\mu)/T}+e^{-3(E_{rot}-\mu)/T}\right),
+```
+
+```math
+\mathcal Q_2^{rot}=\ln\!\left(1+3\bar\Phi e^{-(E_{rot}+\mu)/T}+3\Phi e^{-2(E_{rot}+\mu)/T}+e^{-3(E_{rot}+\mu)/T}\right).
+```
+
+## 4. 平衡态方程（最小）
+
+平衡态由极值条件确定：
+
+```math
+\frac{\partial\Omega_{rot}}{\partial\phi}=0,\qquad
+\frac{\partial\Omega_{rot}}{\partial\Phi}=0,\qquad
+\frac{\partial\Omega_{rot}}{\partial\bar\Phi}=0.
+```
+
+若采用固定密度路径 `T-rho`，需附加：
+
+```math
+R_\rho = \rho_{calc}(T,\mu,\omega)-\rho_{target}=0.
+```
+
+因此常见为 4 变量联立系统（3 个序参量 + 1 个化学势或约束变量）。
+
+## 5. 热力学量定义（与主线一致）
+
+```math
+P=-\Omega_{rot},\qquad
+\rho=-\frac{\partial\Omega_{rot}}{\partial\mu},\qquad
+s=-\frac{\partial\Omega_{rot}}{\partial T},\qquad
+\epsilon=Ts+\mu\rho-P.
+```
+
+## 6. 与现有主线的边界约定
+
+- 本文档只定义最小 rotation 核，不绑定 legacy 的具体节点实现细节。
+- 迁移实现时建议先复用现有 `Models` 求解策略接口，而不是复制旧脚本控制流。
+- 高阶导数（如 `dP/dT^n`, `dP/domega`）列为 Phase-B 增强，不在首批最小核强制实现。
+
+## 7. 代码映射建议
+
+- 公式层：本页
+- 代码层（计划）：`src/models/variants/rotation/`
+- 测试层（计划）：
+  - `tests/unit/models/test_rotation_model.jl`
+  - `tests/integration/models/test_rotation_workflow_smoke.jl`

--- a/docs/reference/formula/models/shared/Lagrangian_to_GrandPotential_MFA_Workflow.md
+++ b/docs/reference/formula/models/shared/Lagrangian_to_GrandPotential_MFA_Workflow.md
@@ -1,0 +1,106 @@
+# 从拉氏量到巨热力学势：平均场推导统一流程（内化版）
+
+## 1. 文档目的
+
+本文档吸收 legacy `docs/formulas/从拉氏量到巨热力学势.md` 的核心价值，但去除对话式冗余，转化为可直接指导本仓库实现与审阅的统一流程。
+
+适用模型：NJL / PNJL / 其可扩展变体（rPNJL、磁场、rotation 等）。
+
+## 2. 统一七步法
+
+### Step 1：写出模型拉氏量
+
+以三味 PNJL 为例：
+
+```math
+\mathcal L
+=\bar q(i\gamma^\mu D_\mu-\hat m+\gamma^0\hat\mu)q
++\mathcal L_{4q}
++\mathcal L_{6q}
+-\mathcal U(\Phi,\bar\Phi;T).
+```
+
+其中 `D_mu` 是否含背景场/外场，决定后续分布与色散的具体形式。
+
+### Step 2：构造配分函数
+
+```math
+Z=\int\mathcal D\bar q\,\mathcal D q\;\exp\left[\int_0^\beta d\tau\int d^3x\;\mathcal L_E\right].
+```
+
+### Step 3：平均场近似（MFA）
+
+把高阶费米子算符线性化到序参量（凝聚）上，例如：
+
+```math
+(\bar q q)^2 \to 2\langle\bar q q\rangle(\bar q q)-\langle\bar q q\rangle^2.
+```
+
+得到“双线性夸克项 + 纯场势能项”的结构。
+
+### Step 4：执行夸克路径积分
+
+双线性费米积分给出泛函行列式：
+
+```math
+\Omega = -\frac{T}{V}\ln Z = \Omega_{field} - \frac{T}{V}\ln\det(S^{-1}).
+```
+
+### Step 5：Matsubara 求和与迹运算
+
+核心技术关系：
+
+```math
+\mathrm{Tr}\ln D = \ln\det D,
+```
+
+```math
+T\sum_n\ln\left(\frac{\omega_n^2+E^2}{T^2}\right)=E+2T\ln(1+e^{-E/T}).
+```
+
+PNJL 情况下色迹会把普通费米对数改写为含 `Phi/PhiBar` 的多项式对数核。
+
+### Step 6：组装巨热力学势
+
+最终统一结构应写成：
+
+```math
+\Omega = \Omega_{cond} + \Omega_{vac} + \Omega_{th} + \Omega_{Polyakov}(+\Omega_{vector}+\Omega_{field\,ext}).
+```
+
+其中：
+
+- `cond`：凝聚与耦合常数项
+- `vac`：真空积分（通常需截断/重整）
+- `th`：有限温密热激发
+- 其余为模型特有扩展项（矢量、磁场、旋转等）
+
+### Step 7：极值条件给出平衡态
+
+```math
+\frac{\partial\Omega}{\partial X_a}=0,
+```
+
+`X_a` 为全部独立序参量（例如 `phi_u,phi_d,phi_s,Phi,PhiBar`）。
+
+## 3. 与代码实现的映射模板
+
+建议把每个模型都映射到同一接口语义：
+
+- `omega_components(...) -> (cond, vac, thermal, polyakov, extra)`
+- `grand_potential(...)` 只做合并
+- `solve_gap(...)` / `solve_constraint(...)` 只处理极值或约束闭合
+
+这样模型差异主要体现在 `components` 的定义，不破坏主线求解器。
+
+## 4. 常见误区（迁移时必须避免）
+
+- 把“模型推导流程”与“某个旧脚本控制流”绑定在一起。
+- 真空项与热项的单位/截断口径混用。
+- 先写大量派生量接口，再补基础 `Omega`，导致语义反转。
+
+## 5. 本仓库内化约束
+
+- 内部单位优先自然单位；对外 MeV 字段显式命名（`*_MeV`）。
+- 公式文档必须能映射到现有或计划中的 `src/models/*` 路径。
+- 以“可测试最小核”作为第一实现目标，而非一次完成全部变体。


### PR DESCRIPTION
## Summary
- add model-formula docs for Gas-Liquid (RMF/Walecka) and Rotation-PNJL in a Julia_RelaxTime-native structure under `docs/reference/formula/models/`
- add a shared theory page that distills the mean-field workflow from Lagrangian to grand potential (`Omega`) as a reusable implementation contract
- introduce a local models-formula index page to connect existing NJL/PNJL lines with the new migration-target formula tracks

## Why
- support the planned phased migration (`docs first -> model core`) with documentation that is integrated with this repository’s units, naming conventions, and architecture boundaries
- avoid mechanical legacy copy by extracting only transferable equations and rewriting them into implementation-oriented constraints that map to `Models` workflows

## Validation
- `julia --project=. scripts/dev/check_docs_consistency.jl`
- `julia --project=. scripts/dev/check_active_docs_governance.jl`