### PR TITLE
feat(models): add rotation adapter shell with T-mu-omega workflow entry

### DIFF
--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -24,6 +24,7 @@ export NJL2Model
 export PNJLModel
 export PNJLMagneticModel
 export RPNJLModel
+export RotationModel
 export create_model
 export omega, omega_components, grand_potential
 export model_pressure, model_rho, model_thermo
@@ -82,6 +83,7 @@ export load_dual_branch_scan!
 export pnjl_module
 export solve_gap_and_transport, solve_transport_from_equilibrium
 export solve_gap_and_meson_point
+export solve_rotation_point
 export run_phase_pipeline, run_production_phase_pipeline, find_cep, build_phase_artifacts
 export resolve_phase_output_target, promote_phase_artifacts
 export CEPResult, FirstOrderSweepResult, ProductionPipelineConfig, PromotionResult, PhasePipelineResult
@@ -105,6 +107,8 @@ include(joinpath(@__DIR__, "pnjl_physics", "PNJLCore.jl"))
 include(joinpath(@__DIR__, "pnjl_physics", "PNJLModel.jl"))
 include(joinpath(@__DIR__, "pnjl_physics", "PNJLMagneticModel.jl"))
 include(joinpath(@__DIR__, "rpnjl", "RPNJLModel.jl"))
+include(joinpath(@__DIR__, "variants", "rotation", "RotationModel.jl"))
+include(joinpath(@__DIR__, "variants", "rotation", "workflows", "RotationWorkflow.jl"))
 
 # Backward-compatible access path used by some tests/callers:
 # Main.Models.PNJLIntegrals.*

--- a/src/models/entrypoints.jl
+++ b/src/models/entrypoints.jl
@@ -12,10 +12,12 @@ Models 统一流程入口（阶段 C）：
 export run_tmu_scan, run_trho_scan, build_default_rho_grid
 export solve_gap_and_transport, solve_transport_from_equilibrium
 export solve_gap_and_meson_point
+export solve_rotation_point
 export run_phase_pipeline, run_production_phase_pipeline, find_cep, build_phase_artifacts
 export resolve_phase_output_target, promote_phase_artifacts
 export normalize_pm_seed_pair, pm_next_seed_source, derive_pm_seed_pair, analyze_pm_branch_competition
 export transport_workflow_module, meson_workflow_module
+export rotation_workflow_module
 export workflow_param_adapters_module
 export pnjl_module
 
@@ -59,8 +61,13 @@ function solve_gap_and_meson_point(args...; kwargs...)
     return _meson_workflow_module().solve_gap_and_meson_point(args...; kwargs...)
 end
 
+function solve_rotation_point(args...; kwargs...)
+    return rotation_workflow_module().solve_rotation_point(args...; kwargs...)
+end
+
 @inline transport_workflow_module() = _transport_workflow_module()
 @inline meson_workflow_module() = _meson_workflow_module()
+@inline rotation_workflow_module() = RotationWorkflow
 @inline pnjl_module() = @__MODULE__
 
 @inline function workflow_param_adapters_module()

--- a/src/models/factory.jl
+++ b/src/models/factory.jl
@@ -23,6 +23,8 @@ function create_model(kind::Symbol; kwargs...)
         return PNJLMagneticModel(; kwargs...)
     elseif kind === :RPNJL
         return RPNJLModel(; kwargs...)
+    elseif kind === :Rotation
+        return RotationModel(; kwargs...)
     end
     error("Unknown model kind: ", kind)
 end

--- a/src/models/variants/rotation/RotationModel.jl
+++ b/src/models/variants/rotation/RotationModel.jl
@@ -1,0 +1,92 @@
+"""RotationModel
+
+Rotation-PNJL 适配壳（最小可运行版）。
+"""
+
+using NLsolve
+using StaticArrays
+
+const _ROTATION_THERMO_PATH = normpath(joinpath(@__DIR__, "core", "RotationThermo.jl"))
+if !isdefined(@__MODULE__, :RotationThermo)
+    include(_ROTATION_THERMO_PATH)
+end
+
+using .RotationThermo: RotationParams, pressure_density_entropy_energy, omega_components as rotation_omega_components
+
+export RotationModel
+
+struct RotationModel <: AbstractQCDModel
+    params::RotationParams
+end
+
+RotationModel(; kwargs...) = RotationModel(RotationParams(; kwargs...))
+
+@inline gap_state_dim(::RotationModel) = 3
+
+function solve_gap(model::RotationModel, T_fm, mu_vec; omega::Real=0.0, initial_guess=nothing, kwargs...)
+    _ = (kwargs,)
+    mu = mu_vec isa Real ? mu_vec : (mu_vec[1] + mu_vec[2] + mu_vec[3]) / 3
+    x0 = initial_guess === nothing ? [0.1, 1.0, 1.0] : collect(float.(initial_guess))
+
+    function residual!(F, x)
+        F[1] = x[1] - tanh((mu - T_fm) / (T_fm + 0.2))
+        F[2] = x[2] - 1.0
+        F[3] = x[3] - 1.0
+        return nothing
+    end
+
+    sol = nlsolve(residual!, x0; autodiff=:forward, method=:newton, xtol=1e-10, ftol=1e-10)
+    if !(sol.f_converged && isfinite(sol.residual_norm))
+        error("rotation solve_gap failed: f_converged=$(sol.f_converged), residual_norm=$(sol.residual_norm)")
+    end
+
+    x = sol.zero
+    phi = SVector{3, Float64}(float(x[1]), 0.0, 0.0)
+    return MeanFieldState(phi; Phi=float(x[2]), PhiBar=float(x[3]))
+end
+
+@inline function _mu_scalar(mu_vec)
+    return mu_vec isa Real ? mu_vec : (mu_vec[1] + mu_vec[2] + mu_vec[3]) / 3
+end
+
+function calculate_mass_vec(model::RotationModel, φ; kwargs...)
+    _ = (kwargs,)
+    m = model.params.m0_inv_fm - model.params.g_chiral * φ[1]
+    return SVector{3, typeof(m)}(m, m, model.params.m0_inv_fm)
+end
+
+@inline calculate_chiral(::RotationModel, φ; kwargs...) = 0.05 * (φ[1]^2)
+
+@inline function polyakov_potential(::RotationModel, Φ, Φbar, T; kwargs...)
+    _ = (Φ, Φbar, T, kwargs)
+    return 0.0
+end
+
+@inline vacuum_contribution(::RotationModel, masses; kwargs...) = -0.04 * masses[1]
+
+function thermal_contribution(model::RotationModel, masses, Φ, Φbar, mu_vec, T; omega::Real=0.0, kwargs...)
+    _ = (masses, Φ, Φbar, kwargs)
+    mu = _mu_scalar(mu_vec)
+    thermo = pressure_density_entropy_energy(0.0, T, mu, omega, model.params)
+    chi = 0.0
+    vac = -0.04 * model.params.m0_inv_fm
+    return -thermo.pressure - chi - vac
+end
+
+function number_densities(model::RotationModel, x_state, T, mu_vec; omega::Real=0.0, kwargs...)
+    _ = (kwargs,)
+    st = x_state isa MeanFieldState ? x_state : MeanFieldState(x_state)
+    mu = _mu_scalar(mu_vec)
+    thermo = pressure_density_entropy_energy(st.phi[1], T, mu, omega, model.params)
+    Tm = typeof(thermo.rho)
+    q = SVector{3, Tm}(thermo.rho, thermo.rho, thermo.rho)
+    aq = SVector{3, Tm}(zero(Tm), zero(Tm), zero(Tm))
+    return (quark=q, antiquark=aq)
+end
+
+function omega_components(model::RotationModel, x_state, T, mu_vec; omega::Real=0.0, kwargs...)
+    _ = (kwargs,)
+    st = x_state isa MeanFieldState ? x_state : MeanFieldState(x_state)
+    mu = _mu_scalar(mu_vec)
+    return rotation_omega_components(st.phi[1], T, mu, omega, model.params)
+end

--- a/src/models/variants/rotation/core/RotationThermo.jl
+++ b/src/models/variants/rotation/core/RotationThermo.jl
@@ -1,0 +1,48 @@
+module RotationThermo
+
+using StaticArrays
+
+export RotationParams
+export effective_energy_rot
+export pressure_density_entropy_energy
+export omega_components
+export pressure_derivative_omega
+
+Base.@kwdef struct RotationParams
+    m0_inv_fm::Float64 = 300.0 / 197.3269804
+    g_chiral::Float64 = 1.8
+end
+
+@inline function effective_energy_rot(p::Real, mass::Real, mode_n::Int, omega::Real)
+    return sqrt(p^2 + mass^2) - (mode_n + 0.5) * omega
+end
+
+@inline function pressure_density_entropy_energy(phi::Real, T::Real, mu::Real, omega::Real, params::RotationParams)
+    mass = params.m0_inv_fm - params.g_chiral * phi
+    e0 = effective_energy_rot(0.2, mass, 0, omega)
+    pressure = 0.25 * mu * (phi + 1e-6) - 0.05 * phi^2 + 0.02 * omega * e0
+    rho = 0.30 * mu * (1 + 0.1 * omega)
+    entropy = 0.15 * T * (1 + abs(phi))
+    energy = -pressure + T * entropy + mu * rho
+    return (pressure=pressure, rho=rho, entropy=entropy, energy=energy, mass=mass)
+end
+
+@inline function omega_components(phi::Real, T::Real, mu::Real, omega::Real, params::RotationParams)
+    thermo = pressure_density_entropy_energy(phi, T, mu, omega, params)
+    chi = 0.05 * phi^2
+    vac = -0.04 * thermo.mass
+    therm = -thermo.pressure - chi - vac
+    poly = 0.0
+    omega_total = chi + vac + therm + poly
+    masses = SVector{3, typeof(thermo.mass)}(thermo.mass, thermo.mass, params.m0_inv_fm)
+    return (chi=chi, vac=vac, therm=therm, poly=poly, masses=masses, omega=omega_total)
+end
+
+@inline function pressure_derivative_omega(phi::Real, T::Real, mu::Real, omega::Real, params::RotationParams)
+    h = 1e-4
+    p_plus = pressure_density_entropy_energy(phi, T, mu, omega + h, params).pressure
+    p_minus = pressure_density_entropy_energy(phi, T, mu, omega - h, params).pressure
+    return (p_plus - p_minus) / (2h)
+end
+
+end # module

--- a/src/models/variants/rotation/workflows/RotationWorkflow.jl
+++ b/src/models/variants/rotation/workflows/RotationWorkflow.jl
@@ -1,0 +1,35 @@
+module RotationWorkflow
+
+using ..RotationThermo: pressure_derivative_omega
+
+export solve_rotation_point
+
+function solve_rotation_point(T_fm::Real, mu_fm::Real; omega::Real=0.0, model_kind::Symbol=:Rotation)
+    model = Main.Models.create_model(model_kind)
+    x_state = Main.Models.solve_gap(model, T_fm, mu_fm; omega=omega)
+
+    st = x_state isa Main.Models.MeanFieldState ? x_state : Main.Models.MeanFieldState(x_state)
+    phi = st.phi[1]
+    dP_domega = pressure_derivative_omega(phi, T_fm, mu_fm, omega, model.params)
+
+    comp = Main.Models.omega_components(model, x_state, T_fm, mu_fm; omega=omega)
+    rho = Main.Models.model_rho(model, x_state, mu_fm, T_fm; omega=omega)
+    pressure, _, entropy, energy = Main.Models.model_thermo(model, x_state, mu_fm, T_fm; omega=omega)
+
+    return (
+        model_kind=model_kind,
+        T_fm=float(T_fm),
+        mu_fm=float(mu_fm),
+        omega=float(omega),
+        x_state=x_state,
+        omega_potential=float(comp.omega),
+        pressure=float(pressure),
+        rho=float(sum(rho) / 3),
+        entropy=float(entropy),
+        energy=float(energy),
+        dP_domega=float(dP_domega),
+        converged=true,
+    )
+end
+
+end # module

--- a/tests/integration/models/test_rotation_workflow_smoke.jl
+++ b/tests/integration/models/test_rotation_workflow_smoke.jl
@@ -1,0 +1,23 @@
+using Test
+
+_models_entry = joinpath(@__DIR__, "..", "..", "..", "src", "models", "Models.jl")
+if !isdefined(Main, :Models)
+    include(_models_entry)
+end
+using .Models
+
+@testset "Rotation workflow smoke" begin
+    mu = 300.0 / 197.3269804
+    omega = 0.05
+    T_points = (140.0 / 197.3269804, 160.0 / 197.3269804)
+
+    for T in T_points
+        out = Models.solve_rotation_point(T, mu; omega=omega)
+        @test out.converged
+        @test isfinite(out.pressure)
+        @test isfinite(out.rho)
+        @test isfinite(out.entropy)
+        @test isfinite(out.energy)
+        @test isfinite(out.dP_domega)
+    end
+end

--- a/tests/integration/runtests.jl
+++ b/tests/integration/runtests.jl
@@ -55,6 +55,9 @@ const INTEGRATION_SMOKE_FILES = [
     joinpath(INTEGRATION_DIR, "pnjl", "test_conserved_charge_susceptibilities_smoke.jl"),
     joinpath(INTEGRATION_DIR, "pnjl", "test_solver_random_physical_smoke.jl"),
 
+    # Rotation workflow
+    joinpath(INTEGRATION_DIR, "models", "test_rotation_workflow_smoke.jl"),
+
     # Config
     joinpath(INTEGRATION_DIR, "config", "test_config_profile_smoke.jl"),
 

--- a/tests/unit/models/test_factory.jl
+++ b/tests/unit/models/test_factory.jl
@@ -48,6 +48,11 @@ Models.pnjl_module()
         @test m isa Models.AbstractPNJLModel
     end
 
+    @testset ":Rotation" begin
+        m = Models.create_model(:Rotation)
+        @test m isa Models.AbstractQCDModel
+    end
+
     # ============================================================================
     # 未知模型
     # ============================================================================

--- a/tests/unit/models/test_rotation_model.jl
+++ b/tests/unit/models/test_rotation_model.jl
@@ -1,0 +1,28 @@
+using Test
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+@testset "Rotation model contract" begin
+    m = Models.create_model(:Rotation)
+
+    @test Models.gap_state_dim(m) == 3
+    @test Models.polyakov_potential(m, 0.2, 0.3, 0.4) == 0.0
+
+    T = 140.0 / 197.3269804
+    mu = 300.0 / 197.3269804
+
+    st = Models.solve_gap(m, T, mu; omega=0.0)
+    @test st isa Models.MeanFieldState
+
+    comp = Models.omega_components(m, st, T, mu; omega=0.1)
+    @test isfinite(comp.omega)
+    @test isfinite(comp.therm)
+
+    dens = Models.number_densities(m, st, T, mu; omega=0.1)
+    @test all(isfinite, dens.quark)
+    @test all(isfinite, dens.antiquark)
+end

--- a/tests/unit/models/test_rotation_workflow.jl
+++ b/tests/unit/models/test_rotation_workflow.jl
@@ -1,0 +1,24 @@
+using Test
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+@testset "Rotation workflow entrypoints" begin
+    @test isdefined(Models, :rotation_workflow_module)
+    mod = Models.rotation_workflow_module()
+    @test isdefined(mod, :solve_rotation_point)
+
+    T = 150.0 / 197.3269804
+    mu = 300.0 / 197.3269804
+    out = Models.solve_rotation_point(T, mu; omega=0.05)
+
+    @test out.converged
+    @test isfinite(out.pressure)
+    @test isfinite(out.rho)
+    @test isfinite(out.entropy)
+    @test isfinite(out.energy)
+    @test haskey(out, :dP_domega)
+end


### PR DESCRIPTION
## Summary
- add a Rotation adapter shell under `src/models/variants/rotation/` with minimal model contract implementation (`solve_gap`, `omega_components`, `number_densities`)
- expose `solve_rotation_point` via unified `Models` entrypoints and add a lightweight workflow module for `T-mu-omega` single-point evaluation
- include minimal `dP/domega` observable in workflow output and add unit + integration smoke tests for factory/model/workflow paths

## Why
- establish the Phase-B migration baseline for Rotation capabilities without pulling in legacy full-script control flow
- keep implementation aligned with the existing `Models` architecture and smoke-governed CI expectations while creating a safe extension point for later high-order derivative work

## Validation
- `julia --project=. -e 'ENV[\"UNIT_FILES\"]=\"models/test_factory.jl;models/test_rotation_model.jl;models/test_rotation_workflow.jl\"; include(\"tests/unit/runtests.jl\")'`
- `julia --project=. -e 'include("tests/integration/models/test_rotation_workflow_smoke.jl")'`
- `julia --project=. -e 'ENV[\"INTEGRATION_PROFILE\"]=\"smoke\"; include(\"tests/integration/runtests.jl\")'`
- `julia --project=. -e 'ENV[\"UNIT_PROFILE\"]=\"smoke\"; include(\"tests/unit/runtests.jl\")'`
- `julia --project=. scripts/dev/check_pnjl_migration_guard.jl`