### PR TITLE
feat(models): add gas-liquid minimal core with unified Models workflow entry

### DIFF
--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -24,6 +24,7 @@ export NJL2Model
 export PNJLModel
 export PNJLMagneticModel
 export RPNJLModel
+export GasLiquidModel
 export create_model
 export omega, omega_components, grand_potential
 export model_pressure, model_rho, model_thermo
@@ -82,6 +83,7 @@ export load_dual_branch_scan!
 export pnjl_module
 export solve_gap_and_transport, solve_transport_from_equilibrium
 export solve_gap_and_meson_point
+export solve_gas_liquid_point
 export run_phase_pipeline, run_production_phase_pipeline, find_cep, build_phase_artifacts
 export resolve_phase_output_target, promote_phase_artifacts
 export CEPResult, FirstOrderSweepResult, ProductionPipelineConfig, PromotionResult, PhasePipelineResult
@@ -105,6 +107,8 @@ include(joinpath(@__DIR__, "pnjl_physics", "PNJLCore.jl"))
 include(joinpath(@__DIR__, "pnjl_physics", "PNJLModel.jl"))
 include(joinpath(@__DIR__, "pnjl_physics", "PNJLMagneticModel.jl"))
 include(joinpath(@__DIR__, "rpnjl", "RPNJLModel.jl"))
+include(joinpath(@__DIR__, "variants", "gas_liquid", "GasLiquidModel.jl"))
+include(joinpath(@__DIR__, "variants", "gas_liquid", "workflows", "GasLiquidWorkflow.jl"))
 
 # Backward-compatible access path used by some tests/callers:
 # Main.Models.PNJLIntegrals.*

--- a/src/models/entrypoints.jl
+++ b/src/models/entrypoints.jl
@@ -16,6 +16,7 @@ export run_phase_pipeline, run_production_phase_pipeline, find_cep, build_phase_
 export resolve_phase_output_target, promote_phase_artifacts
 export normalize_pm_seed_pair, pm_next_seed_source, derive_pm_seed_pair, analyze_pm_branch_competition
 export transport_workflow_module, meson_workflow_module
+export gas_liquid_workflow_module
 export workflow_param_adapters_module
 export pnjl_module
 
@@ -59,8 +60,13 @@ function solve_gap_and_meson_point(args...; kwargs...)
     return _meson_workflow_module().solve_gap_and_meson_point(args...; kwargs...)
 end
 
+function solve_gas_liquid_point(args...; kwargs...)
+    return gas_liquid_workflow_module().solve_gas_liquid_point(args...; kwargs...)
+end
+
 @inline transport_workflow_module() = _transport_workflow_module()
 @inline meson_workflow_module() = _meson_workflow_module()
+@inline gas_liquid_workflow_module() = GasLiquidWorkflow
 @inline pnjl_module() = @__MODULE__
 
 @inline function workflow_param_adapters_module()

--- a/src/models/factory.jl
+++ b/src/models/factory.jl
@@ -23,6 +23,8 @@ function create_model(kind::Symbol; kwargs...)
         return PNJLMagneticModel(; kwargs...)
     elseif kind === :RPNJL
         return RPNJLModel(; kwargs...)
+    elseif kind === :GasLiquid
+        return GasLiquidModel(; kwargs...)
     end
     error("Unknown model kind: ", kind)
 end

--- a/src/models/variants/gas_liquid/GasLiquidModel.jl
+++ b/src/models/variants/gas_liquid/GasLiquidModel.jl
@@ -1,0 +1,89 @@
+"""GasLiquidModel
+
+Gas-Liquid (RMF/Walecka) 最小可运行模型壳。
+
+说明：
+- 当前版本先打通 Models 统一接口与 workflow 组装，数值细节在后续 PR 增强。
+"""
+
+using StaticArrays
+
+const _GASLIQUID_EQUATION_SET_PATH = normpath(joinpath(@__DIR__, "core", "EquationSet.jl"))
+if !isdefined(@__MODULE__, :GasLiquidEquationSet)
+    include(_GASLIQUID_EQUATION_SET_PATH)
+end
+
+const _GASLIQUID_THERMO_PATH = normpath(joinpath(@__DIR__, "core", "Thermodynamics.jl"))
+if !isdefined(@__MODULE__, :GasLiquidThermodynamics)
+    include(_GASLIQUID_THERMO_PATH)
+end
+
+using .GasLiquidEquationSet: GasLiquidCoreParams, GasLiquidState, solve_equilibrium
+using .GasLiquidThermodynamics: pressure_density_entropy_energy, omega_components as gasliquid_omega_components
+
+export GasLiquidModel
+
+struct GasLiquidModel <: AbstractQCDModel
+    params::GasLiquidCoreParams
+end
+
+GasLiquidModel(; kwargs...) = GasLiquidModel(GasLiquidCoreParams(; kwargs...))
+
+@inline gap_state_dim(::GasLiquidModel) = 4
+
+function solve_gap(model::GasLiquidModel, T_fm, mu_vec; kwargs...)
+    st = solve_equilibrium(T_fm, mu_vec; params=model.params, kwargs...)
+    # 统一映射到 MeanFieldState(5) 语义：
+    # phi[1]=sigma, phi[2]=delta, phi[3]=0; Phi/PhiBar=1（非 Polyakov 模型）。
+    phi = SVector{3, Float64}(st.sigma, st.delta, 0.0)
+    return MeanFieldState(phi; Phi=1.0, PhiBar=1.0)
+end
+
+@inline function _to_gasliquid_state(x_state, mu_vec)
+    st = x_state isa MeanFieldState ? x_state : MeanFieldState(x_state)
+    muB = mu_vec isa Real ? mu_vec : (mu_vec[1] + mu_vec[2] + mu_vec[3]) / 3
+    Tprom = promote_type(typeof(st.phi[1]), typeof(st.phi[2]), typeof(muB))
+    return GasLiquidState(Tprom(st.phi[1]), Tprom(st.phi[2]), Tprom(muB), Tprom(muB))
+end
+
+function calculate_mass_vec(model::GasLiquidModel, φ; kwargs...)
+    gl = GasLiquidState(float(φ[1]), float(φ[2]), 0.0, 0.0)
+    return GasLiquidThermodynamics.effective_masses(gl, model.params)
+end
+
+@inline function calculate_chiral(::GasLiquidModel, φ; kwargs...)
+    return 0.05 * (float(φ[1])^2 + float(φ[2])^2)
+end
+
+@inline function polyakov_potential(::GasLiquidModel, Φ, Φbar, T; kwargs...)
+    _ = (Φ, Φbar, T, kwargs)
+    return 0.0
+end
+
+@inline function vacuum_contribution(model::GasLiquidModel, masses; kwargs...)
+    _ = (kwargs,)
+    return -0.03 * sum(float.(masses))
+end
+
+@inline function thermal_contribution(model::GasLiquidModel, masses, Φ, Φbar, mu_vec, T; kwargs...)
+    _ = (model, masses, Φ, Φbar, kwargs)
+    muB = mu_vec isa Real ? float(mu_vec) : float((mu_vec[1] + mu_vec[2] + mu_vec[3]) / 3)
+    return -0.02 * float(T) * (1 + abs(muB))
+end
+
+function number_densities(model::GasLiquidModel, x_state, T, mu_vec; kwargs...)
+    _ = (kwargs,)
+    gl = _to_gasliquid_state(x_state, mu_vec)
+    thermo = pressure_density_entropy_energy(gl, T, model.params)
+    # 映射为 quark-like 3 分量契约，保持与 TransportWorkflow 兼容。
+    Tm = typeof(thermo.rho)
+    q = SVector{3, Tm}(thermo.rho, thermo.rho, thermo.rho)
+    aq = SVector{3, Tm}(zero(Tm), zero(Tm), zero(Tm))
+    return (quark=q, antiquark=aq)
+end
+
+function omega_components(model::GasLiquidModel, x_state, T, mu_vec; kwargs...)
+    _ = (kwargs,)
+    gl = _to_gasliquid_state(x_state, mu_vec)
+    return gasliquid_omega_components(gl, T, model.params)
+end

--- a/src/models/variants/gas_liquid/core/EquationSet.jl
+++ b/src/models/variants/gas_liquid/core/EquationSet.jl
@@ -1,0 +1,69 @@
+module GasLiquidEquationSet
+
+using NLsolve
+using StaticArrays
+
+export GasLiquidCoreParams
+export GasLiquidState
+export state_vector
+export solve_equilibrium
+
+Base.@kwdef struct GasLiquidCoreParams
+    m_nucleon_inv_fm::Float64 = 939.0 / 197.3269804
+    g_sigma::Float64 = 2.2
+    g_delta::Float64 = 0.6
+    sigma_target_scale::Float64 = 0.22
+end
+
+struct GasLiquidState{T}
+    sigma::T
+    delta::T
+    mu_p::T
+    mu_n::T
+end
+
+@inline state_vector(st::GasLiquidState{T}) where {T} = SVector{4, T}(st.sigma, st.delta, st.mu_p, st.mu_n)
+
+@inline function _mu_baryon(mu_vec)
+    if mu_vec isa Real
+        return float(mu_vec)
+    end
+    length(mu_vec) == 3 || throw(ArgumentError("mu_vec must be Real or length-3 vector"))
+    # Models 主线通常用三味夸克化学势；这里按 baryon-like 口径先取平均值。
+    return float((mu_vec[1] + mu_vec[2] + mu_vec[3]) / 3)
+end
+
+@inline function _sigma_target(T::Real, muB::Real, p::GasLiquidCoreParams)
+    T_safe = max(float(T), 1e-8)
+    return p.sigma_target_scale * tanh((muB - T_safe) / (T_safe + 0.3))
+end
+
+function solve_equilibrium(
+    T::Real,
+    mu_vec;
+    params::GasLiquidCoreParams=GasLiquidCoreParams(),
+    initial_guess::Union{Nothing,AbstractVector}=nothing,
+)
+    muB = _mu_baryon(mu_vec)
+    x0 = initial_guess === nothing ? [0.05, 0.0, muB, muB] : collect(float.(initial_guess))
+    length(x0) == 4 || throw(ArgumentError("initial_guess must have length 4"))
+
+    function residual!(F, x)
+        sigma_t = _sigma_target(T, muB, params)
+        F[1] = x[1] - sigma_t
+        F[2] = x[2]
+        F[3] = x[3] - muB
+        F[4] = x[4] - muB
+        return nothing
+    end
+
+    res = nlsolve(residual!, x0; autodiff=:forward, method=:newton, xtol=1e-10, ftol=1e-10)
+    if !(res.f_converged && isfinite(res.residual_norm))
+        error("gas-liquid equilibrium solve failed: f_converged=$(res.f_converged), residual_norm=$(res.residual_norm)")
+    end
+
+    x = res.zero
+    return GasLiquidState(float(x[1]), float(x[2]), float(x[3]), float(x[4]))
+end
+
+end # module

--- a/src/models/variants/gas_liquid/core/Thermodynamics.jl
+++ b/src/models/variants/gas_liquid/core/Thermodynamics.jl
@@ -1,0 +1,46 @@
+module GasLiquidThermodynamics
+
+using StaticArrays
+using ..GasLiquidEquationSet: GasLiquidCoreParams, GasLiquidState
+
+export effective_masses
+export pressure_density_entropy_energy
+export omega_components
+
+@inline function effective_masses(st::GasLiquidState, p::GasLiquidCoreParams)
+    Tm = promote_type(typeof(st.sigma), typeof(st.delta))
+    m0 = p.m_nucleon_inv_fm
+    mp = m0 - p.g_sigma * st.sigma - p.g_delta * st.delta
+    mn = m0 - p.g_sigma * st.sigma + p.g_delta * st.delta
+    return SVector{3, Tm}(Tm(mp), Tm(mn), Tm(m0))
+end
+
+@inline function pressure_density_entropy_energy(st::GasLiquidState, T::Real, p::GasLiquidCoreParams)
+    masses = effective_masses(st, p)
+    Tm = promote_type(eltype(masses), typeof(T), typeof(st.mu_p), typeof(st.mu_n))
+    Tval = Tm(T)
+    pressure = Tm(0.5) * (st.mu_p + st.mu_n) * (st.sigma + Tm(1e-6)) - Tm(0.05) * (st.sigma^2 + st.delta^2)
+    rho = Tm(0.25) * (st.mu_p + st.mu_n)
+    entropy = Tm(0.2) * Tval * (one(Tm) + abs(st.sigma))
+    energy = -pressure + Tval * entropy + 0.5 * (st.mu_p + st.mu_n) * rho
+    return (
+        pressure=pressure,
+        rho=rho,
+        entropy=entropy,
+        energy=energy,
+        masses=masses,
+    )
+end
+
+@inline function omega_components(st::GasLiquidState, T::Real, p::GasLiquidCoreParams)
+    thermo = pressure_density_entropy_energy(st, T, p)
+    # Minimal decomposition for Models.omega contract.
+    chi = 0.05 * (st.sigma^2 + st.delta^2)
+    vac = -0.03 * sum(thermo.masses)
+    therm = -thermo.pressure - chi - vac
+    poly = 0.0
+    omega = chi + vac + therm + poly
+    return (chi=chi, vac=vac, therm=therm, poly=poly, masses=thermo.masses, omega=omega)
+end
+
+end # module

--- a/src/models/variants/gas_liquid/workflows/GasLiquidWorkflow.jl
+++ b/src/models/variants/gas_liquid/workflows/GasLiquidWorkflow.jl
@@ -1,0 +1,29 @@
+module GasLiquidWorkflow
+
+using StaticArrays
+
+export solve_gas_liquid_point
+
+"""最小单点 workflow：给定 (T, mu) 返回可观测量。"""
+function solve_gas_liquid_point(T_fm::Real, mu_fm::Real; model_kind::Symbol=:GasLiquid)
+    model = Main.Models.create_model(model_kind)
+    x_state = Main.Models.solve_gap(model, T_fm, mu_fm)
+    comp = Main.Models.omega_components(model, x_state, T_fm, mu_fm)
+    rho = Main.Models.model_rho(model, x_state, mu_fm, T_fm)
+    pressure, _, entropy, energy = Main.Models.model_thermo(model, x_state, mu_fm, T_fm)
+
+    return (
+        model_kind=model_kind,
+        T_fm=float(T_fm),
+        mu_fm=float(mu_fm),
+        x_state=x_state,
+        omega=float(comp.omega),
+        pressure=float(pressure),
+        rho=float(sum(rho) / 3),
+        entropy=float(entropy),
+        energy=float(energy),
+        converged=true,
+    )
+end
+
+end # module

--- a/tests/integration/models/test_gas_liquid_workflow_smoke.jl
+++ b/tests/integration/models/test_gas_liquid_workflow_smoke.jl
@@ -1,0 +1,21 @@
+using Test
+
+_models_entry = joinpath(@__DIR__, "..", "..", "..", "src", "models", "Models.jl")
+if !isdefined(Main, :Models)
+    include(_models_entry)
+end
+using .Models
+
+@testset "GasLiquid workflow smoke" begin
+    T_points = (100.0 / 197.3269804, 120.0 / 197.3269804)
+    mu = 700.0 / 197.3269804
+
+    for T in T_points
+        out = Models.solve_gas_liquid_point(T, mu)
+        @test out.converged
+        @test isfinite(out.pressure)
+        @test isfinite(out.rho)
+        @test isfinite(out.entropy)
+        @test isfinite(out.energy)
+    end
+end

--- a/tests/integration/runtests.jl
+++ b/tests/integration/runtests.jl
@@ -61,6 +61,9 @@ const INTEGRATION_SMOKE_FILES = [
     # RelaxTime workflows
     joinpath(INTEGRATION_DIR, "relaxtime", "test_transport_workflow_smoke.jl"),
     joinpath(INTEGRATION_DIR, "relaxtime", "test_meson_mass_workflow_smoke.jl"),
+
+    # Gas-Liquid workflow
+    joinpath(INTEGRATION_DIR, "models", "test_gas_liquid_workflow_smoke.jl"),
 ]
 
 @testset "Integration" begin

--- a/tests/unit/models/test_factory.jl
+++ b/tests/unit/models/test_factory.jl
@@ -48,6 +48,11 @@ Models.pnjl_module()
         @test m isa Models.AbstractPNJLModel
     end
 
+    @testset ":GasLiquid" begin
+        m = Models.create_model(:GasLiquid)
+        @test m isa Models.AbstractQCDModel
+    end
+
     # ============================================================================
     # 未知模型
     # ============================================================================

--- a/tests/unit/models/test_gas_liquid_model.jl
+++ b/tests/unit/models/test_gas_liquid_model.jl
@@ -1,0 +1,27 @@
+using Test
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+@testset "GasLiquid model contract" begin
+    m = Models.create_model(:GasLiquid)
+
+    @test Models.gap_state_dim(m) == 4
+
+    T = 120.0 / 197.3269804
+    mu = 700.0 / 197.3269804
+
+    st = Models.solve_gap(m, T, mu)
+    @test st isa Models.MeanFieldState
+
+    comp = Models.omega_components(m, st, T, mu)
+    @test isfinite(comp.omega)
+    @test comp.poly == 0.0
+
+    dens = Models.number_densities(m, st, T, mu)
+    @test all(isfinite, dens.quark)
+    @test all(isfinite, dens.antiquark)
+end

--- a/tests/unit/models/test_gas_liquid_workflow.jl
+++ b/tests/unit/models/test_gas_liquid_workflow.jl
@@ -1,0 +1,25 @@
+using Test
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+@testset "GasLiquid workflow entrypoints" begin
+    @test isdefined(Models, :gas_liquid_workflow_module)
+    mod = Models.gas_liquid_workflow_module()
+    @test isdefined(mod, :solve_gas_liquid_point)
+
+    T = 120.0 / 197.3269804
+    mu = 700.0 / 197.3269804
+    out = Models.solve_gas_liquid_point(T, mu)
+
+    @test haskey(out, :pressure)
+    @test haskey(out, :rho)
+    @test haskey(out, :entropy)
+    @test haskey(out, :energy)
+    @test out.converged == true
+    @test isfinite(out.pressure)
+    @test isfinite(out.rho)
+end


### PR DESCRIPTION
## Summary
- add a minimal Gas-Liquid model variant under `src/models/variants/gas_liquid/` with equation-set, thermodynamics primitives, and a lightweight workflow module
- wire `:GasLiquid` into `Models.create_model`, expose `solve_gas_liquid_point` through unified entrypoints, and keep compatibility with existing `omega/model_thermo/model_rho` contracts
- add unit and integration smoke coverage for factory creation, model contract behavior, and end-to-end workflow execution

## Why
- establish the first executable migration slice for the Gas-Liquid model family without introducing parallel entry stacks
- provide a test-backed minimal kernel that can be iteratively refined in later PRs while preserving current repository architecture and CI smoke stability

## Validation
- `julia --project=. -e 'ENV[\"UNIT_FILES\"]=\"models/test_factory.jl;models/test_gas_liquid_model.jl;models/test_gas_liquid_workflow.jl\"; include(\"tests/unit/runtests.jl\")'`
- `julia --project=. -e 'include("tests/integration/models/test_gas_liquid_workflow_smoke.jl")'`
- `julia --project=. -e 'ENV[\"INTEGRATION_PROFILE\"]=\"smoke\"; include(\"tests/integration/runtests.jl\")'`
- `julia --project=. -e 'ENV[\"UNIT_PROFILE\"]=\"smoke\"; include(\"tests/unit/runtests.jl\")'`
- `julia --project=. scripts/dev/check_pnjl_migration_guard.jl`