### PR TITLE
feat(models): standardize phase pipeline CLI reproducible workflow

### DIFF
--- a/config/models/pnjl/phase_pipeline_default.toml
+++ b/config/models/pnjl/phase_pipeline_default.toml
@@ -1,0 +1,49 @@
+[phase_pipeline]
+model_kind = "PNJL"
+mode = "production"
+profile = "default"
+
+xi = 0.0
+
+T_min = 30.0
+T_max = 350.0
+T_step = 10.0
+
+rho_min = 0.0
+rho_max = 4.0
+rho_step = 0.05
+
+solver_backend = "models"
+seed_policy = "hybrid_continuity"
+reverse_rho = true
+
+p_num = 12
+t_num = 4
+iterations = 80
+
+compute_crossover = true
+crossover_method = "peak"
+crossover_variable = "phi_u"
+crossover_n_mu = 12
+
+cep_strategy = "interpolate"
+cep_interpolate_use_direct_eval = false
+cep_tol = 0.01
+cep_max_bisect_iter = 20
+cep_area_tol_good = 1.0e-4
+cep_area_tol_bad = 5.0e-4
+cep_max_refine_level = 2
+cep_adaptive_rho = true
+cep_adaptive_slope_tol = 5.0
+cep_adaptive_min_gap = 0.002
+cep_adaptive_max_points = 32
+cep_adaptive_digits = 6
+cep_direct_bracket_mode = "directional"
+cep_direct_start = "low"
+cep_direct_initial_step = nan
+cep_direct_expand_factor = 2.0
+cep_direct_max_expand_steps = 8
+cep_direct_fallback_scan = true
+
+promote_reference = false
+verbose = false

--- a/config/models/rpnjl/phase_pipeline_default.toml
+++ b/config/models/rpnjl/phase_pipeline_default.toml
@@ -1,0 +1,49 @@
+[phase_pipeline]
+model_kind = "RPNJL"
+mode = "production"
+profile = "default"
+
+xi = 0.0
+
+T_min = 30.0
+T_max = 350.0
+T_step = 10.0
+
+rho_min = 0.0
+rho_max = 4.0
+rho_step = 0.05
+
+solver_backend = "models"
+seed_policy = "hybrid_continuity"
+reverse_rho = true
+
+p_num = 12
+t_num = 4
+iterations = 80
+
+compute_crossover = true
+crossover_method = "peak"
+crossover_variable = "phi_u"
+crossover_n_mu = 12
+
+cep_strategy = "interpolate"
+cep_interpolate_use_direct_eval = false
+cep_tol = 0.01
+cep_max_bisect_iter = 20
+cep_area_tol_good = 1.0e-4
+cep_area_tol_bad = 5.0e-4
+cep_max_refine_level = 2
+cep_adaptive_rho = true
+cep_adaptive_slope_tol = 5.0
+cep_adaptive_min_gap = 0.002
+cep_adaptive_max_points = 32
+cep_adaptive_digits = 6
+cep_direct_bracket_mode = "directional"
+cep_direct_start = "low"
+cep_direct_initial_step = nan
+cep_direct_expand_factor = 2.0
+cep_direct_max_expand_steps = 8
+cep_direct_fallback_scan = true
+
+promote_reference = false
+verbose = false

--- a/docs/dev/active/2026-03-01_PNJL可选功能盘点与优先级任务单.md
+++ b/docs/dev/active/2026-03-01_PNJL可选功能盘点与优先级任务单.md
@@ -1,6 +1,6 @@
 # PNJL 可选功能盘点与优先级任务单
 
-更新日期：2026-03-25
+更新日期：2026-03-26
 
 当前状态：长期路线图（backlog 型文档），保留在 `docs/dev/active/` 继续滚动维护；
 本次复核不建议归档。
@@ -76,9 +76,22 @@
     - 兼容：`src/models/rpnjl/RPNJLModel.jl` 改为复用统一基势后叠加 Vandermonde `kappa` 项。
     - 验证：`tests/unit/pnjl/test_pnjl_core.jl`、`tests/unit/models/test_rpnjl_model.jl`、`tests/unit/constants/test_constants_pnjl.jl` 本地通过。
 
-- [ ] **[P0] 相图产线标准化（扫描→判据→报告）**
+- [~] **[P0] 相图产线标准化（扫描→判据→报告）**
   - 范围：固化脚本入口、参数模板、结果汇总模板（含 phase line/可能 CEP 标注）。
   - 验收：一条命令产出完整相图结果目录与摘要报告。
+  - 阶段进展（2026-03-26）：
+    - [x] 1.2-A 配置驱动入口首版：`scripts/pnjl/calculate_phase_structure.jl` 支持 `--config`，并引入 `run_manifest.json`。
+    - [x] 1.2-B 默认模板自动加载：按 `model_kind` 自动读取 `config/models/<model>/phase_pipeline_default.toml`。
+    - [x] 1.2-C 轻量复现预设：支持 `--preset=smoke`，用于快速复现实验路径。
+    - [x] 1.2-D 可回放清单增强：manifest 新增 `preset` 与 `effective_config`。
+    - [x] 1.2-E 快速 smoke：新增 `tests/integration/models/test_phase_cli_smoke.jl` 并接入 `tests/integration/runtests.jl` 的 smoke 集。
+    - [x] 1.2-F 阶段验收收口：完成阶段记录、测试证据归档与后续剩余项识别。
+  - 本轮验收命令与结果（2026-03-26）：
+    - `julia --project=. -e 'include("tests/integration/models/test_phase_cli_smoke.jl")'`（通过）
+    - `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`（通过）
+    - `julia --project=. -e 'include("tests/unit/models/test_phase_pipeline.jl")'`（通过）
+  - 剩余待完成（保持 [~]）：
+    - 将 phase line / CEP 标注在报告层做更明确的“结论摘要模板化输出”（当前已有数据与诊断字段，但面向读者的摘要模板仍可继续标准化）。
 
 - [ ] **[P0] 数据输出标准化（CSV + HDF5 首版）**
   - 范围：在不破坏现有输出的前提下增加 HDF5 导出层。

--- a/docs/guides/scripts/README.md
+++ b/docs/guides/scripts/README.md
@@ -17,6 +17,32 @@
   - 守恒荷广义磁化率、累积量、`Ssigma`、`kappa_sigma2` 的统一单点/小范围扫描入口
 - [scripts/pnjl/run_tmu_scan.jl](scripts/pnjl/run_tmu_scan.jl)
   - T-μ 参数空间扫描入口
+- [scripts/pnjl/calculate_phase_structure.jl](scripts/pnjl/calculate_phase_structure.jl)
+  - 相图自动化产线入口（扫描 -> 判据 -> 报告），支持模板配置 + CLI 覆盖
+
+#### 相图最小单命令产线（PNJL）
+
+在仓库根目录执行：
+
+```powershell
+julia --project=. scripts/pnjl/calculate_phase_structure.jl --model_kind=PNJL --mode=research --T_min=150 --T_max=150 --T_step=10 --rho_min=0.1 --rho_max=0.3 --rho_step=0.1 --solver_backend=legacy --output_dir=<your_output_dir>
+```
+
+说明：
+
+- 默认会自动加载 `config/models/pnjl/phase_pipeline_default.toml`。
+- 可以使用 `--config=<path/to/phase_pipeline.toml>` 指定自定义模板。
+- CLI 显式参数优先级高于模板（同名键会覆盖）。
+
+最小产物结构（输出目录）：
+
+- `trho_scan.csv`
+- `first_order_boundary.csv`
+- `spinodal.csv`
+- `crossover_line.csv`
+- `phase_summary.json`
+- `phase_report.md`
+- `run_manifest.json`（记录 argv、config_path、config_hash、git_commit、artifact_paths）
 
 ### Server
 

--- a/docs/guides/scripts/README.md
+++ b/docs/guides/scripts/README.md
@@ -32,6 +32,7 @@ julia --project=. scripts/pnjl/calculate_phase_structure.jl --model_kind=PNJL --
 
 - 默认会自动加载 `config/models/pnjl/phase_pipeline_default.toml`。
 - 可以使用 `--config=<path/to/phase_pipeline.toml>` 指定自定义模板。
+- 可以使用 `--preset=smoke` 快速切换到轻量可复现实验参数（随后仍可用 CLI 显式参数覆盖）。
 - CLI 显式参数优先级高于模板（同名键会覆盖）。
 
 最小产物结构（输出目录）：

--- a/docs/guides/scripts/README.md
+++ b/docs/guides/scripts/README.md
@@ -45,6 +45,11 @@ julia --project=. scripts/pnjl/calculate_phase_structure.jl --model_kind=PNJL --
 - `phase_report.md`
 - `run_manifest.json`（记录 argv、config_path、config_hash、git_commit、artifact_paths）
 
+`run_manifest.json` 关键字段：
+
+- `preset`：若使用 `--preset=...`，记录最终采用的预设名。
+- `effective_config`：记录本次运行的最终有效参数快照（含被 CLI 覆盖后的值）。
+
 ### Server
 
 - [scripts/server/server_full.jl](scripts/server/server_full.jl)

--- a/scripts/pnjl/calculate_phase_structure.jl
+++ b/scripts/pnjl/calculate_phase_structure.jl
@@ -26,6 +26,7 @@ const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", ".."))
 
 Base.@kwdef mutable struct PhaseCliConfig
     config_path::Union{Nothing, String} = nothing
+    preset::Union{Nothing, Symbol} = nothing
     model_kind::Symbol = :PNJL
     mode::Symbol = :production
     xi::Float64 = 0.0
@@ -106,6 +107,25 @@ function _default_phase_config_path(model_kind::Symbol)::Union{Nothing, String}
     return isfile(path) ? path : nothing
 end
 
+function _apply_preset!(cfg::PhaseCliConfig, preset::Symbol)
+    if preset == :smoke
+        cfg.mode = :research
+        cfg.profile = :smoke
+        cfg.solver_backend = :legacy
+        cfg.T_min = 150.0
+        cfg.T_max = 150.0
+        cfg.T_step = 10.0
+        cfg.rho_min = 0.1
+        cfg.rho_max = 0.3
+        cfg.rho_step = 0.1
+        cfg.p_num = 12
+        cfg.t_num = 4
+        cfg.iterations = 10
+        return cfg
+    end
+    throw(ArgumentError("invalid --preset=$(preset); accepted values: smoke"))
+end
+
 function _apply_phase_config!(cfg::PhaseCliConfig, table::AbstractDict)
     haskey(table, "model_kind") && (cfg.model_kind = Symbol(uppercase(String(table["model_kind"]))))
     haskey(table, "mode") && (cfg.mode = Symbol(lowercase(String(table["mode"]))))
@@ -180,6 +200,7 @@ function _usage()
     println("用法: julia scripts/pnjl/calculate_phase_structure.jl [options]")
     println("选项:")
     println("  --config=...           指定 phase pipeline TOML 配置文件")
+    println("  --preset=smoke         使用内置快速复现参数模板（可被后续CLI参数覆盖）")
     println("  --model_kind=PNJL      模型类型（如 PNJL/RPNJL）")
     println("  --mode=production|research  运行模式")
     println("  --xi=0.0               各向异性参数")
@@ -229,10 +250,12 @@ function parse_args(args)
     cfg = PhaseCliConfig()
 
     explicit_config = nothing
+    preset = nothing
     for arg in args
         if startswith(arg, "--config=")
             explicit_config = arg[10:end]
-            break
+        elseif startswith(arg, "--preset=")
+            preset = Symbol(lowercase(split(arg, "="; limit=2)[2]))
         end
     end
 
@@ -248,11 +271,18 @@ function parse_args(args)
         end
     end
 
+    if preset !== nothing
+        cfg.preset = preset
+        _apply_preset!(cfg, preset)
+    end
+
     for arg in args
         if arg in ("-h", "--help")
             _usage()
             exit(0)
         elseif startswith(arg, "--config=")
+            continue
+        elseif startswith(arg, "--preset=")
             continue
         elseif startswith(arg, "--model_kind=")
             cfg.model_kind = Symbol(uppercase(arg[14:end]))

--- a/scripts/pnjl/calculate_phase_structure.jl
+++ b/scripts/pnjl/calculate_phase_structure.jl
@@ -22,6 +22,8 @@ using JSON3
 include(joinpath(@__DIR__, "..", "..", "src", "models", "Models.jl"))
 using .Models
 
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", ".."))
+
 Base.@kwdef mutable struct PhaseCliConfig
     config_path::Union{Nothing, String} = nothing
     model_kind::Symbol = :PNJL
@@ -88,6 +90,20 @@ function _phase_config_table(path::String)
     table = raw["phase_pipeline"]
     table isa AbstractDict || throw(ArgumentError("[phase_pipeline] must be a TOML table in config: $(path)"))
     return table
+end
+
+function _extract_model_kind_hint(args)::Symbol
+    for arg in args
+        startswith(arg, "--model_kind=") || continue
+        return Symbol(uppercase(arg[14:end]))
+    end
+    return :PNJL
+end
+
+function _default_phase_config_path(model_kind::Symbol)::Union{Nothing, String}
+    model_tag = lowercase(String(model_kind))
+    path = joinpath(PROJECT_ROOT, "config", "models", model_tag, "phase_pipeline_default.toml")
+    return isfile(path) ? path : nothing
 end
 
 function _apply_phase_config!(cfg::PhaseCliConfig, table::AbstractDict)
@@ -163,6 +179,7 @@ end
 function _usage()
     println("用法: julia scripts/pnjl/calculate_phase_structure.jl [options]")
     println("选项:")
+    println("  --config=...           指定 phase pipeline TOML 配置文件")
     println("  --model_kind=PNJL      模型类型（如 PNJL/RPNJL）")
     println("  --mode=production|research  运行模式")
     println("  --xi=0.0               各向异性参数")
@@ -211,11 +228,23 @@ end
 function parse_args(args)
     cfg = PhaseCliConfig()
 
+    explicit_config = nothing
     for arg in args
         if startswith(arg, "--config=")
-            cfg.config_path = arg[10:end]
-            _apply_phase_config!(cfg, _phase_config_table(cfg.config_path))
+            explicit_config = arg[10:end]
             break
+        end
+    end
+
+    if explicit_config !== nothing
+        cfg.config_path = explicit_config
+        _apply_phase_config!(cfg, _phase_config_table(cfg.config_path))
+    else
+        model_hint = _extract_model_kind_hint(args)
+        default_cfg = _default_phase_config_path(model_hint)
+        if default_cfg !== nothing
+            cfg.config_path = default_cfg
+            _apply_phase_config!(cfg, _phase_config_table(default_cfg))
         end
     end
 

--- a/scripts/pnjl/calculate_phase_structure.jl
+++ b/scripts/pnjl/calculate_phase_structure.jl
@@ -179,16 +179,39 @@ function _write_run_manifest(output_dir::String, cfg::PhaseCliConfig, args::Vect
     catch
         nothing
     end
+    effective_config = Dict(
+        "model_kind" => String(cfg.model_kind),
+        "mode" => String(cfg.mode),
+        "profile" => String(cfg.profile),
+        "xi" => cfg.xi,
+        "T_min" => cfg.T_min,
+        "T_max" => cfg.T_max,
+        "T_step" => cfg.T_step,
+        "rho_min" => cfg.rho_min,
+        "rho_max" => cfg.rho_max,
+        "rho_step" => cfg.rho_step,
+        "solver_backend" => String(cfg.solver_backend),
+        "seed_policy" => String(cfg.seed_policy),
+        "reverse_rho" => cfg.reverse_rho,
+        "p_num" => cfg.p_num,
+        "t_num" => cfg.t_num,
+        "iterations" => cfg.iterations,
+        "compute_crossover" => cfg.compute_crossover,
+        "promote_reference" => cfg.promote_reference,
+    )
+
     payload = Dict(
         "generated_at" => string(now()),
         "git_commit" => git_commit,
         "argv" => collect(String.(args)),
         "config_path" => cfg.config_path,
+        "preset" => isnothing(cfg.preset) ? nothing : String(cfg.preset),
         "config_hash" => get(result.config_snapshot, "config_hash", nothing),
         "run_id" => result.run_id,
         "mode" => String(cfg.mode),
         "model_kind" => String(cfg.model_kind),
         "artifact_paths" => result.artifact_paths,
+        "effective_config" => effective_config,
     )
     open(manifest_path, "w") do io
         write(io, JSON3.write(payload))

--- a/scripts/pnjl/calculate_phase_structure.jl
+++ b/scripts/pnjl/calculate_phase_structure.jl
@@ -16,11 +16,14 @@ using Pkg
 Pkg.activate(joinpath(@__DIR__, "..", ".."))
 
 using Dates
+using TOML
+using JSON3
 
 include(joinpath(@__DIR__, "..", "..", "src", "models", "Models.jl"))
 using .Models
 
 Base.@kwdef mutable struct PhaseCliConfig
+    config_path::Union{Nothing, String} = nothing
     model_kind::Symbol = :PNJL
     mode::Symbol = :production
     xi::Float64 = 0.0
@@ -63,6 +66,98 @@ Base.@kwdef mutable struct PhaseCliConfig
     cep_direct_fallback_scan::Bool = true
     promote_reference::Bool = false
     verbose::Bool = false
+end
+
+function _as_bool(x, name::AbstractString)
+    if x isa Bool
+        return x
+    elseif x isa Integer
+        return x != 0
+    elseif x isa AbstractString
+        token = lowercase(strip(x))
+        token in ("1", "true", "yes", "on") && return true
+        token in ("0", "false", "no", "off") && return false
+    end
+    throw(ArgumentError("invalid boolean value for $(name): $(repr(x))"))
+end
+
+function _phase_config_table(path::String)
+    isfile(path) || throw(ArgumentError("config file does not exist: $(path)"))
+    raw = TOML.parsefile(path)
+    haskey(raw, "phase_pipeline") || throw(ArgumentError("missing [phase_pipeline] section in config: $(path)"))
+    table = raw["phase_pipeline"]
+    table isa AbstractDict || throw(ArgumentError("[phase_pipeline] must be a TOML table in config: $(path)"))
+    return table
+end
+
+function _apply_phase_config!(cfg::PhaseCliConfig, table::AbstractDict)
+    haskey(table, "model_kind") && (cfg.model_kind = Symbol(uppercase(String(table["model_kind"]))))
+    haskey(table, "mode") && (cfg.mode = Symbol(lowercase(String(table["mode"]))))
+    haskey(table, "xi") && (cfg.xi = Float64(table["xi"]))
+    haskey(table, "T_min") && (cfg.T_min = Float64(table["T_min"]))
+    haskey(table, "T_max") && (cfg.T_max = Float64(table["T_max"]))
+    haskey(table, "T_step") && (cfg.T_step = Float64(table["T_step"]))
+    haskey(table, "rho_min") && (cfg.rho_min = Float64(table["rho_min"]))
+    haskey(table, "rho_max") && (cfg.rho_max = Float64(table["rho_max"]))
+    haskey(table, "rho_step") && (cfg.rho_step = Float64(table["rho_step"]))
+    haskey(table, "profile") && (cfg.profile = Symbol(lowercase(String(table["profile"]))))
+    haskey(table, "run_id") && (cfg.run_id = String(table["run_id"]))
+    haskey(table, "output_dir") && (cfg.output_dir = String(table["output_dir"]))
+    haskey(table, "solver_backend") && (cfg.solver_backend = Symbol(lowercase(String(table["solver_backend"]))))
+    haskey(table, "seed_policy") && (cfg.seed_policy = Symbol(lowercase(String(table["seed_policy"]))))
+    haskey(table, "reverse_rho") && (cfg.reverse_rho = _as_bool(table["reverse_rho"], "phase_pipeline.reverse_rho"))
+    haskey(table, "p_num") && (cfg.p_num = Int(table["p_num"]))
+    haskey(table, "t_num") && (cfg.t_num = Int(table["t_num"]))
+    haskey(table, "iterations") && (cfg.iterations = Int(table["iterations"]))
+    haskey(table, "compute_crossover") && (cfg.compute_crossover = _as_bool(table["compute_crossover"], "phase_pipeline.compute_crossover"))
+    haskey(table, "crossover_method") && (cfg.crossover_method = Symbol(lowercase(String(table["crossover_method"]))))
+    haskey(table, "crossover_variable") && (cfg.crossover_variable = Symbol(String(table["crossover_variable"])))
+    haskey(table, "crossover_n_mu") && (cfg.crossover_n_mu = Int(table["crossover_n_mu"]))
+    haskey(table, "cep_strategy") && (cfg.cep_strategy = Symbol(lowercase(String(table["cep_strategy"]))))
+    haskey(table, "cep_interpolate_use_direct_eval") && (cfg.cep_interpolate_use_direct_eval = _as_bool(table["cep_interpolate_use_direct_eval"], "phase_pipeline.cep_interpolate_use_direct_eval"))
+    haskey(table, "cep_tol") && (cfg.cep_tol = Float64(table["cep_tol"]))
+    haskey(table, "cep_max_bisect_iter") && (cfg.cep_max_bisect_iter = Int(table["cep_max_bisect_iter"]))
+    haskey(table, "cep_area_tol_good") && (cfg.cep_area_tol_good = Float64(table["cep_area_tol_good"]))
+    haskey(table, "cep_area_tol_bad") && (cfg.cep_area_tol_bad = Float64(table["cep_area_tol_bad"]))
+    haskey(table, "cep_max_refine_level") && (cfg.cep_max_refine_level = Int(table["cep_max_refine_level"]))
+    haskey(table, "cep_adaptive_rho") && (cfg.cep_adaptive_rho = _as_bool(table["cep_adaptive_rho"], "phase_pipeline.cep_adaptive_rho"))
+    haskey(table, "cep_adaptive_slope_tol") && (cfg.cep_adaptive_slope_tol = Float64(table["cep_adaptive_slope_tol"]))
+    haskey(table, "cep_adaptive_min_gap") && (cfg.cep_adaptive_min_gap = Float64(table["cep_adaptive_min_gap"]))
+    haskey(table, "cep_adaptive_max_points") && (cfg.cep_adaptive_max_points = Int(table["cep_adaptive_max_points"]))
+    haskey(table, "cep_adaptive_digits") && (cfg.cep_adaptive_digits = Int(table["cep_adaptive_digits"]))
+    haskey(table, "cep_direct_bracket_mode") && (cfg.cep_direct_bracket_mode = Symbol(lowercase(String(table["cep_direct_bracket_mode"]))))
+    haskey(table, "cep_direct_start") && (cfg.cep_direct_start = Symbol(lowercase(String(table["cep_direct_start"]))))
+    haskey(table, "cep_direct_initial_step") && (cfg.cep_direct_initial_step = Float64(table["cep_direct_initial_step"]))
+    haskey(table, "cep_direct_expand_factor") && (cfg.cep_direct_expand_factor = Float64(table["cep_direct_expand_factor"]))
+    haskey(table, "cep_direct_max_expand_steps") && (cfg.cep_direct_max_expand_steps = Int(table["cep_direct_max_expand_steps"]))
+    haskey(table, "cep_direct_fallback_scan") && (cfg.cep_direct_fallback_scan = _as_bool(table["cep_direct_fallback_scan"], "phase_pipeline.cep_direct_fallback_scan"))
+    haskey(table, "promote_reference") && (cfg.promote_reference = _as_bool(table["promote_reference"], "phase_pipeline.promote_reference"))
+    haskey(table, "verbose") && (cfg.verbose = _as_bool(table["verbose"], "phase_pipeline.verbose"))
+    return cfg
+end
+
+function _write_run_manifest(output_dir::String, cfg::PhaseCliConfig, args::Vector{String}, result)
+    manifest_path = joinpath(output_dir, "run_manifest.json")
+    git_commit = try
+        readchomp(`git -C $(joinpath(@__DIR__, "..", "..")) rev-parse HEAD`)
+    catch
+        nothing
+    end
+    payload = Dict(
+        "generated_at" => string(now()),
+        "git_commit" => git_commit,
+        "argv" => collect(String.(args)),
+        "config_path" => cfg.config_path,
+        "config_hash" => get(result.config_snapshot, "config_hash", nothing),
+        "run_id" => result.run_id,
+        "mode" => String(cfg.mode),
+        "model_kind" => String(cfg.model_kind),
+        "artifact_paths" => result.artifact_paths,
+    )
+    open(manifest_path, "w") do io
+        write(io, JSON3.write(payload))
+    end
+    return manifest_path
 end
 
 function _usage()
@@ -115,10 +210,21 @@ end
 
 function parse_args(args)
     cfg = PhaseCliConfig()
+
+    for arg in args
+        if startswith(arg, "--config=")
+            cfg.config_path = arg[10:end]
+            _apply_phase_config!(cfg, _phase_config_table(cfg.config_path))
+            break
+        end
+    end
+
     for arg in args
         if arg in ("-h", "--help")
             _usage()
             exit(0)
+        elseif startswith(arg, "--config=")
+            continue
         elseif startswith(arg, "--model_kind=")
             cfg.model_kind = Symbol(uppercase(arg[14:end]))
         elseif startswith(arg, "--mode=")
@@ -264,11 +370,15 @@ function main(args=ARGS)
         promote_reference=cfg.promote_reference,
     )
 
+    output_root = isnothing(cfg.output_dir) ? dirname(result.artifact_paths["phase_summary"]) : cfg.output_dir
+    manifest_path = _write_run_manifest(output_root, cfg, collect(String.(args)), result)
+
     println("\n完成:")
     println("  run_id = $(result.run_id)")
     println("  CEP found = $(result.cep.found)")
     println("  boundary_count = $(length(result.first_order_boundary))")
     println("  artifacts = $(result.artifact_paths)")
+    println("  manifest = $(manifest_path)")
     if cfg.promote_reference
         println("  promotion = passed=$(result.promotion_status.passed), baseline_id=$(result.promotion_status.baseline_id)")
         if !isempty(result.promotion_status.failed_checks)

--- a/tests/integration/models/test_phase_cli_direct_smoke.jl
+++ b/tests/integration/models/test_phase_cli_direct_smoke.jl
@@ -111,6 +111,26 @@ end
     @test occursin(joinpath("config", "models", "pnjl", "phase_pipeline_default.toml"), String(manifest["config_path"]))
 end
 
+@testset "Phase CLI supports --preset=smoke" begin
+    cfg = parse_args(["--preset=smoke"])
+    @test cfg.mode == :research
+    @test cfg.profile == :smoke
+    @test cfg.solver_backend == :legacy
+    @test cfg.iterations == 10
+    @test cfg.p_num == 12
+    @test cfg.t_num == 4
+end
+
+@testset "Phase CLI keeps explicit args over --preset=smoke" begin
+    cfg = parse_args([
+        "--preset=smoke",
+        "--iterations=77",
+        "--mode=production",
+    ])
+    @test cfg.iterations == 77
+    @test cfg.mode == :production
+end
+
 @testset "Phase CLI loads config file and allows CLI override" begin
     tmpdir = mktempdir()
     cfg_path = joinpath(tmpdir, "phase_cli.toml")

--- a/tests/integration/models/test_phase_cli_direct_smoke.jl
+++ b/tests/integration/models/test_phase_cli_direct_smoke.jl
@@ -188,4 +188,25 @@ end
     @test haskey(manifest, "config_hash")
     @test haskey(manifest, "run_id")
     @test haskey(manifest, "artifact_paths")
+    @test haskey(manifest, "effective_config")
+end
+
+@testset "Phase CLI manifest includes preset and effective config" begin
+    output_dir = mktempdir()
+    cmd = `$(Base.julia_cmd()) --project=$(PROJECT_ROOT) $(CLI_SCRIPT) --preset=smoke --iterations=77 --output_dir=$(output_dir)`
+    run(cmd)
+
+    manifest_path = joinpath(output_dir, "run_manifest.json")
+    @test isfile(manifest_path)
+    manifest = JSON3.read(read(manifest_path, String))
+
+    @test haskey(manifest, "preset")
+    @test String(manifest["preset"]) == "smoke"
+
+    @test haskey(manifest, "effective_config")
+    effective = manifest["effective_config"]
+    @test haskey(effective, "iterations")
+    @test Int(effective["iterations"]) == 77
+    @test haskey(effective, "profile")
+    @test String(effective["profile"]) == "smoke"
 end

--- a/tests/integration/models/test_phase_cli_direct_smoke.jl
+++ b/tests/integration/models/test_phase_cli_direct_smoke.jl
@@ -1,5 +1,6 @@
 using Test
 using JSON3
+using TOML
 
 const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
 const CLI_SCRIPT = joinpath(PROJECT_ROOT, "scripts", "pnjl", "calculate_phase_structure.jl")
@@ -82,4 +83,63 @@ end
     @test occursin("invalid --mode=invalid", output)
     @test occursin("production", output)
     @test occursin("research", output)
+end
+
+@testset "Phase CLI loads config file and allows CLI override" begin
+    tmpdir = mktempdir()
+    cfg_path = joinpath(tmpdir, "phase_cli.toml")
+    open(cfg_path, "w") do io
+        TOML.print(io, Dict(
+            "phase_pipeline" => Dict(
+                "mode" => "research",
+                "model_kind" => "RPNJL",
+                "T_min" => 140.0,
+                "T_max" => 160.0,
+                "T_step" => 5.0,
+                "rho_min" => 0.2,
+                "rho_max" => 0.8,
+                "rho_step" => 0.2,
+                "profile" => "smoke",
+                "solver_backend" => "legacy",
+                "seed_policy" => "hybrid_continuity",
+                "reverse_rho" => true,
+                "compute_crossover" => false,
+                "promote_reference" => false,
+            )
+        ))
+    end
+
+    from_cfg = parse_args(["--config=$(cfg_path)"])
+    @test from_cfg.mode == :research
+    @test from_cfg.model_kind == :RPNJL
+    @test from_cfg.T_min == 140.0
+    @test from_cfg.rho_max == 0.8
+
+    overridden = parse_args([
+        "--config=$(cfg_path)",
+        "--mode=production",
+        "--model_kind=PNJL",
+        "--T_min=150",
+        "--rho_max=0.4",
+    ])
+    @test overridden.mode == :production
+    @test overridden.model_kind == :PNJL
+    @test overridden.T_min == 150.0
+    @test overridden.rho_max == 0.4
+end
+
+@testset "Phase CLI writes run manifest" begin
+    output_dir = mktempdir()
+    cmd = `$(Base.julia_cmd()) --project=$(PROJECT_ROOT) $(CLI_SCRIPT) --model_kind=PNJL --mode=research --T_min=150 --T_max=150 --T_step=10 --rho_min=0.1 --rho_max=0.3 --rho_step=0.1 --output_dir=$(output_dir) --profile=smoke --solver_backend=legacy --iterations=10`
+    run(cmd)
+
+    manifest_path = joinpath(output_dir, "run_manifest.json")
+    @test isfile(manifest_path)
+    manifest = JSON3.read(read(manifest_path, String))
+    @test haskey(manifest, "generated_at")
+    @test haskey(manifest, "git_commit")
+    @test haskey(manifest, "argv")
+    @test haskey(manifest, "config_hash")
+    @test haskey(manifest, "run_id")
+    @test haskey(manifest, "artifact_paths")
 end

--- a/tests/integration/models/test_phase_cli_direct_smoke.jl
+++ b/tests/integration/models/test_phase_cli_direct_smoke.jl
@@ -85,6 +85,32 @@ end
     @test occursin("research", output)
 end
 
+@testset "Phase CLI auto-loads default template by model_kind" begin
+    cfg_pnjl = parse_args(String[])
+    @test cfg_pnjl.model_kind == :PNJL
+    @test cfg_pnjl.config_path !== nothing
+    @test occursin(joinpath("config", "models", "pnjl", "phase_pipeline_default.toml"), cfg_pnjl.config_path)
+    @test cfg_pnjl.compute_crossover == true
+
+    cfg_rpnjl = parse_args(["--model_kind=RPNJL"])
+    @test cfg_rpnjl.model_kind == :RPNJL
+    @test cfg_rpnjl.config_path !== nothing
+    @test occursin(joinpath("config", "models", "rpnjl", "phase_pipeline_default.toml"), cfg_rpnjl.config_path)
+    @test cfg_rpnjl.compute_crossover == true
+end
+
+@testset "Phase CLI run without --config uses default template" begin
+    output_dir = mktempdir()
+    cmd = `$(Base.julia_cmd()) --project=$(PROJECT_ROOT) $(CLI_SCRIPT) --model_kind=PNJL --mode=research --T_min=150 --T_max=150 --T_step=10 --rho_min=0.1 --rho_max=0.3 --rho_step=0.1 --output_dir=$(output_dir) --profile=smoke --solver_backend=legacy --iterations=10`
+    run(cmd)
+
+    manifest_path = joinpath(output_dir, "run_manifest.json")
+    @test isfile(manifest_path)
+    manifest = JSON3.read(read(manifest_path, String))
+    @test haskey(manifest, "config_path")
+    @test occursin(joinpath("config", "models", "pnjl", "phase_pipeline_default.toml"), String(manifest["config_path"]))
+end
+
 @testset "Phase CLI loads config file and allows CLI override" begin
     tmpdir = mktempdir()
     cfg_path = joinpath(tmpdir, "phase_cli.toml")

--- a/tests/integration/models/test_phase_cli_smoke.jl
+++ b/tests/integration/models/test_phase_cli_smoke.jl
@@ -1,0 +1,28 @@
+using Test
+using JSON3
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+const CLI_SCRIPT = joinpath(PROJECT_ROOT, "scripts", "pnjl", "calculate_phase_structure.jl")
+
+@testset "Phase CLI smoke" begin
+    @test isfile(CLI_SCRIPT)
+
+    output_dir = mktempdir()
+    cmd = `$(Base.julia_cmd()) --project=$(PROJECT_ROOT) $(CLI_SCRIPT) --preset=smoke --output_dir=$(output_dir)`
+    run(cmd)
+
+    summary_path = joinpath(output_dir, "phase_summary.json")
+    manifest_path = joinpath(output_dir, "run_manifest.json")
+
+    @test isfile(summary_path)
+    @test isfile(manifest_path)
+
+    summary = JSON3.read(read(summary_path, String))
+    manifest = JSON3.read(read(manifest_path, String))
+
+    @test haskey(summary, "cep")
+    @test haskey(summary, "stats")
+    @test haskey(manifest, "preset")
+    @test String(manifest["preset"]) == "smoke"
+    @test haskey(manifest, "effective_config")
+end

--- a/tests/integration/runtests.jl
+++ b/tests/integration/runtests.jl
@@ -49,6 +49,7 @@ const INTEGRATION_SMOKE_FILES = [
     joinpath(INTEGRATION_DIR, "models", "test_models_dispatch_interface_smoke.jl"),
     joinpath(INTEGRATION_DIR, "models", "test_models_implicitdiff_flavor_mu_smoke.jl"),
     joinpath(INTEGRATION_DIR, "models", "test_rpnjl_model_factory_smoke.jl"),
+    joinpath(INTEGRATION_DIR, "models", "test_phase_cli_smoke.jl"),
 
     # PNJL scans
     joinpath(INTEGRATION_DIR, "pnjl", "test_tmu_scan_smoke.jl"),


### PR DESCRIPTION
## Summary
- Add config-driven phase CLI workflow with default model templates and CLI override precedence to make runs reproducible and easier to operate.
- Introduce `--preset=smoke` and enrich `run_manifest.json` with `preset` plus `effective_config` snapshot for replay/auditability.
- Expand integration coverage for config loading, default template auto-load, preset behavior, override precedence, and manifest schema fields; update script guide with single-command pipeline usage.

## Test Plan
- julia --project=. -e 'include("tests/integration/models/test_phase_cli_direct_smoke.jl")'
- julia --project=. -e 'include("tests/unit/models/test_phase_pipeline.jl")'