### PR TITLE
fix(pnjl/scripts): resolve nightly full regression TmuScanConfig import collision

### DIFF
--- a/scripts/pnjl/run_tmu_scan.jl
+++ b/scripts/pnjl/run_tmu_scan.jl
@@ -87,7 +87,7 @@ using .Models: run_tmu_scan
 
 const DEFAULT_OUTPUT_DIR = joinpath(@__DIR__, "..", "..", "data", "outputs", "results", "pnjl", "scan", "tmu")
 
-struct TmuScanConfig
+struct ScriptTmuScanConfig
     mode::Symbol
     xi::Float64
     T_min::Float64
@@ -183,7 +183,7 @@ function parse_args(args)
         output_path = joinpath(DEFAULT_OUTPUT_DIR, suffix)
     end
     
-    return TmuScanConfig(
+    return ScriptTmuScanConfig(
         mode,
         xi, T_min, T_max, T_step, mu_min, mu_max, mu_step,
         T_mev, mu_mev,

--- a/scripts/pnjl/run_tmu_scan.jl
+++ b/scripts/pnjl/run_tmu_scan.jl
@@ -87,25 +87,27 @@ using .Models: run_tmu_scan
 
 const DEFAULT_OUTPUT_DIR = joinpath(@__DIR__, "..", "..", "data", "outputs", "results", "pnjl", "scan", "tmu")
 
-struct ScriptTmuScanConfig
-    mode::Symbol
-    xi::Float64
-    T_min::Float64
-    T_max::Float64
-    T_step::Float64
-    mu_min::Float64
-    mu_max::Float64
-    mu_step::Float64
-    T_mev::Float64
-    mu_mev::Float64
-    output_path::String
-    resume::Bool
-    overwrite::Bool
-    use_phase_aware::Bool
-    solver_backend::Symbol
-    p_num::Int
-    t_num::Int
-    verbose::Bool
+if !isdefined(Main, :ScriptTmuScanConfig)
+    struct ScriptTmuScanConfig
+        mode::Symbol
+        xi::Float64
+        T_min::Float64
+        T_max::Float64
+        T_step::Float64
+        mu_min::Float64
+        mu_max::Float64
+        mu_step::Float64
+        T_mev::Float64
+        mu_mev::Float64
+        output_path::String
+        resume::Bool
+        overwrite::Bool
+        use_phase_aware::Bool
+        solver_backend::Symbol
+        p_num::Int
+        t_num::Int
+        verbose::Bool
+    end
 end
 
 function parse_args(args)

--- a/tests/unit/pnjl/test_run_tmu_scan_import_compat.jl
+++ b/tests/unit/pnjl/test_run_tmu_scan_import_compat.jl
@@ -1,0 +1,14 @@
+using Test
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+const SCRIPT_PATH = joinpath(PROJECT_ROOT, "scripts", "pnjl", "run_tmu_scan.jl")
+
+@testset "run_tmu_scan script import compatibility" begin
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+    using Main.Models: TmuScanConfig
+
+    @test begin
+        include(SCRIPT_PATH)
+        true
+    end
+end

--- a/tests/unit/pnjl/test_run_tmu_scan_import_compat.jl
+++ b/tests/unit/pnjl/test_run_tmu_scan_import_compat.jl
@@ -7,8 +7,5 @@ const SCRIPT_PATH = joinpath(PROJECT_ROOT, "scripts", "pnjl", "run_tmu_scan.jl")
     include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
     using Main.Models: TmuScanConfig
 
-    @test begin
-        include(SCRIPT_PATH)
-        true
-    end
+    @test include(SCRIPT_PATH) === nothing
 end


### PR DESCRIPTION
## Summary
- Fix nightly `unit full profile` regression where including `scripts/pnjl/run_tmu_scan.jl` after `Models` import raised `cannot declare Main.TmuScanConfig constant; it was already declared as an import`.
- Rename script-local config type from `TmuScanConfig` to `ScriptTmuScanConfig` to avoid colliding with `Models.TmuScanConfig` in shared `Main` context.
- Add unit test `tests/unit/pnjl/test_run_tmu_scan_import_compat.jl` to lock this include-order compatibility contract.

## Root Cause
`nightly-full-regression` (run `23832160211`) failed in `Run unit full profile` because the script declared `TmuScanConfig` in `Main` while `Main.Models` already imported `TmuScanConfig` from scan config, causing a deterministic name conflict.

## Verification
- `julia --project=. -e 'include("tests/unit/pnjl/test_run_tmu_scan_import_compat.jl")'`
- `julia --project=. -e 'include("tests/unit/pnjl/test_run_tmu_scan_script_modes.jl")'`
- `julia --project=. -e 'ENV["UNIT_PROFILE"]="full"; include("tests/unit/runtests.jl")'` (local run result: `Pass 2810 / Total 2810`)
