### PR TITLE
feat(models): add structured phase report conclusions

### DIFF
--- a/docs/dev/active/2026-03-01_PNJL可选功能盘点与优先级任务单.md
+++ b/docs/dev/active/2026-03-01_PNJL可选功能盘点与优先级任务单.md
@@ -76,7 +76,7 @@
     - 兼容：`src/models/rpnjl/RPNJLModel.jl` 改为复用统一基势后叠加 Vandermonde `kappa` 项。
     - 验证：`tests/unit/pnjl/test_pnjl_core.jl`、`tests/unit/models/test_rpnjl_model.jl`、`tests/unit/constants/test_constants_pnjl.jl` 本地通过。
 
-- [~] **[P0] 相图产线标准化（扫描→判据→报告）**
+- [x] **[P0] 相图产线标准化（扫描→判据→报告）**
   - 范围：固化脚本入口、参数模板、结果汇总模板（含 phase line/可能 CEP 标注）。
   - 验收：一条命令产出完整相图结果目录与摘要报告。
   - 阶段进展（2026-03-26）：
@@ -86,12 +86,13 @@
     - [x] 1.2-D 可回放清单增强：manifest 新增 `preset` 与 `effective_config`。
     - [x] 1.2-E 快速 smoke：新增 `tests/integration/models/test_phase_cli_smoke.jl` 并接入 `tests/integration/runtests.jl` 的 smoke 集。
     - [x] 1.2-F 阶段验收收口：完成阶段记录、测试证据归档与后续剩余项识别。
+    - [x] 1.2-G 报告结论模板化：`phase_report.md` 新增 `## Conclusion`，`phase_summary.json` 新增 `conclusion` 结构化字段。
   - 本轮验收命令与结果（2026-03-26）：
     - `julia --project=. -e 'include("tests/integration/models/test_phase_cli_smoke.jl")'`（通过）
     - `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`（通过）
     - `julia --project=. -e 'include("tests/unit/models/test_phase_pipeline.jl")'`（通过）
-  - 剩余待完成（保持 [~]）：
-    - 将 phase line / CEP 标注在报告层做更明确的“结论摘要模板化输出”（当前已有数据与诊断字段，但面向读者的摘要模板仍可继续标准化）。
+    - `julia --project=. -e 'include("tests/integration/models/test_phase_pipeline_smoke.jl")'`（通过）
+  - 当前结论：该条目按既定验收标准已完成，后续增强转入新条目管理（如数据输出标准化、报告扩展）。
 
 - [ ] **[P0] 数据输出标准化（CSV + HDF5 首版）**
   - 范围：在不破坏现有输出的前提下增加 HDF5 导出层。
@@ -138,7 +139,7 @@
 
 ## 3. 执行建议（最小可行路线）
 
-- [ ] 里程碑 M1（2~3 周）：完成 P0 前两项（势切换框架 + 相图产线标准化）。
+- [x] 里程碑 M1（2~3 周）：完成 P0 前两项（势切换框架 + 相图产线标准化）。
 - [ ] 里程碑 M2（3~4 周）：完成 P0 后两项（标准化输出 + 依赖审计守护）。
 - [ ] 里程碑 M3（4~6 周）：启动 P1（有限体积 / `μI` / `G_V`）三选一做首个物理扩展。
 

--- a/src/models/phase/PhaseArtifacts.jl
+++ b/src/models/phase/PhaseArtifacts.jl
@@ -70,7 +70,27 @@ function _write_crossover_line(path::String, rows::Vector{NamedTuple})
     end
 end
 
+function _build_conclusion(result::PhasePipelineResult)
+    boundary_count = length(result.first_order_boundary)
+    crossover_count = length(result.crossover_line)
+    phase_structure = if boundary_count > 0
+        "first_order_detected"
+    elseif crossover_count > 0
+        "crossover_only"
+    else
+        "no_transition_signal"
+    end
+    cep_result = result.cep.found ? "found" : "not_found"
+    return Dict(
+        "phase_structure" => phase_structure,
+        "cep_result" => cep_result,
+        "boundary_count" => boundary_count,
+        "crossover_count" => crossover_count,
+    )
+end
+
 function _write_phase_report(path::String, result::PhasePipelineResult)
+    conclusion = _build_conclusion(result)
     open(path, "w") do io
         println(io, "# Phase Pipeline Report")
         println(io)
@@ -96,10 +116,15 @@ function _write_phase_report(path::String, result::PhasePipelineResult)
         for (k, v) in sort(collect(result.diagnostics); by=first)
             println(io, "- diag.$k: $v")
         end
+        println(io)
+        println(io, "## Conclusion")
+        println(io, "- phase_structure: $(conclusion["phase_structure"])")
+        println(io, "- cep_result: $(conclusion["cep_result"])")
     end
 end
 
 function _build_summary(result::PhasePipelineResult)
+    conclusion = _build_conclusion(result)
     scan_total = get(result.diagnostics, "scan_total", 0)
     scan_success = get(result.diagnostics, "scan_success", 0)
     scan_failure = get(result.diagnostics, "scan_failure", 0)
@@ -155,6 +180,7 @@ function _build_summary(result::PhasePipelineResult)
         ),
         "stats" => result.diagnostics,
         "stats_compare" => stats_compare,
+        "conclusion" => conclusion,
     )
 end
 

--- a/tests/integration/models/test_phase_pipeline_smoke.jl
+++ b/tests/integration/models/test_phase_pipeline_smoke.jl
@@ -1,4 +1,5 @@
 using Test
+using JSON3
 
 _models_entry = joinpath(@__DIR__, "..", "..", "..", "src", "models", "Models.jl")
 if !isdefined(Main, :Models)
@@ -64,4 +65,15 @@ end
     @test haskey(result.artifact_paths, "phase_report")
     @test isfile(result.artifact_paths["phase_summary"])
     @test isfile(result.artifact_paths["phase_report"])
+
+    report_text = read(result.artifact_paths["phase_report"], String)
+    @test occursin("## Conclusion", report_text)
+    @test occursin("- phase_structure:", report_text)
+    @test occursin("- cep_result:", report_text)
+
+    summary = JSON3.read(read(result.artifact_paths["phase_summary"], String))
+    @test haskey(summary, "conclusion")
+    conclusion = summary["conclusion"]
+    @test haskey(conclusion, "phase_structure")
+    @test haskey(conclusion, "cep_result")
 end


### PR DESCRIPTION
## Summary
- Add structured phase conclusion generation in `PhaseArtifacts` so report and summary outputs both expose clear phase/CEP conclusions.
- Extend `phase_report.md` with a dedicated `## Conclusion` section and include the same conclusion payload under `phase_summary.json.conclusion`.
- Update smoke integration assertions and active roadmap progress records to reflect completion of the phase-pipeline standardization tail item.

## Test Plan
- julia --project=. -e 'include("tests/integration/models/test_phase_pipeline_smoke.jl")'
- julia --project=. -e 'include("tests/integration/models/test_phase_cli_smoke.jl")'
- julia --project=. -e 'include("tests/unit/models/test_phase_pipeline.jl")'