### PR TITLE
feat(models): add switchable Polyakov potential schemes

### DIFF
--- a/config/models/pnjl/default.toml
+++ b/config/models/pnjl/default.toml
@@ -3,9 +3,13 @@ N_flavor = 3
 rho0_fm3 = 0.16
 
 [polyakov]
+scheme = "log"
 T0_MeV = 210.0
 a0 = 3.51
 a1 = -2.47
 a2 = 15.2
+a3 = 0.0
 b3 = -1.75
 b4 = 7.555
+fukushima_a_MeV = 664.0
+fukushima_b_MeV3 = 7529536.0

--- a/config/models/pnjl/unittest.toml
+++ b/config/models/pnjl/unittest.toml
@@ -2,4 +2,8 @@
 N_color = 7
 
 [polyakov]
+scheme = "log"
 T0_MeV = 333.0
+a3 = 0.0
+fukushima_a_MeV = 664.0
+fukushima_b_MeV3 = 7529536.0

--- a/config/models/rpnjl/default.toml
+++ b/config/models/rpnjl/default.toml
@@ -15,9 +15,13 @@ g2_MeV_inv8 = -5.890e-22
 kappa = 0.1
 
 # rPNJL Polyakov parameters (table 3.2).
+scheme = "log"
 T0_MeV = 175.0
 a0 = 6.75
 a1 = -9.8
 a2 = 0.26
+a3 = 0.0
 b3 = 0.805
 b4 = 7.55
+fukushima_a_MeV = 664.0
+fukushima_b_MeV3 = 7529536.0

--- a/docs/dev/active/2026-03-01_PNJL可选功能盘点与优先级任务单.md
+++ b/docs/dev/active/2026-03-01_PNJL可选功能盘点与优先级任务单.md
@@ -1,6 +1,9 @@
 # PNJL 可选功能盘点与优先级任务单
 
-更新日期：2026-03-01
+更新日期：2026-03-25
+
+当前状态：长期路线图（backlog 型文档），保留在 `docs/dev/active/` 继续滚动维护；
+本次复核不建议归档。
 
 > 目的：基于 `2026-03-01_待加入功能.md` 的讨论条目，结合当前仓库代码现状，输出“已实现/未实现”盘点与可执行的优先级任务单。
 
@@ -31,10 +34,10 @@
 
 ### 1.2 部分实现（有基础但未形成完整产品能力）
 
-- [ ] Polyakov 势“多参数化方案切换”
-  - 现状：已有对数势实现，但未见统一的多势插件式切换层（如 Poland/Fukushima 可配置切换）。
-- [ ] 相图自动化产线
-  - 现状：已有扫描与相变判据，但“CEP 自动定位+报告化产物”仍可继续产品化。
+- [x] Polyakov 势“多参数化方案切换”
+  - 现状：已落地统一可切换框架，支持 `log / poly / fukushima` 三种势参数化；通过配置 `polyakov.scheme` 切换。
+- [~] 相图自动化产线
+  - 现状：已有扫描、相变判据与生产管线雏形（含 `src/models/phase/ProductionPhasePipeline.jl`、`src/models/phase/CEPDetector.jl` 与 `scripts/pnjl/calculate_phase_structure.jl`），但“CEP 自动定位+报告化产物”仍需进一步产品化。
 - [ ] 数据输出标准化
   - 现状：已支持文本/结果目录沉淀，但 HDF5/NetCDF 等标准科学格式未系统化。
 
@@ -64,9 +67,14 @@
 
 ### 2.1 P0（近期建议）
 
-- [ ] **[P0] 建立 Polyakov 势参数化可切换框架**
+- [x] **[P0] 建立 Polyakov 势参数化可切换框架**
   - 范围：抽象势函数接口，支持至少“当前对数势 + 1 种替代势”。
   - 验收：配置文件可切换；同一输入下可复现实验对比曲线。
+  - 完成记录（2026-03-25）：
+    - 实现：`src/models/pnjl_physics/PNJLCore.jl` 引入多重派发 tag（`LogPolyakovPotential` / `PolynomialPolyakovPotential` / `FukushimaPolyakovPotential`），统一入口 `polyakov_potential`。
+    - 配置：`src/Constants_PNJL.jl` 与 `config/models/pnjl/default.toml`、`config/models/pnjl/unittest.toml`、`config/models/rpnjl/default.toml` 新增 `polyakov.scheme` 与扩展参数（`a3`、`fukushima_a_MeV`、`fukushima_b_MeV3`）。
+    - 兼容：`src/models/rpnjl/RPNJLModel.jl` 改为复用统一基势后叠加 Vandermonde `kappa` 项。
+    - 验证：`tests/unit/pnjl/test_pnjl_core.jl`、`tests/unit/models/test_rpnjl_model.jl`、`tests/unit/constants/test_constants_pnjl.jl` 本地通过。
 
 - [ ] **[P0] 相图产线标准化（扫描→判据→报告）**
   - 范围：固化脚本入口、参数模板、结果汇总模板（含 phase line/可能 CEP 标注）。
@@ -130,3 +138,9 @@
   - 对应测试（unit/smoke）
   - 文档（API + 使用示例）
   - 执行台账（命令、产物、结果）
+
+## 5. 本次复核结论（2026-03-24）
+
+- 保留 `active`：该文档属于长期规划与优先级排期，不是“完成即归档”的执行台账。
+- 状态更新：将“相图自动化产线”由未实现调整为部分实现（有主线能力但未完全产品化）。
+- 后续建议：当 P0/P1 条目形成明确实施任务单后，再拆分到独立 active 文档执行，避免本路线图过载。

--- a/scripts/plot_scan_csv.py
+++ b/scripts/plot_scan_csv.py
@@ -219,6 +219,17 @@ def _sanitize_filename(s: str) -> str:
     return s2 if s2 else "value"
 
 
+def _as_float_list(values) -> List[float]:
+    if values is None:
+        return []
+    if isinstance(values, (int, float)):
+        return [float(values)]
+    try:
+        return [float(v) for v in values]
+    except TypeError:
+        return []
+
+
 def _split_rows(rows: List[Dict[str, str]], *, split: str | None) -> List[Tuple[str, List[Dict[str, str]]]]:
     if not split:
         return [("__all__", rows)]
@@ -250,7 +261,7 @@ def plot_lines(
     line_style: str = "-",
     figsize: Tuple[float, float] | None = None,
     show_title: bool = False,
-    formats: List[str] = None,
+    formats: List[str] | None = None,
     dpi: int = 600,
     check: bool = False,
 ) -> None:
@@ -306,13 +317,13 @@ def plot_lines(
         x_values = []
         y_values = []
         for line in ax.get_lines():
-            xd = line.get_xdata()
-            yd = line.get_ydata()
-            x_values.extend([float(v) for v in xd if not math.isnan(v)])
-            y_values.extend([float(v) for v in yd if not math.isnan(v)])
+            xd = _as_float_list(line.get_xdata())
+            yd = _as_float_list(line.get_ydata())
+            x_values.extend([v for v in xd if not math.isnan(v)])
+            y_values.extend([v for v in yd if not math.isnan(v)])
 
-        _set_axis_limits_strict(ax, axis="x", values=x_values, user_lim=tuple(xlim) if xlim else None, scale=xscale)
-        _set_axis_limits_strict(ax, axis="y", values=y_values, user_lim=tuple(ylim) if ylim else None, scale=yscale)
+        _set_axis_limits_strict(ax, axis="x", values=x_values, user_lim=xlim, scale=xscale)
+        _set_axis_limits_strict(ax, axis="y", values=y_values, user_lim=ylim, scale=yscale)
         _apply_axis_alignment(ax)
 
         if show_title and title_prefix:
@@ -323,7 +334,7 @@ def plot_lines(
             plt.legend(loc=legend_loc, frameon=False)
         else:
             plt.legend(frameon=False)
-        fmts = formats or ["pdf", "png"]
+        fmts = formats or ["png"]
         y_tag = "_".join([str(s) for s in ys])
         # keep filename reasonably short but stable
         if len(y_tag) > 80:
@@ -395,13 +406,13 @@ def plot_lines(
         x_values = []
         y_values = []
         for line in ax.get_lines():
-            xd = line.get_xdata()
-            yd = line.get_ydata()
-            x_values.extend([float(v) for v in xd if not math.isnan(v)])
-            y_values.extend([float(v) for v in yd if not math.isnan(v)])
+            xd = _as_float_list(line.get_xdata())
+            yd = _as_float_list(line.get_ydata())
+            x_values.extend([v for v in xd if not math.isnan(v)])
+            y_values.extend([v for v in yd if not math.isnan(v)])
 
-        _set_axis_limits_strict(ax, axis="x", values=x_values, user_lim=tuple(xlim) if xlim else None, scale=xscale)
-        _set_axis_limits_strict(ax, axis="y", values=y_values, user_lim=tuple(ylim) if ylim else None, scale=yscale)
+        _set_axis_limits_strict(ax, axis="x", values=x_values, user_lim=xlim, scale=xscale)
+        _set_axis_limits_strict(ax, axis="y", values=y_values, user_lim=ylim, scale=yscale)
 
         _apply_axis_alignment(ax)
 
@@ -415,8 +426,8 @@ def plot_lines(
                 plt.legend(loc=legend_loc, frameon=False)
             else:
                 plt.legend(frameon=False)
-        # 保存为指定格式（优先支持矢量 PDF）
-        fmts = formats or ["pdf", "png"]
+        # 保存为指定格式（默认仅输出 PNG）
+        fmts = formats or ["png"]
         saved = []
         for fmt in fmts:
             out = out_dir / f"{y}_vs_{x}.{fmt}"
@@ -465,7 +476,7 @@ def _pick_bounds_from_ticks(ticks: List[float], lo: float, hi: float) -> Tuple[f
     return low, high
 
 
-def _set_axis_limits_strict(ax, *, axis: str, values: List[float], user_lim: Tuple[float, float] | None, scale: str | None):
+def _set_axis_limits_strict(ax, *, axis: str, values: List[float], user_lim: Tuple[float, ...] | None, scale: str | None):
     """Set axis limits according to rule:
     - If user_lim provided, use it.
     - Else compute major ticks from data range and set axis limits to first/last major tick.
@@ -554,7 +565,7 @@ def plot_heatmaps(
     cmap: str | None,
     figsize: Tuple[float, float] | None = None,
     show_title: bool = False,
-    formats: List[str] = None,
+    formats: List[str] | None = None,
     dpi: int = 600,
     check: bool = False,
 ) -> None:
@@ -620,7 +631,7 @@ def plot_heatmaps(
             grid2,
             origin="lower",
             aspect="auto",
-            extent=[x0, x1, y0, y1],
+            extent=(x0, x1, y0, y1),
             interpolation="nearest",
             cmap=cmap,
             norm=norm,
@@ -645,15 +656,15 @@ def plot_heatmaps(
             ax.set_yscale(yscale)
 
         # Apply strict axis limits based on grid coordinates xs2/ys2 unless user provided limits
-        _set_axis_limits_strict(ax, axis="x", values=xs2, user_lim=tuple(xlim) if xlim else None, scale=xscale)
-        _set_axis_limits_strict(ax, axis="y", values=ys2, user_lim=tuple(ylim) if ylim else None, scale=yscale)
+        _set_axis_limits_strict(ax, axis="x", values=xs2, user_lim=xlim, scale=xscale)
+        _set_axis_limits_strict(ax, axis="y", values=ys2, user_lim=ylim, scale=yscale)
 
         _apply_axis_alignment(ax)
         if show_title:
             title = f"{title_prefix} - {field}" if title_prefix else field
             ax.set_title(title)
 
-        fmts = formats or ["pdf", "png"]
+        fmts = formats or ["png"]
         saved = []
         for fmt in fmts:
             out = out_dir / f"heatmap_{field}_({y}_vs_{x}).{fmt}"
@@ -728,7 +739,7 @@ def configure_publication_style(*, font: str = "Times New Roman", font_size: int
         "pdf.fonttype": 42,
         "ps.fonttype": 42,
         "savefig.dpi": dpi,
-        "savefig.format": "pdf",
+        "savefig.format": "png",
         "savefig.bbox": "tight",
         "savefig.pad_inches": 0.08,
     })
@@ -835,7 +846,7 @@ def main() -> None:
     )
 
     # output formats and quality
-    ap.add_argument("--formats", type=str, default="pdf,png", help="Comma-separated output formats (e.g. pdf,png,eps)")
+    ap.add_argument("--formats", type=str, default="png", help="Comma-separated output formats (e.g. png,pdf,eps)")
     ap.add_argument("--dpi", type=int, default=600, help="Output DPI for saved figures (default 600)")
 
     args = ap.parse_args()

--- a/src/Constants_PNJL.jl
+++ b/src/Constants_PNJL.jl
@@ -23,7 +23,7 @@ using .TransportConstants: SCATTERING_MESON_MAP, SCATTERING_PROCESS_KEYS
 
 export ħc_MeV_fm, α
 export N_color, N_flavor, ρ0_inv_fm3, m_ud0_inv_fm, m_s0_inv_fm, Λ_inv_fm, G_fm2, K_fm5
-export T0_inv_fm, a0, a1, a2, b3, b4
+export T0_inv_fm, polyakov_scheme, a0, a1, a2, a3, b3, b4, fukushima_a_inv_fm, fukushima_b_inv_fm3
 export λ₀, λ₈, ψ_u, ψ_d, ψ_s, ψbar_u, ψbar_d, ψbar_s
 export PNJL_PROFILE, PNJL_CONFIG_PATH, load_pnjl_config
 export pnjl_constants
@@ -52,12 +52,16 @@ const DEFAULT_PNJL_MODEL_CONFIG = Dict{String, Any}(
         "m_s0_MeV" => 140.7,
     ),
     "polyakov" => Dict(
+        "scheme" => "log",
         "T0_MeV" => 210.0,
         "a0" => 3.51,
         "a1" => -2.47,
         "a2" => 15.2,
+        "a3" => 0.0,
         "b3" => -1.75,
         "b4" => 7.555,
+        "fukushima_a_MeV" => 664.0,
+        "fukushima_b_MeV3" => 7529536.0,
     ),
 )
 
@@ -177,12 +181,18 @@ function pnjl_constants(
 
     T0_MeV = Float64(get(polyakov_cfg, "T0_MeV", 210.0))
     T0_inv_fm = T0_MeV / hbarc_MeV_fm
+    polyakov_scheme = Symbol(lowercase(String(get(polyakov_cfg, "scheme", "log"))))
 
     a0 = Float64(get(polyakov_cfg, "a0", 3.51))
     a1 = Float64(get(polyakov_cfg, "a1", -2.47))
     a2 = Float64(get(polyakov_cfg, "a2", 15.2))
+    a3 = Float64(get(polyakov_cfg, "a3", 0.0))
     b3 = Float64(get(polyakov_cfg, "b3", -1.75))
     b4 = Float64(get(polyakov_cfg, "b4", 7.555))
+    fukushima_a_MeV = Float64(get(polyakov_cfg, "fukushima_a_MeV", 664.0))
+    fukushima_b_MeV3 = Float64(get(polyakov_cfg, "fukushima_b_MeV3", 7529536.0))
+    fukushima_a_inv_fm = fukushima_a_MeV / hbarc_MeV_fm
+    fukushima_b_inv_fm3 = fukushima_b_MeV3 / (hbarc_MeV_fm^3)
 
     if validate
         _validate_pnjl_critical_params(
@@ -215,11 +225,15 @@ function pnjl_constants(
         G_fm2=G_fm2,
         K_fm5=K_fm5,
         T0_inv_fm=T0_inv_fm,
+        polyakov_scheme=polyakov_scheme,
         a0=a0,
         a1=a1,
         a2=a2,
+        a3=a3,
         b3=b3,
         b4=b4,
+        fukushima_a_inv_fm=fukushima_a_inv_fm,
+        fukushima_b_inv_fm3=fukushima_b_inv_fm3,
     )
 end
 
@@ -247,11 +261,15 @@ const K_fm5 = Float64(model_cfg["K_over_Lambda5"]) / Λ_inv_fm^5  # NJL六夸克
 # Polyakov环有效势参数-------------------------------------
 const polyakov_cfg = PNJL_CONFIG["polyakov"]
 const T0_inv_fm = Float64(polyakov_cfg["T0_MeV"]) / ħc_MeV_fm  # Polyakov有效势参数
+const polyakov_scheme = Symbol(lowercase(String(get(polyakov_cfg, "scheme", "log"))))
 const a0 = Float64(polyakov_cfg["a0"])
 const a1 = Float64(polyakov_cfg["a1"])
 const a2 = Float64(polyakov_cfg["a2"])
+const a3 = Float64(get(polyakov_cfg, "a3", 0.0))
 const b3 = Float64(polyakov_cfg["b3"])
 const b4 = Float64(polyakov_cfg["b4"])
+const fukushima_a_inv_fm = Float64(get(polyakov_cfg, "fukushima_a_MeV", 664.0)) / ħc_MeV_fm
+const fukushima_b_inv_fm3 = Float64(get(polyakov_cfg, "fukushima_b_MeV3", 7529536.0)) / (ħc_MeV_fm^3)
 
 # Gell-Mann矩阵(SU(3)味对称性)-------------------------------------
 # λ₀: 味单位矩阵(归一化)

--- a/src/models/pnjl_physics/PNJLCore.jl
+++ b/src/models/pnjl_physics/PNJLCore.jl
@@ -25,6 +25,7 @@ export calculate_mass_vec, chiral_potential, polyakov_potential
 export vacuum_integral_with_cutoff
 export cached_nodes, calculate_log_sum
 export DEFAULT_MOMENTUM_COUNT, DEFAULT_THETA_COUNT
+export LogPolyakovPotential, PolynomialPolyakovPotential, FukushimaPolyakovPotential
 
 const _PNJL_INTEGRALS_PATH = normpath(joinpath(@__DIR__, "PNJLIntegrals.jl"))
 if !isdefined(@__MODULE__, :PNJLIntegrals)
@@ -54,11 +55,31 @@ Base.@kwdef struct PNJLParams
     K_fm5::Float64
 
     T0_inv_fm::Float64
+    polyakov_scheme::Symbol = :log
     a0::Float64
     a1::Float64
     a2::Float64
+    a3::Float64 = 0.0
     b3::Float64
     b4::Float64
+    fukushima_a_inv_fm::Float64 = 664.0 / 197.3269804
+    fukushima_b_inv_fm3::Float64 = (196.0 / 197.3269804)^3
+end
+
+abstract type AbstractPolyakovPotential end
+struct LogPolyakovPotential <: AbstractPolyakovPotential end
+struct PolynomialPolyakovPotential <: AbstractPolyakovPotential end
+struct FukushimaPolyakovPotential <: AbstractPolyakovPotential end
+
+@inline function _polyakov_tag(s::Symbol)::AbstractPolyakovPotential
+    if s === :log
+        return LogPolyakovPotential()
+    elseif s === :poly
+        return PolynomialPolyakovPotential()
+    elseif s === :fukushima
+        return FukushimaPolyakovPotential()
+    end
+    throw(ArgumentError("unknown Polyakov potential scheme: $(s); expected :log, :poly or :fukushima"))
 end
 
 function pnjl_params(constants::NamedTuple)
@@ -77,11 +98,15 @@ function pnjl_params(constants::NamedTuple)
         G_fm2=Float64(constants.G_fm2),
         K_fm5=Float64(constants.K_fm5),
         T0_inv_fm=Float64(constants.T0_inv_fm),
+        polyakov_scheme=Symbol(lowercase(String(get(constants, :polyakov_scheme, :log)))),
         a0=Float64(constants.a0),
         a1=Float64(constants.a1),
         a2=Float64(constants.a2),
+        a3=Float64(get(constants, :a3, 0.0)),
         b3=Float64(constants.b3),
         b4=Float64(constants.b4),
+        fukushima_a_inv_fm=Float64(get(constants, :fukushima_a_inv_fm, 664.0 / Float64(constants.hbarc_MeV_fm))),
+        fukushima_b_inv_fm3=Float64(get(constants, :fukushima_b_inv_fm3, (196.0 / Float64(constants.hbarc_MeV_fm))^3)),
     )
 end
 
@@ -105,11 +130,15 @@ end
         G_fm2=p.G_fm2,
         K_fm5=p.K_fm5,
         T0_inv_fm=p.T0_inv_fm,
+        polyakov_scheme=p.polyakov_scheme,
         a0=p.a0,
         a1=p.a1,
         a2=p.a2,
+        a3=p.a3,
         b3=p.b3,
         b4=p.b4,
+        fukushima_a_inv_fm=p.fukushima_a_inv_fm,
+        fukushima_b_inv_fm3=p.fukushima_b_inv_fm3,
     )
 end
 
@@ -139,12 +168,7 @@ end
     return x < min_x ? log(min_x) : log(x)
 end
 
-function polyakov_potential(p::PNJLParams, Φ, Φbar, T_fm)
-    TT = promote_type(typeof(Φ), typeof(Φbar), typeof(T_fm))
-    ΦT = convert(TT, Φ)
-    ΦbarT = convert(TT, Φbar)
-    TT_fm = convert(TT, T_fm)
-
+@inline function _polyakov_potential(::LogPolyakovPotential, p::PNJLParams, ΦT, ΦbarT, TT_fm, ::Type{TT}) where {TT}
     T0 = convert(TT, p.T0_inv_fm)
     a0 = convert(TT, p.a0)
     a1 = convert(TT, p.a1)
@@ -156,6 +180,37 @@ function polyakov_potential(p::PNJLParams, Φ, Φbar, T_fm)
     Tb = b3 * T_ratio^3
     value = 1 - 6 * ΦbarT * ΦT + 4 * (ΦbarT^3 + ΦT^3) - 3 * (ΦbarT * ΦT)^2
     return TT_fm^4 * (-0.5 * Ta * ΦbarT * ΦT + Tb * _safe_log(value))
+end
+
+@inline function _polyakov_potential(::PolynomialPolyakovPotential, p::PNJLParams, ΦT, ΦbarT, TT_fm, ::Type{TT}) where {TT}
+    T0 = convert(TT, p.T0_inv_fm)
+    a0 = convert(TT, p.a0)
+    a1 = convert(TT, p.a1)
+    a2 = convert(TT, p.a2)
+    a3 = convert(TT, p.a3)
+    b3 = convert(TT, p.b3)
+    b4 = convert(TT, p.b4)
+
+    ratio = T0 / TT_fm
+    b2 = a0 + a1 * ratio + a2 * ratio^2 + a3 * ratio^3
+    φφ = ΦbarT * ΦT
+    return TT_fm^4 * (-0.5 * b2 * φφ - (b3 / 6) * (ΦT^3 + ΦbarT^3) + 0.25 * b4 * φφ^2)
+end
+
+@inline function _polyakov_potential(::FukushimaPolyakovPotential, p::PNJLParams, ΦT, ΦbarT, TT_fm, ::Type{TT}) where {TT}
+    a = convert(TT, p.fukushima_a_inv_fm)
+    b = convert(TT, p.fukushima_b_inv_fm3)
+    φφ = ΦbarT * ΦT
+    log_arg = 1 - 6 * φφ - 3 * φφ^2 + 4 * (ΦT^3 + ΦbarT^3)
+    return TT_fm^4 * (-b * TT_fm * (54 * exp(-a / TT_fm) * φφ + _safe_log(log_arg)))
+end
+
+function polyakov_potential(p::PNJLParams, Φ, Φbar, T_fm)
+    TT = promote_type(typeof(Φ), typeof(Φbar), typeof(T_fm))
+    ΦT = convert(TT, Φ)
+    ΦbarT = convert(TT, Φbar)
+    TT_fm = convert(TT, T_fm)
+    return _polyakov_potential(_polyakov_tag(p.polyakov_scheme), p, ΦT, ΦbarT, TT_fm, TT)
 end
 
 @inline function vacuum_integral_with_cutoff(mass::T, Λ::T) where {T}

--- a/src/models/rpnjl/RPNJLModel.jl
+++ b/src/models/rpnjl/RPNJLModel.jl
@@ -249,18 +249,34 @@ end
 function polyakov_potential(model::RPNJLModel, Φ, Φbar, T_fm; kwargs...)
     model.use_extensions || return polyakov_potential(model.base, Φ, Φbar, T_fm; kwargs...)
 
-    base_value = PNJLCore.polyakov_potential(_base_params(model), Φ, Φbar, T_fm)
-    kappa = model.ext.kappa
-    kappa == 0 && return base_value
-
-    TT = promote_type(typeof(Φ), typeof(Φbar), typeof(T_fm), typeof(kappa))
+    TT = promote_type(typeof(Φ), typeof(Φbar), typeof(T_fm))
     ΦT = convert(TT, Φ)
     ΦbarT = convert(TT, Φbar)
+    TT_fm = convert(TT, T_fm)
+
+    params = _base_params(model)
+    T0 = convert(TT, Float64(params.T0_inv_fm))
+    a0 = convert(TT, Float64(params.a0))
+    a1 = convert(TT, Float64(params.a1))
+    a2 = convert(TT, Float64(params.a2))
+    b3 = convert(TT, Float64(params.b3))
+    b4 = convert(TT, Float64(params.b4))
+    kappa = convert(TT, Float64(model.ext.kappa))
+
+    t_ratio = T0 / TT_fm
+    b2 = a0 + a1 * t_ratio * exp(-a2 / t_ratio)
+
     φφ = ΦT * ΦbarT
     j_poly = 1 - 6 * φφ + 4 * (ΦT^3 + ΦbarT^3) - 3 * φφ^2
     j_pref = convert(TT, 27.0 / (24.0 * π^2))
     jac = j_pref * j_poly
-    return convert(TT, base_value) - convert(TT, kappa) * _rpnjl_safe_log(jac)
+
+    return TT_fm^4 * (
+        -0.5 * b2 * φφ
+        - (b3 / 6) * (ΦT^3 + ΦbarT^3)
+        + (b4 / 4) * φφ^2
+        - kappa * _rpnjl_safe_log(jac)
+    )
 end
 
 function vacuum_contribution(model::RPNJLModel, masses::SVector{3, T}; kwargs...) where {T}

--- a/src/models/rpnjl/RPNJLModel.jl
+++ b/src/models/rpnjl/RPNJLModel.jl
@@ -91,17 +91,38 @@ function _load_rpnjl_extension(; profile::String, hbarc_MeV_fm::Float64, log_con
 end
 
 function _apply_rpnjl_polyakov_overrides(base_params::PNJLCore.PNJLParams, extension_dict::Dict{String, Any})
-    haskey(extension_dict, "T0_MeV") || return base_params
+    has_poly_override = any(k -> haskey(extension_dict, k), (
+        "scheme",
+        "T0_MeV",
+        "a0",
+        "a1",
+        "a2",
+        "a3",
+        "b3",
+        "b4",
+        "fukushima_a_MeV",
+        "fukushima_b_MeV3",
+    ))
+    has_poly_override || return base_params
+
+    hbarc = Float64(base_params.hbarc_MeV_fm)
+    scheme = Symbol(lowercase(String(get(extension_dict, "scheme", base_params.polyakov_scheme))))
+    fukushima_a_inv_fm = Float64(get(extension_dict, "fukushima_a_MeV", Float64(base_params.fukushima_a_inv_fm) * hbarc)) / hbarc
+    fukushima_b_inv_fm3 = Float64(get(extension_dict, "fukushima_b_MeV3", Float64(base_params.fukushima_b_inv_fm3) * hbarc^3)) / hbarc^3
 
     return PNJLCore.PNJLParams(
         ;
         PNJLCore.as_namedtuple(base_params)...,
-        T0_inv_fm=Float64(extension_dict["T0_MeV"]) / Float64(base_params.hbarc_MeV_fm),
+        T0_inv_fm=Float64(get(extension_dict, "T0_MeV", Float64(base_params.T0_inv_fm) * hbarc)) / hbarc,
+        polyakov_scheme=scheme,
         a0=Float64(get(extension_dict, "a0", base_params.a0)),
         a1=Float64(get(extension_dict, "a1", base_params.a1)),
         a2=Float64(get(extension_dict, "a2", base_params.a2)),
+        a3=Float64(get(extension_dict, "a3", base_params.a3)),
         b3=Float64(get(extension_dict, "b3", base_params.b3)),
         b4=Float64(get(extension_dict, "b4", base_params.b4)),
+        fukushima_a_inv_fm=fukushima_a_inv_fm,
+        fukushima_b_inv_fm3=fukushima_b_inv_fm3,
     )
 end
 
@@ -228,34 +249,18 @@ end
 function polyakov_potential(model::RPNJLModel, Φ, Φbar, T_fm; kwargs...)
     model.use_extensions || return polyakov_potential(model.base, Φ, Φbar, T_fm; kwargs...)
 
-    TT = promote_type(typeof(Φ), typeof(Φbar), typeof(T_fm))
+    base_value = PNJLCore.polyakov_potential(_base_params(model), Φ, Φbar, T_fm)
+    kappa = model.ext.kappa
+    kappa == 0 && return base_value
+
+    TT = promote_type(typeof(Φ), typeof(Φbar), typeof(T_fm), typeof(kappa))
     ΦT = convert(TT, Φ)
     ΦbarT = convert(TT, Φbar)
-    TT_fm = convert(TT, T_fm)
-
-    params = _base_params(model)
-    T0 = convert(TT, Float64(params.T0_inv_fm))
-    a0 = convert(TT, Float64(params.a0))
-    a1 = convert(TT, Float64(params.a1))
-    a2 = convert(TT, Float64(params.a2))
-    b3 = convert(TT, Float64(params.b3))
-    b4 = convert(TT, Float64(params.b4))
-    kappa = convert(TT, Float64(model.ext.kappa))
-
-    t_ratio = T0 / TT_fm
-    b2 = a0 + a1 * t_ratio * exp(-a2 / t_ratio)
-
     φφ = ΦT * ΦbarT
     j_poly = 1 - 6 * φφ + 4 * (ΦT^3 + ΦbarT^3) - 3 * φφ^2
     j_pref = convert(TT, 27.0 / (24.0 * π^2))
     jac = j_pref * j_poly
-
-    return TT_fm^4 * (
-        -0.5 * b2 * φφ
-        - (b3 / 6) * (ΦT^3 + ΦbarT^3)
-        + (b4 / 4) * φφ^2
-        - kappa * _rpnjl_safe_log(jac)
-    )
+    return convert(TT, base_value) - convert(TT, kappa) * _rpnjl_safe_log(jac)
 end
 
 function vacuum_contribution(model::RPNJLModel, masses::SVector{3, T}; kwargs...) where {T}

--- a/tests/unit/models/test_rpnjl_model.jl
+++ b/tests/unit/models/test_rpnjl_model.jl
@@ -8,6 +8,7 @@
 
 using Test
 using StaticArrays
+using Base.MathConstants: π
 
 const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
 
@@ -73,6 +74,37 @@ Models.pnjl_module()
         μ = SVector{3}(0.0, 0.0, 0.0)
         ω = Models.omega(m, x, T, μ; p_num=24, t_num=6, xi=0.0)
         @test isfinite(ω)
+    end
+
+    @testset "polyakov_potential 默认兼容 rPNJL 旧公式" begin
+        m = Models.RPNJLModel()
+        Φ = 0.31
+        Φbar = 0.29
+        T = 0.72
+
+        p = m.base.params
+        T0 = Float64(p.T0_inv_fm)
+        a0 = Float64(p.a0)
+        a1 = Float64(p.a1)
+        a2 = Float64(p.a2)
+        b3 = Float64(p.b3)
+        b4 = Float64(p.b4)
+        kappa = Float64(m.ext.kappa)
+
+        t_ratio = T0 / T
+        b2 = a0 + a1 * t_ratio * exp(-a2 / t_ratio)
+        φφ = Φ * Φbar
+        j_poly = 1 - 6 * φφ + 4 * (Φ^3 + Φbar^3) - 3 * φφ^2
+        jac = (27.0 / (24.0 * π^2)) * j_poly
+        expected = T^4 * (
+            -0.5 * b2 * φφ
+            - (b3 / 6.0) * (Φ^3 + Φbar^3)
+            + (b4 / 4.0) * φφ^2
+            - kappa * log(max(jac, 1e-16))
+        )
+
+        actual = Models.polyakov_potential(m, Φ, Φbar, T)
+        @test isapprox(actual, expected; rtol=1e-12, atol=1e-12)
     end
 
     # --- gap_residual 可调用 ---

--- a/tests/unit/pnjl/test_pnjl_core.jl
+++ b/tests/unit/pnjl/test_pnjl_core.jl
@@ -24,6 +24,13 @@ const polyakov_potential = PNJLCore_mod.polyakov_potential
 @testset "PNJLCore" begin
     params = pnjl_params()
 
+    @testset "polyakov scheme 参数存在" begin
+        @test hasproperty(params, :polyakov_scheme)
+        @test hasproperty(params, :a3)
+        @test hasproperty(params, :fukushima_a_inv_fm)
+        @test hasproperty(params, :fukushima_b_inv_fm3)
+    end
+
     @testset "pnjl_params 默认参数有效" begin
         @test params isa Any  # PNJLParams struct
     end
@@ -48,5 +55,45 @@ const polyakov_potential = PNJLCore_mod.polyakov_potential
         Φbar = 0.2
         V_poly = polyakov_potential(params, Φ, Φbar, T_fm)
         @test isfinite(V_poly)
+    end
+
+    @testset "polyakov_potential 可切换参数化" begin
+        T_fm = 0.9
+        Φ = 0.25
+        Φbar = 0.23
+
+        base = PNJLCore_mod.as_namedtuple(params)
+
+        log_params = PNJLCore_mod.PNJLParams(; base..., polyakov_scheme=:log)
+        V_log = polyakov_potential(log_params, Φ, Φbar, T_fm)
+        @test isfinite(V_log)
+
+        poly_params = PNJLCore_mod.PNJLParams(
+            ;
+            base...,
+            polyakov_scheme=:poly,
+            a0=6.75,
+            a1=-1.95,
+            a2=2.625,
+            a3=-7.44,
+            b3=0.75,
+            b4=7.5,
+        )
+        V_poly_alt = polyakov_potential(poly_params, Φ, Φbar, T_fm)
+        @test isfinite(V_poly_alt)
+
+        hbarc = params.hbarc_MeV_fm
+        fuku_params = PNJLCore_mod.PNJLParams(
+            ;
+            base...,
+            polyakov_scheme=:fukushima,
+            fukushima_a_inv_fm=664.0 / hbarc,
+            fukushima_b_inv_fm3=(196.0 / hbarc)^3,
+        )
+        V_fuku = polyakov_potential(fuku_params, Φ, Φbar, T_fm)
+        @test isfinite(V_fuku)
+
+        bad_params = PNJLCore_mod.PNJLParams(; base..., polyakov_scheme=:unknown_scheme)
+        @test_throws ArgumentError polyakov_potential(bad_params, Φ, Φbar, T_fm)
     end
 end


### PR DESCRIPTION
## Summary
- Introduce a switchable Polyakov potential framework in PNJL core with dispatch tags for `log`, `poly`, and `fukushima`, and route selection through `polyakov.scheme` config.
- Extend PNJL/rPNJL config and constants plumbing for scheme-specific parameters (`a3`, Fukushima coefficients), and make `RPNJLModel` reuse the unified base potential before adding Vandermonde `kappa`.
- Add unit coverage for scheme switching/error handling, and include the sidecar plotting-script update so `scripts/plot_scan_csv.py` now defaults to PNG-only output (PDF requires explicit `--formats png,pdf`).

## Verification
- `julia --project=. -e 'include("tests/unit/pnjl/test_pnjl_core.jl")'`
- `julia --project=. -e 'include("tests/unit/models/test_rpnjl_model.jl")'`
- `julia --project=. -e 'include("tests/unit/constants/test_constants_pnjl.jl")'`