### PR TITLE
feat(simulation/docs): close full-repo audit backlog and archive report

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Julia
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v2
         with:
-          version: "1.10"
+          version: "1.12.5"
 
       - name: Generate dependency graph
         run: julia --project=. scripts/dev/gen_deps.jl

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ julia --project=. scripts/dev/gen_deps.jl
 
 ## 当前功能概览
 
-- **散射运动学**：`src/simulation/MomentumMapping.jl` 提供 2→2 运动学求解、Mandelstam 变量与椭球包络，并在 `scripts/server/server_full.jl` 中通过 `/compute` 端点暴露；`tests/unit/test_momentum_mapping.jl`、`test_frame_transformations.jl` 已覆盖核心校验。
+- **散射运动学**：`src/simulation/MomentumMapping.jl` 提供 2→2 运动学求解、Mandelstam 变量与椭球包络，并在 `scripts/server/server_full.jl` 中通过 `/compute` 端点暴露；`tests/unit/simulation/test_momentum_mapping.jl`、`tests/unit/simulation/test_frame_transformations.jl` 已覆盖核心校验。
 - **散射矩阵元（当前可用）**：`src/relaxtime/ScatteringAmplitude.jl` 及依赖模块（`Polarization*`, `EffectiveCouplings`, `MesonPropagator` 等）仍是稳定入口，可提供 Σ|M|² 结果给外部积分器；相关推导见 `docs/api/relaxtime/scattering/ScatteringAmplitude.md` 与 `docs/reference/formula`。
 - **截面/弛豫时间链路（已验证可用）**：`DifferentialCrossSection.jl`, `TotalCrossSection.jl`, `RelaxationTime*.jl` 已完成当前验证集下的可用性校验；默认仍不在服务器或前端中直接暴露，研究性调用建议通过脚本与模块入口执行并保留对比记录。
 - **积分与数值工具**：`src/integration/` 提供 Cauchy 主值与 Gauss-Legendre 节点，`src/utils/` 集中常用校验、数值辅助；`QuarkDistribution*.jl` 暴露各向同性/各向异性分布函数。
@@ -62,8 +62,8 @@ julia --project=. scripts/dev/gen_deps.jl
 - **文档与流程**：`docs/guides/QUICKSTART.md`、`docs/guides/USER_GUIDE.md`、`docs/guides/STATUS.md` 说明部署/排错；`docs/dev/active/` 与 `docs/dev/archived/` 管理开发计划与归档；`docs/reference/` 存放公式与推导。
 - **数据与结果**：`data/outputs/` 用于收集服务器或批处理输出（例如 `data/outputs/results/relaxtime/` 下的扫描 CSV），便于跨语言/跨实现对比。
 	- 目录口径：默认只使用 `data/outputs/` 落盘；根目录 `outputs/` 仅保留历史兼容，不作为新流程默认路径。
-- **PNJL（求解器 + 扫描）**：`src/pnjl/` 提供 PNJL 平衡求解与扫描能力。
-	- 推荐入口：`PNJL.solve(...)` + seed 策略（`MultiSeed/PhaseAwareContinuitySeed` 等），见 `docs/api/pnjl/PNJL.md` 与 `docs/api/pnjl/SeedStrategies.md`。
+- **PNJL（求解器 + 扫描）**：主线入口已统一到 `Models`（`src/models/Models.jl` + `src/models/entrypoints.jl`）。
+	- 推荐入口：`Models.solve_gap(...)`、`Models.run_tmu_scan(...)`、`Models.run_trho_scan(...)` 与 workflow 入口（`Models.solve_gap_and_transport(...)` 等），见 `docs/api/models/` 与 `docs/api/models/workflows/`。
 	- 扫描脚本：`scripts/relaxtime/run_gap_transport_scan.jl` 可批量输出平衡量与输运相关派生量到 CSV。
 	- HTTP 端（实验性）：`scripts/server/server_full.jl` 提供 `POST /api/modules/pnjl-gap/run` 单点调用（请求体仍使用 `T_mev`/`mu_mev` 这类 MeV 输入字段；内部会换算到自然单位）。
 	- HTTP 扫描长任务（实验性）：
@@ -79,7 +79,7 @@ julia --project=. scripts/dev/gen_deps.jl
 
 ## 计算链路概览（各向异性输运）
 
-1. **能隙求解 → 序参量/有效质量**：在各向异性 PNJL 下先解能隙方程，得到序参量与三味夸克有效质量、粒子数密度（`src/pnjl/`）。
+1. **能隙求解 → 序参量/有效质量**：在各向异性 PNJL 下先解能隙方程，得到序参量与三味夸克有效质量、粒子数密度（`src/models/`）。
 2. **弛豫时间近似 (RTA)**：输运系数采用 RTA，需要弛豫时间 \(\tau\)。
 3. **弛豫时间依赖平均散射率**：\(\tau\) 由各散射过程的平均散射率 \(\Gamma\) 决定，\(\Gamma\) 需要在入射动量可行域上对散射截面加权积分。
 4. **总截面需要微分截面积分**：`TotalCrossSection.jl` 对 \(\mathrm{d}\sigma/\mathrm{d}t\) 在 \(t\) 或 \(\theta^*\) 空间积分，包含各向异性分布的阻塞因子（`quark_distribution_aniso(...,\cos\theta^*)`）。
@@ -153,7 +153,8 @@ Pkg.instantiate()
 
 2. 使用模块：
 ```julia
-include("src/relaxtime/relaxtime.jl")
+include("src/models/Models.jl")
+using .Models
 ```
 
 3. 常用入口：
@@ -243,7 +244,7 @@ pressure = Models.calculate_pressure(model, result)
 | --- | --- | --- |
 | `server*.jl`, `start.bat` | `scripts/server/` | 所有后端/启动脚本集中到单一目录，`start.bat` 会自动回到仓库根目录再拉起 `server_full.jl`。 |
 | `test_unit/` | `tests/unit/` | 原全部单元测试未改名，只调整路径；引用 `../../src/...` 即可。 |
-| `test_other/` | `tests/analysis/` | 各类性能分析、调试脚本、诊断报告集中。 |
+| `test_other/` | `scripts/analysis/` | 各类分析、调试与诊断脚本集中管理（非测试入口）。 |
 | `results/` | `data/outputs/results/` | 将运行产物与原始数据分离，方便清理或忽略。 |
 | `doc/`（公式、domain-knowledge 等） | `docs/reference/` | 文档分类更明确。 |
 | `prompt/` | `docs/dev/active/plans/` | 规范类草案与计划统一纳入开发任务区（按 active/archived 生命周期管理）。 |

--- a/docs/api/pnjl/PNJL.md
+++ b/docs/api/pnjl/PNJL.md
@@ -1,106 +1,38 @@
-# PNJL 模型 API 参考
+# PNJL 兼容层说明
 
-本文件概述仓库中已实现的 PNJL（多味道 Nambu–Jona-Lasinio + Polyakov）模型核心 API、模块与使用示例。
+本页为历史兼容层说明，不是当前主线开发入口。
 
-**单位约定**：
-- 求解器 `PNJL.solve(...)` 使用自然单位 `fm⁻¹`（`T_fm`, `μ_fm`）。
-- 扫描脚本/扫描模块通常使用 MeV（`T_MeV`, `μ_MeV`, `μB_MeV`），再通过 `ħc_MeV_fm` 换算到 `fm⁻¹`。
+## 当前主线入口
 
-**注意**：仓库已迁移到新架构（位于 `src/pnjl`）。旧版 `SeedCache/AnisoGapSolver/SinglePointSolver` 已移除或废弃；现行 API 说明以本文件及 `docs/api/models/*`、`docs/api/relaxtime/*` 主题页为准。
+仓库已统一使用 `Models` 与 `src/models/entrypoints.jl` 暴露 PNJL 相关能力：
 
-**迁移期定位（2026-02-24）**：
-- `PNJL` 模块当前定位为兼容层与历史入口聚合层。
-- 新增业务调用（尤其 `simulation/fullserver` 运行时链路）应优先通过 `Models` 统一入口（`src/models/entrypoints.jl`）。
-- 既有 `PNJL.run_*` 与求解相关接口可用于存量调用回放与灰度迁移，但不作为新功能默认入口。
+- 平衡求解：`Models.solve_gap(...)`
+- 扫描入口：`Models.run_tmu_scan(...)`、`Models.run_trho_scan(...)`
+- workflow 入口：`Models.solve_gap_and_transport(...)`、`Models.solve_gap_and_meson_point(...)`
+- 相图产线：`Models.run_phase_pipeline(...)`、`Models.find_cep(...)`
 
----
+优先阅读：
 
-## 模块概览
+- `docs/api/models/solver/README.md`
+- `docs/api/models/scans/README.md`
+- `docs/api/models/workflows/README.md`
+- `docs/api/models/phase/README.md`
 
-**模块：PNJL**
+## 兼容层定位
 
-- 位置：`src/pnjl/PNJL.jl`
-- 作用：聚合并导出以下子模块能力：
-  - `PNJL.Integrals` / `PNJL.Thermodynamics`：积分与热力学量
-  - `PNJL.ConstraintModes` / `PNJL.SeedStrategies` / `PNJL.ImplicitSolver`：求解器主链路
-  - `PNJL.ThermoDerivatives`：热力学导数/体粘滞相关导数
-  - `PNJL.TmuScan` / `PNJL.TrhoScan`：扫描与相变分析辅助
-  - `PNJL.MagneticIntegrals` / `PNJL.MagneticThermodynamics`：外磁场 PNJL（Landau 能级）
-  - `PNJL.PhaseTransition`：S 形检测、Maxwell 构造、crossover 扫描等
-  - （按需）`PNJL.DualBranchScan`：一阶相变区域双分支扫描（不进入主线默认加载/导出）
+- `docs/api/pnjl/*` 仅保留历史语义与迁移背景说明。
+- 新功能与新调用方不应以 `PNJL` 兼容层作为默认入口。
+- 若需回放历史流程，可参考兼容说明页并转译为 `Models` 等价调用。
 
-## 核心入口（新架构）
+## 单位约定
 
-### 平衡求解
+- 核心求解内部使用自然单位 `fm^-1`。
+- 面向脚本/HTTP 的参数通常使用 MeV 输入，再在入口处换算。
 
-```julia
-using PNJL
+## 迁移建议
 
-res = PNJL.solve(PNJL.FixedMu(), T_fm, μ_fm; xi=0.0)
-res = PNJL.solve(PNJL.FixedMu(), T_fm, μ_fm; xi=0.0, seed_strategy=PNJL.MultiSeed())
-```
+若你仍在使用旧调用风格，建议按以下顺序迁移：
 
-更多求解器细节见：
-- `docs/api/models/solver/ImplicitSolvers.md`
-- `docs/api/models/solver/SeedStrategies.md`
-- 涨落 AD 接入路径（含隐式求导边界）：`docs/api/models/solver/CoreConcepts.md`
-- 扫描采样模板与禁用区间：`docs/api/models/scans/SamplingGrid.md`
-
-### 扫描
-
-- `PNJL.run_tmu_scan`：T-μ 网格扫描（见 `docs/api/models/scans/TmuScan.md`）
-- `PNJL.run_trho_scan`：T-ρ 网格扫描（见 `docs/api/models/scans/TrhoScan.md`）
-- 统一输出契约：`docs/api/models/scans/Overview.md`
-- （按需）一阶相变区域双分支扫描：先调用 `PNJL.load_dual_branch_scan!()`，再使用 `PNJL.DualBranchScan.*`（见 `docs/api/pnjl/DualBranchScan.md`）
-
-### 外磁场 PNJL
-
-- 主题入口：`docs/api/models/variants/magnetic/README.md`
-- 参数与配置：`docs/api/models/variants/magnetic/ModelAndConfig.md`
-
----
-
-**种子表（CSV）格式与生成**
-- 默认路径：`data/raw/pnjl/seeds/sobol_seed_table.csv`（常量 `PNJL.SeedCache.DEFAULT_SEED_PATH` 指向该位置）。
-- 列（CSV header）：
-  - `T_MeV, mu_MeV, rho, xi, phi_u, phi_d, phi_s, Phi1, Phi2, mu_u_MeV, mu_d_MeV, mu_s_MeV`
-- 生成脚本：`scripts/pnjl/generate_seed_table.jl`
-  - 使用 LHS/Sobol（实现为 Latin Hypercube）在给定参数区间采样，调用 `AnisoGapSolver.solve_fixed_mu` 逐点求解并输出成功的收敛解到 CSV。
-  - 可配置参数（样本数、T/mu/xi 区间、积分节点数等），示例运行：
-
-```pwsh
-julia --project scripts/pnjl/generate_seed_table.jl --samples=200 --output=data/raw/pnjl/seeds/sobol_seed_table.csv
-```
-
-**种子查找微基准**
-- 脚本 `scripts/pnjl/benchmark_seed_lookup.jl` 对 `find_initial_seed` 的热路径（KD-tree 查询、邻居融合）做了 `BenchmarkTools.@btime` 微基准。典型热路径延迟约为几十至百微秒（取决于 k）。
-
----
-
-## 使用示例
-
-```julia
-using PNJL
-
-T_fm = 150.0 / PNJL.ħc_MeV_fm
-μ_fm = 0.0
-xi = 0.0
-
-res = PNJL.solve(PNJL.FixedMu(), T_fm, μ_fm; xi=xi, seed_strategy=PNJL.MultiSeed())
-@show res.converged res.omega res.masses
-```
-
----
-
-## 注意事项
-
-- 若你发现某些点“收敛但落在高 Ω 的非物理/亚稳态分支”，优先用 `MultiSeed()` 或在扫描中使用 `PhaseAwareContinuitySeed(...; bootstrap_multiseed=true)`。
-- 一阶相变区域更适合使用 `DualBranchScan` 做物理分析（两分支显式比较 Ω），而不是只靠单分支连续性。
-
----
-
-若希望把此文档自动生成成网站页面或把函数签名与注释同步为更详细的 API 文档，我可以：
-- 将此文件转为 docs 网站页（例如 MkDocs/Documenter.jl 格式）。
-- 提取并补充每个导出函数的参数类型注释与更丰富的示例（包含 `nlsolve_kwargs` 常用配置示例）。
-
-请告诉我下一步想要的格式或更详细内容（例如增加 `Trho` 种子生成说明、示例输入/输出 JSON 模板或把文档集成到 README）。
+1. 将入口 include/using 切换到 `src/models/Models.jl`。
+2. 将扫描与 workflow 调用改为 `Models.run_*` / `Models.solve_*`。
+3. 对照 `docs/api/models/*` 完成参数与返回结构的口径对齐。

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -93,7 +93,7 @@ julia --project=. scripts/dev/archive_docs.jl <filename.md>
 - 必须：更新或新增 API 文档（docs/api/）
 - 可选：更新或新增公式文档（docs/reference/formula/）
 - 必须：补充单元测试（tests/unit/），或在归档说明中写明原因
-- 可选：补充性能测试或分析（tests/perf/ 或 tests/analysis/）
+- 可选：补充性能测试或分析（benchmark/ 或 scripts/perf/ 或 scripts/analysis/）
 
 ## 项目结构约定（合并版）
 
@@ -103,7 +103,11 @@ julia --project=. scripts/dev/archive_docs.jl <filename.md>
 - scripts/：可执行脚本、批处理与实验入口。
 - tests/：测试与诊断。
 	- tests/unit/：可自动化的单元测试。
-	- tests/analysis/：分析/性能/调试脚本与报告。
+	- tests/integration/：跨模块集成测试。
+	- tests/regression/：数值回归测试。
+	- tests/validation/：外部参考验证测试。
+- scripts/analysis/：分析/诊断脚本与报告（非测试入口）。
+- scripts/perf/：性能探针与 profiling 脚本（非测试入口）。
 - docs/：文档中心。
 	- docs/api/：面向使用者的 API 文档。
 	- docs/dev/：开发者文档。
@@ -123,7 +127,7 @@ julia --project=. scripts/dev/archive_docs.jl <filename.md>
 - 以模块边界组织，而不是以功能碎片随意拆文件。
 - 新增模块前先确认：是通用逻辑还是一次性实验。
 	- 通用逻辑 → src/
-	- 实验/临时对比 → scripts/ 或 tests/analysis/
+	- 实验/临时对比 → scripts/ 或 scripts/analysis/
 
 ### 单位与命名
 

--- a/docs/dev/active/2026-03-28_全仓10维度体检结果报告.md
+++ b/docs/dev/active/2026-03-28_全仓10维度体检结果报告.md
@@ -162,7 +162,19 @@ owner: opencode-agent
 - [x] P1：修正文档旧路径残留（首批）。
   - 变更：`docs/dev/README.md`、`docs/guides/PARAMETER_STRUCT_MIGRATION.md`、`docs/guides/error_handling.md`
 
+- [x] P1：修正 `configuration.md` 中旧配置路径口径（`config/models/*`、`config/physics/*`、`config/workflows/*`）。
+  - 变更：`docs/guides/configuration.md`
+
+- [x] P1/P2：`pnjl_scan_jobs` 错误契约补齐 `error_code`，并引入 finished job TTL 老化清理策略。
+  - 变更：`src/simulation/fullserver/pnjl_scan_jobs.jl`
+  - 测试：`tests/unit/simulation/test_pnjl_scan_jobs.jl`
+
 ### 待完成
 
 - [x] P2：统一 CI workflow Julia 版本策略（dependency-audit 已与主线统一为 1.12.5）。
   - 变更：`.github/workflows/dependency-audit.yml`
+
+### 验证记录
+
+- `julia --project=. -e 'ENV["UNIT_FILES"]="simulation/test_pnjl_scan_jobs.jl;simulation/test_fullserver_compute_handlers.jl"; include("tests/unit/runtests.jl")'` 通过。
+- `julia --project=. scripts/dev/check_docs_consistency.jl` 通过。

--- a/docs/dev/active/2026-03-28_全仓10维度体检结果报告.md
+++ b/docs/dev/active/2026-03-28_全仓10维度体检结果报告.md
@@ -1,0 +1,167 @@
+---
+title: 全仓10维度体检结果报告（2026-03-28）
+status: active
+created: 2026-03-28
+owner: opencode-agent
+---
+
+# 全仓10维度体检结果报告（2026-03-28）
+
+## 1. 背景与目的
+
+本报告仿照 `docs/dev/archived/2026-03-27_src体检结果报告_10维度.md` 的十维框架，
+将审查范围从 `src/` 扩展到全仓：`src/`、`tests/`、`scripts/`、`docs/`、`config/`、`.github/workflows/`、`benchmark/`。
+
+另行核查对外说明（尤其 `README.md` 与 `docs/guides/*`）是否与当前主线实现一致。
+
+## 2. 评估范围与证据口径
+
+- 代码与运行链路：`src/models/*`、`src/simulation/*`、`scripts/server/*`。
+- 测试分层与入口：`tests/unit|integration|regression|validation`。
+- 配置与复现：`config/models/*`、`config/physics/*`、`src/config/ConfigLoader.jl`。
+- 工程治理：`.github/workflows/*.yml`、`scripts/dev/*`、`docs/dev/*`。
+- 对外文档：`README.md`、`INSTALL.md`、`docs/guides/*`、`docs/api/*`。
+
+## 3. 总览结论
+
+- 主线架构已完成从旧 `PNJL` 路径向 `Models + src/models/entrypoints.jl` 的收敛，测试与 CI 分层总体完整。
+- 全仓最高优先风险来自对外错误信息暴露（P0），其次是文档主入口口径与现状不一致（P1）。
+- 代码行为与治理脚本整体可用，但文档中仍有多处历史路径残留，会持续放大协作与交付认知偏差。
+
+## 4. 十维体检结果
+
+### 4.1 正确性与数值稳健性
+
+- 现状：核心计算主链保持显式输入校验与测试护栏；扫描 job 对 `xi` 策略、重试上限、网格规模有边界约束。
+- 风险：错误回传策略在个别接口上将内部异常细节外泄，可能干扰“可控失败”语义。
+- 证据：`src/simulation/fullserver/pnjl_scan_jobs.jl:98`、`src/simulation/fullserver/pnjl_scan_jobs.jl:450`、`src/simulation/fullserver/compute_handlers.jl:69`。
+- 优先级：P1。
+- 建议：统一 API 异常分层（参数错误 vs 运行失败），对客户端仅暴露错误码与摘要。
+
+### 4.2 API 与语义一致性
+
+- 现状：代码主入口已以 `Models` 为统一面，`entrypoints.jl` 显式导出扫描、workflow、phase 入口。
+- 风险：README 与部分 API 文档仍把 `src/pnjl` / `using PNJL` 表述为主入口，形成“代码主线 vs 文档口径”分叉。
+- 证据：`src/models/entrypoints.jl:1`、`README.md:65`、`README.md:66`、`docs/api/pnjl/PNJL.md:22`。
+- 优先级：P1。
+- 建议：对外文档统一声明“主入口=Models；PNJL页仅兼容历史说明”。
+
+### 4.3 架构与模块边界
+
+- 现状：`Models.jl` 聚合导出+`entrypoints.jl` 流程入口模式已成型；`src/pnjl/**` 已从主线实现中移除。
+- 风险：文档仍有“旧架构存在”暗示，降低边界清晰度并增加新成员上手成本。
+- 证据：`src/models/Models.jl:16`、`src/models/entrypoints.jl:12`、`glob src/pnjl/** -> No files found`。
+- 优先级：P1。
+- 建议：在 `docs/api/README.md` 与 `README.md` 中建立单一主导航，不再并列旧入口。
+
+### 4.4 可测试性与验证完备度
+
+- 现状：四层测试入口（unit/integration/regression/validation）与 smoke/full 策略齐全，`pnjl_scan_jobs` 已有单测。
+- 风险：文档层仍有已废弃测试目录引用，影响“测试放置规则”可执行性。
+- 证据：`tests/unit/simulation/test_pnjl_scan_jobs.jl:1`、`tests/unit/runtests.jl:30`、`tests/integration/runtests.jl:46`、`docs/dev/README.md:96`。
+- 优先级：P1。
+- 建议：同步修正文档中的 `tests/analysis`、`tests/perf` 历史描述为 `scripts/analysis`、`benchmark` / `scripts/perf`。
+
+### 4.5 可维护性与可读性
+
+- 现状：模块职责较清晰，workflow/phase/scans 有明确文件分区。
+- 风险：部分说明文档（如 configuration/error_handling）含大量历史示例与过时路径，读者难区分“范式示例”与“现行实现”。
+- 证据：`docs/guides/configuration.md:63`、`docs/guides/configuration.md:80`、`docs/guides/error_handling.md:230`。
+- 优先级：P2。
+- 建议：为“示例代码”加显式标签（概念示例/非当前路径），并追加现行路径对照块。
+
+### 4.6 配置治理与可复现性
+
+- 现状：配置目录结构完整（models/physics/workflows/ci），`ConfigLoader` 具备内容哈希缓存与 deep-merge。
+- 风险：文档中仍存在旧目录写法（如 `config/{model}/default.toml`）与当前 `config/models/<model>/...` 不一致。
+- 证据：`config/models/pnjl/default.toml:1`、`config/physics/default.toml`、`src/config/ConfigLoader.jl:138`、`docs/guides/configuration.md:63`。
+- 优先级：P1。
+- 建议：先修 `configuration.md` 的路径基线，再补一个“当前生效 profile 清单”小节。
+
+### 4.7 并发与状态安全
+
+- 现状：scan jobs 全局状态含锁与 semaphore 限流，并实现 finished job 数量裁剪。
+- 风险：清理策略为“完成态保留上限”，尚无 TTL/老化策略；长时运行下需持续观察内存曲线。
+- 证据：`src/simulation/fullserver/pnjl_scan_jobs.jl:4`、`src/simulation/fullserver/pnjl_scan_jobs.jl:12`、`src/simulation/fullserver/pnjl_scan_jobs.jl:172`。
+- 优先级：P2。
+- 建议：补充可选 TTL 参数与状态观测指标（删除计数、常驻作业数）。
+
+### 4.8 观测性与诊断能力
+
+- 现状：scan 接口返回 `diagnostics`、`policy`、`queue`；配置与服务有基础日志。
+- 风险：不同接口错误结构不统一（有的含 `error_code`，有的直接字符串+堆栈），不利于前端和自动化消费。
+- 证据：`src/simulation/fullserver/pnjl_handlers.jl:17`、`src/simulation/fullserver/pnjl_scan_jobs.jl:484`、`src/simulation/fullserver/compute_handlers.jl:72`。
+- 优先级：P1。
+- 建议：定义最小统一错误契约：`status/error_code/error/message_id` + 可选 `diagnostics`。
+
+### 4.9 工程治理与交付质量
+
+- 现状：存在 docs consistency、active docs governance、path guard、unit/integration/validation 多条 CI 门禁。
+- 风险：依赖审计 workflow 仍使用 Julia 1.10，与主 CI 1.12.5 存在版本口径偏差。
+- 证据：`.github/workflows/docs-consistency.yml:29`、`.github/workflows/unit-smoke.yml:35`、`.github/workflows/dependency-audit.yml:25`。
+- 优先级：P2。
+- 建议：统一 workflow Julia 版本策略，减少跨版本行为差异。
+
+### 4.10 安全与健壮性
+
+- 现状：`pnjl_scan_jobs` 已实现输出路径白名单（限制在 `data/outputs` 子树）。
+- 风险（P0）：`/compute` 失败时直接返回包含 backtrace 的错误文本给客户端，存在信息泄露面。
+- 证据：`src/simulation/fullserver/pnjl_scan_jobs.jl:67`、`src/simulation/fullserver/pnjl_scan_jobs.jl:81`、`src/simulation/fullserver/compute_handlers.jl:69`、`src/simulation/fullserver/compute_handlers.jl:72`。
+- 优先级：P0。
+- 建议：客户端响应改为通用错误码；完整异常仅保留服务端日志。
+
+## 5. README 与对外文档一致性核查结论
+
+### 5.1 需要更新（高优先）
+
+1. `README.md`
+   - 仍将 `src/pnjl/` 和 `PNJL.solve(...)` 作为推荐主入口，应改为 `Models` / `src/models/entrypoints.jl`。
+   - `项目结构` 与 `目录迁移指南` 中含历史目录（`tests/analysis`）描述，需与当前目录树对齐。
+
+2. `docs/api/pnjl/PNJL.md`
+   - 文档写法与仓库现状冲突（引用 `src/pnjl/PNJL.jl`、`using PNJL` 主用法），建议降级为“历史兼容说明页”并引导到 `docs/api/models/*`。
+
+3. `docs/dev/README.md`
+   - 仍出现 `tests/analysis` / `tests/perf` 作为当前落盘位置的描述，应更新为现行治理口径。
+
+4. `docs/guides/PARAMETER_STRUCT_MIGRATION.md`、`docs/guides/error_handling.md`
+   - 含 `src/pnjl/scans/...` 等旧路径引用，需增补“历史阶段说明/当前路径映射”。
+
+### 5.2 基本一致（可保持）
+
+- `INSTALL.md`、`docs/guides/QUICKSTART.md`、`docs/guides/STATUS.md` 与当前服务启动/测试入口基本一致。
+
+## 6. 优先级建议（Top 5）
+
+1. P0：修复 `/compute` 对外错误泄露（仅返回错误码+摘要）。
+2. P1：修正 `README.md` 主入口叙述（Models 主线化）。
+3. P1：重写 `docs/api/pnjl/PNJL.md` 定位为兼容历史页，去除“主入口”叙述。
+4. P1：清理 `docs/dev/README.md`、`docs/guides/*` 中旧目录/旧路径残留。
+5. P2：统一 CI Julia 版本策略（至少给出明确差异说明）。
+
+## 7. 非目标与说明
+
+- 本次仅做“体检与记录”，不包含代码实现修改。
+- 本次未重跑全量测试与 benchmark，仅基于仓库当前文件证据与入口逻辑分析。
+
+## 8. 执行状态（按优先级推进）
+
+### 已完成
+
+- [x] P0：`/compute` 对外错误信息脱敏（不再回传 backtrace 文本；统一错误码与摘要）。
+  - 变更：`src/simulation/fullserver/compute_handlers.jl`
+  - 新增测试：`tests/unit/simulation/test_fullserver_compute_handlers.jl`
+  - smoke 入口纳入：`tests/unit/runtests.jl`
+
+- [x] P1：`README.md` 主入口口径切换到 `Models`，并清理过时目录迁移描述。
+  - 变更：`README.md`
+
+- [x] P1：`docs/api/pnjl/PNJL.md` 重写为兼容层说明页，主导航导向 `docs/api/models/*`。
+  - 变更：`docs/api/pnjl/PNJL.md`
+
+- [x] P1：修正文档旧路径残留（首批）。
+  - 变更：`docs/dev/README.md`、`docs/guides/PARAMETER_STRUCT_MIGRATION.md`、`docs/guides/error_handling.md`
+
+### 待完成
+
+- [ ] P2：统一 CI workflow Julia 版本策略（或形成明确差异说明）。

--- a/docs/dev/active/2026-03-28_全仓10维度体检结果报告.md
+++ b/docs/dev/active/2026-03-28_全仓10维度体检结果报告.md
@@ -164,4 +164,5 @@ owner: opencode-agent
 
 ### 待完成
 
-- [ ] P2：统一 CI workflow Julia 版本策略（或形成明确差异说明）。
+- [x] P2：统一 CI workflow Julia 版本策略（dependency-audit 已与主线统一为 1.12.5）。
+  - 变更：`.github/workflows/dependency-audit.yml`

--- a/docs/dev/archived/2026-03-28_全仓10维度体检结果报告.md
+++ b/docs/dev/archived/2026-03-28_全仓10维度体检结果报告.md
@@ -1,5 +1,17 @@
 ---
 title: 全仓10维度体检结果报告（2026-03-28）
+archived: true
+original: docs/dev/active/2026-03-28_全仓10维度体检结果报告.md
+archived_date: 2026-03-28
+---
+
+
+以下为原始内容（保留，以便审阅与历史参考）：
+
+---
+
+---
+title: 全仓10维度体检结果报告（2026-03-28）
 status: active
 created: 2026-03-28
 owner: opencode-agent

--- a/docs/guides/PARAMETER_STRUCT_MIGRATION.md
+++ b/docs/guides/PARAMETER_STRUCT_MIGRATION.md
@@ -32,7 +32,7 @@ Phase B extends the migration from RelaxationTime chain to PNJL workflows/scans.
      - `src/models/workflows/MesonMassWorkflow.jl`
 
 3. **Structured scan config objects added (non-breaking)**
-     - Added: `src/pnjl/scans/ScanConfig.jl`
+     - Added: `src/models/scans/ScanConfig.jl`
      - Types:
          - `TmuScanConfig`
          - `TrhoScanConfig`

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -60,8 +60,8 @@ QCD模型库使用三层配置结构：
 
 | 配置类型 | 位置 | 用途 | 示例 |
 |---------|------|------|------|
-| **模型参数** | `config/{model}/default.toml` | 物理参数、耦合常数 | G, K, Lambda |
-| **数值参数** | `config/numerical.toml` | 积分节点、容差 | nodes=64, tol=1e-10 |
+| **模型参数** | `config/models/<model>/default.toml` | 物理参数、耦合常数 | G, K, Lambda |
+| **物理常量参数** | `config/physics/default.toml` | 跨模型共享常量 | hbarc, rho0 |
 | **环境配置** | `.env` 或环境变量 | 路径、日志级别 | DATA_DIR, LOG_LEVEL |
 | **运行时配置** | 函数参数 | 特定计算的参数 | T, mu, xi |
 
@@ -77,7 +77,7 @@ QCD模型库使用三层配置结构：
 - 类型明确
 - Julia原生支持
 
-**示例**：`config/pnjl/default.toml`
+**示例**：`config/models/pnjl/default.toml`
 
 ```toml
 # PNJL模型默认参数配置
@@ -131,7 +131,7 @@ xi_max = 1.0
 
 **用途**：与外部工具交互、Web API
 
-**示例**：`config/pnjl/default.json`
+**示例**：`config/models/pnjl/default.json`（概念示例）
 
 ```json
 {
@@ -164,7 +164,7 @@ xi_max = 1.0
 using TOML
 
 """加载PNJL模型配置"""
-function load_pnjl_config(config_file::String="config/pnjl/default.toml")
+function load_pnjl_config(config_file::String="config/models/pnjl/default.toml")
     if !isfile(config_file)
         @warn "Config file not found, using defaults" config_file
         return get_default_pnjl_config()
@@ -264,7 +264,7 @@ const PNJL_CONFIG_SCHEMA = Dict(
 model = create_model(:PNJL)
 
 # 从指定配置文件创建
-model = create_model(:PNJL, config_file="config/pnjl/custom.toml")
+model = create_model(:PNJL, config_file="config/models/pnjl/custom.toml")
 
 # 从配置字典创建
 config = load_pnjl_config()
@@ -297,19 +297,25 @@ model = create_model(:PNJL, params=params)
 
 ```
 config/
-├── pnjl/
-│   ├── default.toml          # 默认参数
-│   ├── high_density.toml     # 高密度场景
-│   └── low_temperature.toml  # 低温场景
-├── rpnjl/
-│   └── default.toml
-├── numerical.toml            # 数值参数
-└── logging.toml              # 日志配置
+├── models/
+│   ├── pnjl/
+│   │   ├── default.toml      # 默认参数
+│   │   └── unittest.toml     # 单测覆盖参数
+│   ├── rpnjl/
+│   │   ├── default.toml
+│   │   └── unittest.toml
+│   ├── njl/
+│   └── njl2/
+├── physics/
+│   ├── default.toml          # 共享物理常量
+│   └── unittest.toml
+└── workflows/
+    └── relaxtime/
 ```
 
 ### 4.3 场景配置
 
-**高密度场景**：`config/pnjl/high_density.toml`
+**高密度场景**：`config/models/pnjl/high_density.toml`
 
 ```toml
 [parameters.coupling]
@@ -438,9 +444,9 @@ data_dir = ENV["QCD_DATA_DIR"]
 ### 7.1 配置继承
 
 ```toml
-# config/pnjl/high_density.toml
+# config/models/pnjl/high_density.toml
 [inherit]
-base = "config/pnjl/default.toml"
+base = "config/models/pnjl/default.toml"
 
 [parameters.coupling]
 # 只覆盖需要改变的参数
@@ -470,7 +476,7 @@ end
 ### 7.2 配置模板
 
 ```toml
-# config/templates/scan.toml
+# config/workflows/templates/scan.toml
 [scan]
 type = "{{SCAN_TYPE}}"  # TmuScan, TrhoScan
 T_min = {{T_MIN}}
@@ -496,7 +502,7 @@ vars = Dict(
     "T_MAX" => 0.3,
     "T_STEPS" => 50
 )
-config = render_config_template("config/templates/scan.toml", vars)
+config = render_config_template("config/workflows/templates/scan.toml", vars)
 ```
 
 ### 7.3 配置验证Schema
@@ -600,7 +606,7 @@ end
 ### 9.1 完整的PNJL配置
 
 ```toml
-# config/pnjl/production.toml
+# config/models/pnjl/production.toml
 # PNJL模型生产环境配置
 
 [meta]
@@ -716,7 +722,7 @@ save_convergence_info = true
 
 ```julia
 # 错误
-ERROR: Config file not found: config/pnjl/custom.toml
+ERROR: Config file not found: config/models/pnjl/custom.toml
 
 # 解决
 # 1. 检查文件路径是否正确

--- a/docs/guides/error_handling.md
+++ b/docs/guides/error_handling.md
@@ -227,7 +227,7 @@ end
 
 **高层API层**：
 ```julia
-# src/pnjl/scans/TmuScan.jl
+# src/models/scans/TmuScan.jl
 function run_tmu_scan(model, T_range, mu_range; kwargs...)
     results = []
     for T in T_range, mu in mu_range

--- a/src/simulation/fullserver/compute_handlers.jl
+++ b/src/simulation/fullserver/compute_handlers.jl
@@ -16,7 +16,12 @@ function handle_compute(req::HTTP.Request)
             return HTTP.Response(
                 400,
                 ["Content-Type" => "application/json"],
-                JSON3.write(Dict("success" => false, "error" => "Invalid input: NaN detected")),
+                JSON3.write(Dict(
+                    "success" => false,
+                    "data" => nothing,
+                    "error_code" => "INVALID_INPUT",
+                    "error" => "Invalid input: NaN detected",
+                )),
             )
         end
 
@@ -66,14 +71,29 @@ function handle_compute(req::HTTP.Request)
         ]
         return HTTP.Response(200, headers, JSON3.write(response_data))
     catch e
-        error_msg = sprint(showerror, e, catch_backtrace())
         @error "Computation error" exception = (e, catch_backtrace())
 
-        response_data = Dict("success" => false, "data" => nothing, "error" => error_msg)
+        response_data = if e isa ArgumentError || e isa DomainError
+            Dict(
+                "success" => false,
+                "data" => nothing,
+                "error_code" => "INVALID_INPUT",
+                "error" => "Invalid request parameters",
+            )
+        else
+            Dict(
+                "success" => false,
+                "data" => nothing,
+                "error_code" => "COMPUTATION_ERROR",
+                "error" => "Computation failed",
+            )
+        end
+
+        status = e isa ArgumentError || e isa DomainError ? 400 : 500
         headers = [
             "Content-Type" => "application/json; charset=utf-8",
             "Access-Control-Allow-Origin" => "*",
         ]
-        return HTTP.Response(400, headers, JSON3.write(response_data))
+        return HTTP.Response(status, headers, JSON3.write(response_data))
     end
 end

--- a/src/simulation/fullserver/pnjl_scan_jobs.jl
+++ b/src/simulation/fullserver/pnjl_scan_jobs.jl
@@ -11,6 +11,7 @@ const _PNJL_SCAN_MAX_PENDING = 32
 const _PNJL_SCAN_MAX_XI_POINTS = 64
 const _PNJL_SCAN_SEMAPHORE = Base.Semaphore(_PNJL_SCAN_MAX_RUNNING)
 const _PNJL_SCAN_FINISHED_KEEP_MAX = 64
+const _PNJL_SCAN_FINISHED_TTL_SECONDS = 86400
 
 @inline function _json_response(status::Int, payload::AbstractDict)
     headers = [
@@ -164,27 +165,66 @@ function _new_job(kind::String, request_snapshot::Dict{String, Any}; total_point
     )
     lock(_PNJL_SCAN_JOBS_LOCK) do
         _PNJL_SCAN_JOBS[job_id] = job
-        _prune_finished_jobs_locked!(_PNJL_SCAN_FINISHED_KEEP_MAX)
+        _prune_finished_jobs_locked!(_PNJL_SCAN_FINISHED_KEEP_MAX; ttl_seconds=_PNJL_SCAN_FINISHED_TTL_SECONDS)
     end
     return job_id
 end
 
-function _prune_finished_jobs_locked!(keep_max::Int=_PNJL_SCAN_FINISHED_KEEP_MAX)
+@inline function _parse_job_ended_at(raw)
+    raw === nothing && return nothing
+    if raw isa DateTime
+        return raw
+    end
+    if raw isa AbstractString
+        s = strip(raw)
+        isempty(s) && return nothing
+        try
+            return DateTime(s, dateformat"yyyy-mm-ddTHH:MM:SS")
+        catch
+            try
+                return DateTime(s)
+            catch
+                return nothing
+            end
+        end
+    end
+    return nothing
+end
+
+function _prune_finished_jobs_locked!(
+    keep_max::Int=_PNJL_SCAN_FINISHED_KEEP_MAX;
+    now::DateTime=Dates.now(),
+    ttl_seconds::Int=_PNJL_SCAN_FINISHED_TTL_SECONDS,
+)
     keep_max >= 0 || throw(ArgumentError("keep_max must be >= 0"))
+    ttl_seconds >= 0 || throw(ArgumentError("ttl_seconds must be >= 0"))
 
     finished = Tuple{String, Int}[]
+    expired_ids = String[]
     for (job_id, job) in _PNJL_SCAN_JOBS
         st = get(job, "status", "")
         if st == "succeeded" || st == "failed"
+            ended_at = _parse_job_ended_at(get(job, "ended_at", nothing))
+            if ended_at !== nothing && (now - ended_at) > Dates.Second(ttl_seconds)
+                push!(expired_ids, job_id)
+                continue
+            end
             push!(finished, (job_id, Int(get(job, "seq", typemax(Int)))))
         end
     end
 
+    removed = 0
+    for job_id in expired_ids
+        if haskey(_PNJL_SCAN_JOBS, job_id)
+            delete!(_PNJL_SCAN_JOBS, job_id)
+            removed += 1
+        end
+    end
+
     excess = length(finished) - keep_max
-    excess <= 0 && return 0
+    excess <= 0 && return removed
 
     sort!(finished; by=last)
-    removed = 0
     for i in 1:excess
         job_id = finished[i][1]
         if haskey(_PNJL_SCAN_JOBS, job_id)
@@ -438,6 +478,7 @@ function handle_pnjl_scan_job_create(req::HTTP.Request)
         if snap.queued >= _PNJL_SCAN_MAX_PENDING
             return _json_response(429, Dict(
                 "status" => "error",
+                "error_code" => "QUEUE_FULL",
                 "error" => "queue is full",
                 "policy" => Dict(
                     "max_running" => _PNJL_SCAN_MAX_RUNNING,
@@ -483,6 +524,7 @@ function handle_pnjl_scan_job_create(req::HTTP.Request)
     catch e
         return _json_response(400, Dict(
             "status" => "error",
+            "error_code" => "INVALID_REQUEST",
             "error" => sprint(showerror, e),
             "diagnostics" => _build_job_diagnostics(nothing, nothing, "rejected"; err=e),
         ))
@@ -515,7 +557,7 @@ function handle_pnjl_scan_job_status(job_id::String)
         )
     end
 
-    payload === nothing && return _json_response(404, Dict("status" => "error", "error" => "job not found", "job_id" => job_id))
+    payload === nothing && return _json_response(404, Dict("status" => "error", "error_code" => "JOB_NOT_FOUND", "error" => "job not found", "job_id" => job_id))
     return _json_response(200, payload)
 end
 
@@ -527,6 +569,7 @@ function handle_pnjl_scan_job_result(job_id::String)
             return Dict{String, Any}(
                 "status" => "error",
                 "job_id" => job_id,
+                "error_code" => "JOB_NOT_SUCCEEDED",
                 "error" => "job not succeeded",
                 "job_status" => status,
                 "diagnostics" => _build_job_diagnostics(job_id, job["kind"], status),
@@ -546,7 +589,7 @@ function handle_pnjl_scan_job_result(job_id::String)
         )
     end
 
-    payload === nothing && return _json_response(404, Dict("status" => "error", "error" => "job not found", "job_id" => job_id))
+    payload === nothing && return _json_response(404, Dict("status" => "error", "error_code" => "JOB_NOT_FOUND", "error" => "job not found", "job_id" => job_id))
     if payload["status"] == "error"
         return _json_response(409, payload)
     end

--- a/tests/unit/runtests.jl
+++ b/tests/unit/runtests.jl
@@ -68,6 +68,7 @@ const SMOKE_FILES = [
     # [Simulation] 模拟子系统
     joinpath(UNIT_DIR, "simulation", "test_frame_transformations.jl"),
     joinpath(UNIT_DIR, "simulation", "test_momentum_mapping.jl"),
+    joinpath(UNIT_DIR, "simulation", "test_fullserver_compute_handlers.jl"),
     joinpath(UNIT_DIR, "simulation", "test_pnjl_scan_jobs.jl"),
 ]
 

--- a/tests/unit/simulation/test_fullserver_compute_handlers.jl
+++ b/tests/unit/simulation/test_fullserver_compute_handlers.jl
@@ -1,0 +1,52 @@
+using Test
+using HTTP
+using JSON3
+
+const PROJECT_ROOT_FCH = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :FullServerApp)
+    if !isdefined(Main, :Models)
+        include(joinpath(PROJECT_ROOT_FCH, "src", "models", "Models.jl"))
+    end
+    include(joinpath(PROJECT_ROOT_FCH, "src", "simulation", "FullServerApp.jl"))
+end
+
+const FCH = Main.FullServerApp
+
+function _make_compute_req(payload::Dict)
+    return HTTP.Request(
+        "POST",
+        "/compute",
+        ["Content-Type" => "application/json"],
+        JSON3.write(payload),
+    )
+end
+
+function _parse_body(resp::HTTP.Response)
+    return JSON3.read(String(resp.body))
+end
+
+@testset "FullServer compute handler" begin
+    @testset "runtime error response is sanitized" begin
+        req = _make_compute_req(Dict(
+            "p1x" => 0.5,
+            "p1y" => 0.0,
+            "p1z" => 1.8,
+            "p2x" => -0.5,
+            "p2y" => 0.0,
+            "p2z" => -1.8,
+            "m1" => 1.52,
+            "m2" => 1.52,
+            "m3" => 1.52,
+        ))
+
+        resp = FCH.handle_compute(req)
+        body = _parse_body(resp)
+
+        @test resp.status == 500
+        @test body.success == false
+        @test body.data === nothing
+        @test body.error_code == "COMPUTATION_ERROR"
+        @test body.error == "Computation failed"
+    end
+end

--- a/tests/unit/simulation/test_pnjl_scan_jobs.jl
+++ b/tests/unit/simulation/test_pnjl_scan_jobs.jl
@@ -1,6 +1,7 @@
 using Test
 using HTTP
 using JSON3
+using Dates: DateTime
 
 const PROJECT_ROOT_PSJ = normpath(joinpath(@__DIR__, "..", "..", ".."))
 
@@ -66,6 +67,7 @@ end
         body = _body_dict(resp)
         @test resp.status == 400
         @test body.status == "error"
+        @test body.error_code == "INVALID_REQUEST"
         @test occursin("max_retries", String(body.error))
         @test haskey(body, :diagnostics)
         @test body.diagnostics.error_type in ("ErrorException", "ArgumentError")
@@ -83,6 +85,7 @@ end
         body = _body_dict(resp)
         @test resp.status == 400
         @test body.status == "error"
+        @test body.error_code == "INVALID_REQUEST"
         @test occursin("Use only one xi strategy", String(body.error))
     end
 
@@ -103,6 +106,7 @@ end
         result_body = _body_dict(result_payload)
         @test result_payload.status == 409
         @test result_body.status == "error"
+        @test result_body.error_code == "JOB_NOT_SUCCEEDED"
         @test result_body.job_status == "queued"
         @test haskey(result_body, :diagnostics)
         @test result_body.diagnostics.job_id == job_id
@@ -135,6 +139,7 @@ end
         body = _body_dict(resp)
         @test resp.status == 429
         @test body.status == "error"
+        @test body.error_code == "QUEUE_FULL"
         @test body.error == "queue is full"
     end
 
@@ -196,6 +201,46 @@ end
             @test !haskey(PSJ._PNJL_SCAN_JOBS, "done_3")
             @test haskey(PSJ._PNJL_SCAN_JOBS, "done_4")
             @test haskey(PSJ._PNJL_SCAN_JOBS, "done_5")
+        end
+    end
+
+    @testset "finished jobs pruning honors ttl" begin
+        _reset_jobs_state!()
+        lock(PSJ._PNJL_SCAN_JOBS_LOCK) do
+            PSJ._PNJL_SCAN_JOBS["done_old"] = Dict{String, Any}(
+                "job_id" => "done_old",
+                "seq" => 1,
+                "kind" => "tmu",
+                "status" => "succeeded",
+                "created_at" => "",
+                "started_at" => nothing,
+                "ended_at" => "2026-03-01T00:00:00",
+                "progress" => Dict{String, Any}("total" => 1, "completed" => 1, "percent" => 100.0),
+                "result" => Dict{String, Any}(),
+                "error" => nothing,
+                "request" => Dict{String, Any}(),
+            )
+            PSJ._PNJL_SCAN_JOBS["done_new"] = Dict{String, Any}(
+                "job_id" => "done_new",
+                "seq" => 2,
+                "kind" => "tmu",
+                "status" => "failed",
+                "created_at" => "",
+                "started_at" => nothing,
+                "ended_at" => "2026-03-28T00:00:15",
+                "progress" => Dict{String, Any}("total" => 1, "completed" => 1, "percent" => 100.0),
+                "result" => Dict{String, Any}(),
+                "error" => "x",
+                "request" => Dict{String, Any}(),
+            )
+
+            removed = PSJ._prune_finished_jobs_locked!(10; now=DateTime(2026, 3, 28, 0, 0, 20), ttl_seconds=10)
+            @test removed == 1
+        end
+
+        lock(PSJ._PNJL_SCAN_JOBS_LOCK) do
+            @test !haskey(PSJ._PNJL_SCAN_JOBS, "done_old")
+            @test haskey(PSJ._PNJL_SCAN_JOBS, "done_new")
         end
     end
 


### PR DESCRIPTION
## Summary
- Sanitize `/compute` and `pnjl-scan/jobs` error responses with stable `error_code` contracts, and add finished-job TTL pruning to reduce long-running in-memory accumulation risk.
- Align user-facing docs with the Models-first architecture (`README`, PNJL compat page, config/migration/error-handling docs) and update CI dependency-audit Julia version to `1.12.5`.
- Add targeted unit coverage for compute handler and scan-job contract/TTL behavior, then archive the completed 2026-03-28 full-repo 10-dimension audit task report.

## Verification
- `julia --project=. -e 'ENV["UNIT_FILES"]="simulation/test_pnjl_scan_jobs.jl;simulation/test_fullserver_compute_handlers.jl"; include("tests/unit/runtests.jl")'`
- `julia --project=. scripts/dev/check_docs_consistency.jl`
- `julia --project=. scripts/dev/analyze_deps.jl`