### PR TITLE
feat(models/solver): converge Wave-B governance and compat routing

### DIFF
--- a/docs/dev/active/2026-04-01_PNJL求解器解耦Wave-B任务单.md
+++ b/docs/dev/active/2026-04-01_PNJL求解器解耦Wave-B任务单.md
@@ -8,74 +8,78 @@
 
 ## 1. 目标
 
-- [ ] 将 Wave-A 已冻结契约推进到扫描/单点共用执行路径。
-- [ ] 准备兼容入口 deprecation 节奏（不在本波次强删）。
-- [ ] 固化 fallback/selection 诊断稳定性回归。
+- [x] 将 Wave-A 已冻结契约推进到扫描/单点共用执行路径。
+- [x] 准备兼容入口 deprecation 节奏（不在本波次强删）。
+- [x] 固化 fallback/selection 诊断稳定性回归。
 
 ## 2. 范围
 
 ### 2.1 本期范围
 
-- [ ] scan 侧候选治理接线收敛。
-- [ ] 兼容入口统一路由与迁移状态补齐。
-- [ ] fallback 原因标签规范化。
+- [x] scan 侧候选治理接线收敛。
+- [x] 兼容入口统一路由与迁移状态补齐。
+- [x] fallback 原因标签规范化。
 
 ### 2.2 非范围
 
-- [ ] 不移除 `solve_fixed*` 兼容入口。
-- [ ] 不替换求解后端。
+- [x] 不移除 `solve_fixed*` 兼容入口。
+- [x] 不替换求解后端。
 
 ## 3. 任务分解
 
 ### B1：scan 侧治理并轨
 
-- [ ] 为 scan 治理并轨补失败回归测试。
-- [ ] 让 `TmuScan/TrhoScan` 走共享 governance 接口。
-- [ ] 验证代表点无非预期漂移。
+- [x] 为 scan 治理并轨补失败回归测试。
+- [x] 让 `TmuScan/TrhoScan` 走共享 governance 接口。
+- [x] 验证代表点无非预期漂移。
 
 ### B2：兼容路由 deprecation-ready
 
-- [ ] 为统一入口/兼容入口等价性补失败 smoke。
-- [ ] 完善迁移状态与查询接口。
-- [ ] 保持外部签名兼容。
-- [ ] 新建/维护 Wave-B 迁移映射台账：`docs/dev/active/2026-04-01_求解器兼容层迁移映射表_Wave-B.md`。
+- [x] 为统一入口/兼容入口等价性补失败 smoke。
+- [x] 完善迁移状态与查询接口。
+- [x] 保持外部签名兼容。
+- [x] 新建/维护 Wave-B 迁移映射台账：`docs/dev/active/2026-04-01_求解器兼容层迁移映射表_Wave-B.md`。
 
 ### B3：fallback 诊断稳定性
 
-- [ ] 为 fallback reason 标签补失败回归。
-- [ ] 统一 reason tag 与输出顺序。
-- [ ] 验证诊断输出可稳定复现。
+- [x] 为 fallback reason 标签补失败回归。
+- [x] 统一 reason tag 与输出顺序。
+- [x] 验证诊断输出可稳定复现。
 
 ### B4：文档治理同步
 
-- [ ] 更新迁移映射状态与删除门槛。
-- [ ] 回填验证证据到本任务单。
-- [ ] 通过 docs/governance 检查。
+- [x] 更新迁移映射状态与删除门槛。
+- [x] 回填验证证据到本任务单。
+- [x] 通过 docs/governance 检查。
 
 ## 4. 验收标准
 
-- [ ] scan 与单点使用统一治理口径。
-- [ ] compatibility 路由行为可追溯且保持非破坏。
-- [ ] fallback 诊断回归稳定。
-- [ ] smoke + docs/governance 通过。
+- [x] scan 与单点使用统一治理口径。
+- [x] compatibility 路由行为可追溯且保持非破坏。
+- [x] fallback 诊断回归稳定。
+- [x] smoke + docs/governance 通过。
 
 ## 5. 验证命令
 
-- [ ] `julia --project=. -e 'include("tests/integration/models/test_waveb_compat_routing_smoke.jl")'`
-- [ ] `julia --project=. -e 'include("tests/regression/pnjl/test_waveb_scan_governance_stability.jl")'`
-- [ ] `julia --project=. -e 'ENV["UNIT_PROFILE"]="smoke"; include("tests/unit/runtests.jl")'`
-- [ ] `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`
-- [ ] `julia --project=. -e 'ENV["REGRESSION_PROFILE"]="smoke"; include("tests/regression/runtests.jl")'`
-- [ ] `julia --project=. scripts/dev/check_docs_consistency.jl`
-- [ ] `julia --project=. scripts/dev/check_active_docs_governance.jl`
+- [x] `julia --project=. -e 'include("tests/integration/models/test_waveb_compat_routing_smoke.jl")'`
+- [x] `julia --project=. -e 'include("tests/regression/pnjl/test_waveb_scan_governance_stability.jl")'`
+- [x] `julia --project=. -e 'ENV["UNIT_PROFILE"]="smoke"; include("tests/unit/runtests.jl")'`
+- [x] `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`
+- [x] `julia --project=. -e 'ENV["REGRESSION_PROFILE"]="smoke"; include("tests/regression/runtests.jl")'`
+- [x] `julia --project=. scripts/dev/check_docs_consistency.jl`
+- [x] `julia --project=. scripts/dev/check_active_docs_governance.jl`
 
 ## 6. DoD
 
-- [ ] 任务项与验收项全部勾选。
-- [ ] 关键验证命令可复现通过。
-- [ ] 迁移状态文档同步更新。
+- [x] 任务项与验收项全部勾选。
+- [x] 关键验证命令可复现通过。
+- [x] 迁移状态文档同步更新。
 
 ## 7. 执行记录
 
 - [x] 2026-04-01：基于 Wave-A 完成状态创建 Wave-B 任务单。
 - [x] 2026-04-01：补充 Wave-B 迁移台账路径与新增测试命令，降低执行歧义。
+- [x] 2026-04-01（B1）：新增 `tests/regression/pnjl/test_waveb_scan_governance_stability.jl` 并先失败后修复；`ScanCommon.attempt_with_candidates` 统一通过 governance 选择并输出 `governance.selection=*` 诊断。
+- [x] 2026-04-01（B2）：新增 `tests/integration/models/test_waveb_compat_routing_smoke.jl` 并先失败后修复；新增 `Models.solver_migration_status` 查询接口，保持 legacy `solve_fixed*` 兼容入口可调用。
+- [x] 2026-04-01（B3）：在同一 regression 中新增 fallback reason 标签归一化失败用例并修复；`ScanCommon.join_messages` 统一输出顺序 `governance.selection -> fallback.reason`。
+- [x] 2026-04-01（验证）：定向测试、unit/integration/regression smoke、docs governance 均通过（integration smoke 期间可见预期 fail-on-fallback 演示日志，但测试总集 `Pass 353/353`）。

--- a/docs/dev/active/2026-04-01_PNJL求解器解耦Wave-C任务单.md
+++ b/docs/dev/active/2026-04-01_PNJL求解器解耦Wave-C任务单.md
@@ -1,0 +1,91 @@
+# PNJL求解器解耦 Wave-C 任务单
+
+> 执行主线说明：本任务单用于 Wave-C 的唯一执行主线（勾选、证据、验收）。
+> 设计与实现参考：
+> - `docs/superpowers/specs/2026-04-01-pnjl-solver-decoupling-wave-c-design.md`
+> - `docs/superpowers/plans/2026-04-01-pnjl-solver-decoupling-wave-c-implementation-plan.md`
+> - `docs/dev/archived/2026-03-31_PNJL求解器解耦框架约束与分层草案.md`
+
+## 1. 目标
+
+- [ ] 将 Wave-B 统一治理能力延伸到扫描/工作流脚本主入口。
+- [ ] 收敛模型特化扫描 SOP 到 unified model-driven 路径。
+- [ ] 固化 Wave-C 迁移状态与稳定性回归基线。
+
+## 2. 范围
+
+### 2.1 本期范围
+
+- [ ] script/workflow 侧统一路由并轨。
+- [ ] 兼容适配层 migration 状态查询与台账同步。
+- [ ] model-driven 扫描输出稳定性回归。
+
+### 2.2 非范围
+
+- [ ] 不更换求解后端。
+- [ ] 不在本波次执行兼容入口强删。
+
+## 3. 任务分解
+
+### C1：脚本与工作流统一路由
+
+- [ ] 为 script 路径与 unified 路径等价性补失败 smoke。
+- [ ] 将 scan 脚本入口收敛到统一 model-driven API。
+- [ ] 保持 CLI/外部调用签名兼容。
+
+### C2：SOP 分叉收敛与迁移治理
+
+- [ ] 为兼容适配路由与迁移状态查询补失败测试。
+- [ ] 统一旧 SOP 为 compat adapter（unified-first）。
+- [ ] 更新/维护 Wave-C 扫描与工作流迁移映射台账：`docs/dev/active/2026-04-01_扫描与工作流兼容层迁移映射表_Wave-C.md`。
+
+### C3：model-driven 稳定性回归
+
+- [ ] 为 representative points 补失败回归。
+- [ ] 统一诊断与输出顺序，保证断言稳定。
+- [ ] 验证回归可重复通过。
+
+### C4：文档治理同步
+
+- [ ] 回填 Wave-C 任务单证据与勾选状态。
+- [ ] 同步迁移状态、删除门槛与风险备注。
+- [ ] 通过 docs/governance 检查。
+
+## 4. 验收标准
+
+- [ ] 扫描/工作流新调用方默认走 unified model-driven 路径。
+- [ ] legacy SOP 保持 non-breaking 且行为可追溯。
+- [ ] model-driven 扫描回归稳定可复现。
+- [ ] smoke + docs/governance 通过。
+
+## 5. 验证命令
+
+- [ ] `julia --project=. -e 'include("tests/integration/models/test_wavec_scan_workflow_parity_smoke.jl")'`
+- [ ] `julia --project=. -e 'include("tests/regression/pnjl/test_wavec_model_driven_scan_stability.jl")'`
+- [ ] `julia --project=. -e 'ENV["UNIT_PROFILE"]="smoke"; include("tests/unit/runtests.jl")'`
+- [ ] `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`
+- [ ] `julia --project=. -e 'ENV["REGRESSION_PROFILE"]="smoke"; include("tests/regression/runtests.jl")'`
+- [ ] `julia --project=. scripts/dev/check_docs_consistency.jl`
+- [ ] `julia --project=. scripts/dev/check_active_docs_governance.jl`
+
+## 5.1 默认零上下文 agent 执行约束
+
+- [ ] 仅以下三份文档作为 Wave-C 执行主线：
+  - `docs/dev/active/2026-04-01_PNJL求解器解耦Wave-C任务单.md`
+  - `docs/superpowers/specs/2026-04-01-pnjl-solver-decoupling-wave-c-design.md`
+  - `docs/superpowers/plans/2026-04-01-pnjl-solver-decoupling-wave-c-implementation-plan.md`
+- [ ] 参考台账：`docs/dev/active/2026-04-01_扫描与工作流兼容层迁移映射表_Wave-C.md`
+- [ ] 执行顺序必须严格按 C1 -> C2 -> C3（文档同步与验证在 C4/C5）。
+- [ ] 每个子步采用 TDD（先失败测试，再最小实现，再回归）。
+- [ ] 每个子步必须运行：本步定向测试 + unit/integration/regression smoke + docs governance checks。
+- [ ] 不执行 Wave-C 之外的代码级改动；兼容路径只做 deprecation-ready，不做破坏性删除。
+
+## 6. DoD
+
+- [ ] 任务项与验收项全部勾选。
+- [ ] 关键验证命令可复现通过。
+- [ ] Wave-C 迁移台账与状态文档同步更新。
+
+## 7. 执行记录
+
+- [x] 2026-04-01：创建 Wave-C 任务单草案，承接 archived 分层草案（Wave-C：扫描收敛阶段）与 Wave-B 已完成状态。

--- a/docs/dev/active/2026-04-01_扫描与工作流兼容层迁移映射表_Wave-C.md
+++ b/docs/dev/active/2026-04-01_扫描与工作流兼容层迁移映射表_Wave-C.md
@@ -1,0 +1,32 @@
+# 扫描与工作流兼容层迁移映射表（Wave-C）
+
+## 目标
+
+在 Wave-C 保持对外 non-breaking 前提下，将扫描/工作流脚本路由收敛到 unified model-driven 入口，并为 Wave-D 兼容层清理提供可追溯状态。
+
+主入口：`Models.run_tmu_scan`、`Models.run_trho_scan`、`Models.solve_gap_and_transport`（及统一 entrypoints）。
+
+## 迁移映射
+
+| 兼容路径（脚本/SOP） | 统一入口 | Wave-C 状态 | 删除门槛（后续波次） | 目标波次 |
+|---|---|---|---|---|
+| `scripts/pnjl/run_tmu_scan.jl` 模型特化分支 | `Models.run_tmu_scan(...; model_kind=...)` | planned (compat adapter, unified-first) | 脚本调用方统一到 model-driven 参数化入口 + parity 回归稳定 | D |
+| `scripts/pnjl/run_dense_trho_scan.jl` 与 `scripts/pnjl/run_adaptive_trho_scan.jl` 模型特化分支 | `Models.run_trho_scan(...; model_kind=...)` | planned (compat adapter, unified-first) | 脚本调用方统一到 model-driven 参数化入口 + parity 回归稳定 | D |
+| 历史 workflow 直连脚本 SOP | `Models` 统一 workflow entrypoints | planned (compat adapter, unified-first) | workflow 侧无脚本分叉调用 + smoke/regression 稳定 | D |
+
+## Wave-C 约束
+
+- 兼容脚本入口必须保持可调用，不引入 breaking change。
+- 新调用方默认走 unified model-driven 路径，不新增模型特化 SOP 分叉。
+- 兼容行为需可追溯到 migration 状态与 parity 验证证据。
+
+## 验证建议
+
+- `julia --project=. -e 'include("tests/integration/models/test_wavec_scan_workflow_parity_smoke.jl")'`
+- `julia --project=. -e 'include("tests/regression/pnjl/test_wavec_model_driven_scan_stability.jl")'`
+- `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`
+- `julia --project=. -e 'ENV["REGRESSION_PROFILE"]="smoke"; include("tests/regression/runtests.jl")'`
+
+## 执行记录
+
+- [x] 2026-04-01：创建 Wave-C 扫描/工作流迁移映射表草案，作为 C2 的状态管理基线。

--- a/docs/dev/active/2026-04-01_求解器兼容层迁移映射表_Wave-B.md
+++ b/docs/dev/active/2026-04-01_求解器兼容层迁移映射表_Wave-B.md
@@ -28,6 +28,12 @@
 - `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`
 - `julia --project=. -e 'ENV["REGRESSION_PROFILE"]="smoke"; include("tests/regression/runtests.jl")'`
 
+## 代码查询接口（Wave-B 新增）
+
+- `Models.solver_migration_map()`：返回全量兼容入口映射（含状态与删除门槛）。
+- `Models.solver_migration_status(old_entry::AbstractString)`：按兼容入口查询单条迁移状态；返回 `route=:compat_shim` 与 `deprecation_ready=true`，用于 deprecation-ready 节奏跟踪。
+
 ## 执行记录
 
 - [x] 2026-04-01：创建 Wave-B 迁移映射表，承接已归档 Wave-A 映射文档。
+- [x] 2026-04-01：B2 落地 `solver_migration_status` 查询接口，并通过 `tests/integration/models/test_waveb_compat_routing_smoke.jl` 验证 unified/compat 路由等价性与非破坏兼容性。

--- a/docs/superpowers/plans/2026-04-01-pnjl-solver-decoupling-wave-c-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-01-pnjl-solver-decoupling-wave-c-implementation-plan.md
@@ -1,0 +1,101 @@
+# PNJL Solver Decoupling Wave-C Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Converge scan/workflow execution onto model-driven unified entrypoints, contract legacy SOP forks into compatibility adapters, and freeze migration+regression stability for Wave-D cleanup.
+
+**Architecture:** Keep solver contracts from Wave-A/B unchanged, and focus on L4 workflow/scan convergence: model-parameterized orchestration, explicit compatibility mapping, deterministic parity diagnostics.
+
+**Tech Stack:** Julia (`src/models/scans/*`, `src/models/workflows/*`, `scripts/pnjl/*`), tests in `tests/unit|integration|regression`, docs in `docs/dev|docs/superpowers`.
+
+---
+
+## File Structure (Planned)
+
+- Modify: `scripts/pnjl/run_tmu_scan.jl`
+- Modify: `scripts/pnjl/run_dense_trho_scan.jl`
+- Modify: `scripts/pnjl/run_adaptive_trho_scan.jl`
+- Modify: `src/models/entrypoints.jl`
+- Modify: `src/models/scans/TmuScan.jl`
+- Modify: `src/models/scans/TrhoScan.jl`
+- Modify: `src/models/Models.jl`
+- Modify: `docs/dev/active/2026-04-01_PNJL求解器解耦Wave-C任务单.md`
+- Create/Modify: `docs/dev/active/2026-04-01_扫描与工作流兼容层迁移映射表_Wave-C.md`
+- Create: `tests/integration/models/test_wavec_scan_workflow_parity_smoke.jl`
+- Create: `tests/regression/pnjl/test_wavec_model_driven_scan_stability.jl`
+
+## Chunk 1: Script/Workflow Unified Routing
+
+### Task C1: Converge scan scripts onto model-driven unified entrypoints
+
+**Files:**
+- Modify: `scripts/pnjl/run_tmu_scan.jl`
+- Modify: `scripts/pnjl/run_dense_trho_scan.jl`
+- Modify: `scripts/pnjl/run_adaptive_trho_scan.jl`
+- Modify: `src/models/entrypoints.jl`
+
+- [ ] **Step 1: Add failing integration smoke for script path vs unified model-driven path parity**
+- [ ] **Step 2: Route script scan entrypoints through unified model-driven APIs**
+- [ ] **Step 3: Keep CLI signatures and behavior backward-compatible**
+- [ ] **Step 4: Re-run parity smoke and verify no unintended drift**
+
+## Chunk 2: SOP Fork Contraction and Migration Governance
+
+### Task C2: Convert model-specialized SOP forks into compatibility adapters
+
+**Files:**
+- Modify: `src/models/scans/TmuScan.jl`
+- Modify: `src/models/scans/TrhoScan.jl`
+- Modify: `src/models/Models.jl`
+- Create/Modify: `docs/dev/active/2026-04-01_扫描与工作流兼容层迁移映射表_Wave-C.md`
+
+- [ ] **Step 1: Add failing tests for compatibility adapter routing metadata/queryability**
+- [ ] **Step 2: Implement/extend migration status query surface for scan/workflow adapters**
+- [ ] **Step 3: Ensure old SOP paths remain non-breaking but unified-first**
+- [ ] **Step 4: Re-run tests and confirm migration status traceability**
+
+## Chunk 3: Model-Driven Scan Stability Baselines
+
+### Task C3: Freeze deterministic regression around unified model-driven scan outputs
+
+**Files:**
+- Create: `tests/regression/pnjl/test_wavec_model_driven_scan_stability.jl`
+- Modify: `src/models/scans/TmuScan.jl`
+- Modify: `src/models/scans/TrhoScan.jl`
+
+- [ ] **Step 1: Add failing regression for representative model-driven scan points**
+- [ ] **Step 2: Normalize required diagnostics/output ordering for stable assertions**
+- [ ] **Step 3: Re-run regression and verify deterministic behavior**
+
+## Chunk 4: Documentation and Governance Sync
+
+### Task C4: Update Wave-C active task/evidence and migration mapping
+
+**Files:**
+- Modify: `docs/dev/active/2026-04-01_PNJL求解器解耦Wave-C任务单.md`
+- Create/Modify: `docs/dev/active/2026-04-01_扫描与工作流兼容层迁移映射表_Wave-C.md`
+
+- [ ] **Step 1: Update migration states and deletion thresholds for Wave-C progress**
+- [ ] **Step 2: Backfill evidence and command outcomes to task sheet**
+- [ ] **Step 3: Verify docs governance checks remain green**
+
+## Chunk 5: Verification Matrix and Closure
+
+### Task C5: Execute Wave-C verification matrix
+
+**Files:**
+- Create/Modify tests listed above
+
+- [ ] **Step 1: Run targeted new integration/regression tests**
+  - `julia --project=. -e 'include("tests/integration/models/test_wavec_scan_workflow_parity_smoke.jl")'`
+  - `julia --project=. -e 'include("tests/regression/pnjl/test_wavec_model_driven_scan_stability.jl")'`
+- [ ] **Step 2: Run unit smoke profile**
+  - `julia --project=. -e 'ENV["UNIT_PROFILE"]="smoke"; include("tests/unit/runtests.jl")'`
+- [ ] **Step 3: Run integration smoke profile**
+  - `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`
+- [ ] **Step 4: Run regression smoke profile**
+  - `julia --project=. -e 'ENV["REGRESSION_PROFILE"]="smoke"; include("tests/regression/runtests.jl")'`
+- [ ] **Step 5: Run docs/governance checks**
+  - `julia --project=. scripts/dev/check_docs_consistency.jl`
+  - `julia --project=. scripts/dev/check_active_docs_governance.jl`
+- [ ] **Step 6: Update Wave-C task sheet completion evidence**

--- a/docs/superpowers/specs/2026-04-01-pnjl-solver-decoupling-wave-c-design.md
+++ b/docs/superpowers/specs/2026-04-01-pnjl-solver-decoupling-wave-c-design.md
@@ -1,0 +1,68 @@
+# PNJL Solver Decoupling Wave-C Design
+
+## Context
+
+Wave-A froze contracts and governance interfaces.
+Wave-B converged scan/single-point governance behavior and added deprecation-ready compatibility routing metadata.
+
+Wave-C should shift the decoupling focus from "solver-path convergence" to "scan/workflow convergence":
+
+1. make scan/workflow entrypoints model-driven by default,
+2. eliminate model-specific SOP duplication in scripts/workflows,
+3. keep migration traceability and non-breaking rollout discipline.
+
+## Goals
+
+1. Converge script and workflow scan orchestration on unified `Models` entrypoints (`run_tmu_scan`, `run_trho_scan`, and workflow-facing model-driven APIs).
+2. Replace model-specialized scan SOP forks with parameterized model dispatch.
+3. Keep backward compatibility during Wave-C via migration markers and deprecation-ready routing.
+4. Lock deterministic regression coverage for representative model-driven scan outputs.
+
+## Non-Goals
+
+1. No solver backend replacement.
+2. No aggressive hard deletion of compatibility wrappers in Wave-C.
+3. No broad refactor outside scan/workflow convergence and migration governance scope.
+
+## Design Decisions
+
+### D1: Model-driven scan orchestration as the only primary path
+
+Wave-C treats `model_kind` + unified mode interfaces as the source of truth for scan/workflow routing. New call sites must go through the unified model-driven path, not model-specialized script forks.
+
+### D2: SOP fork contraction through adapter normalization
+
+Legacy SOP scripts stay callable short-term, but become thin adapters over unified scan/workflow entrypoints. Their behavior should be externally equivalent at representative points.
+
+### D3: Migration governance mirrors solver compatibility governance
+
+Wave-C introduces script/workflow migration status tracking with explicit state, target wave, and deletion thresholds to prevent untracked drift.
+
+### D4: Regression-first stability for convergence points
+
+Representative points across scan/workflow routes must have deterministic baseline assertions, including parity between legacy SOP adapters and unified model-driven paths.
+
+## Target Artifacts
+
+1. Wave-C active task sheet with ordered execution checkpoints (C1 -> C2 -> C3).
+2. Wave-C implementation plan with TDD steps and verification matrix.
+3. Migration status notes for script/workflow SOP compatibility-to-unified mapping.
+4. Targeted integration/regression tests for model-driven scan/workflow parity.
+
+## Verification Strategy
+
+Wave-C minimum matrix:
+
+1. script/workflow parity smoke for representative model-driven scan points,
+2. regression stability for unified scan diagnostics/output fields,
+3. unit/integration/regression smoke reruns,
+4. docs governance checks.
+
+## Risks and Mitigations
+
+1. Risk: script path contraction changes implicit defaults.
+   - Mitigation: freeze representative parity points before routing edits.
+2. Risk: migration markers drift from real call graph.
+   - Mitigation: keep code-queryable migration status and doc mapping synchronized.
+3. Risk: model-driven parameterization introduces hidden coupling.
+   - Mitigation: isolate adapter layers and enforce single responsibility for routing.

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -63,6 +63,7 @@ export select_pressure_max_candidate
 export solve_constraint
 export solve, solve_multi, SolverResult
 export solver_migration_map
+export solver_migration_status
 export ConstraintModes
 export ProblemSpec, build_problem_spec
 export HardRule, CandidateSelector, build_candidate_context

--- a/src/models/scans/ScanCommon.jl
+++ b/src/models/scans/ScanCommon.jl
@@ -66,7 +66,7 @@ function join_messages(messages)
         push!(normalized, msg)
     end
 
-    sort!(normalized; by=_message_rank)
+    sort!(normalized; by=m -> (_message_rank(m), m))
     unique_msgs = unique(normalized)
     return join(unique_msgs, " | ")
 end
@@ -162,8 +162,8 @@ function attempt_with_candidates(candidates;
     stop_on_first_success::Bool=true,
 )
     messages = String[]
-    governance_candidates = NamedTuple[]
-    point_results = Any[]
+    governance_candidates = NamedTuple{(:pressure, :residual_norm, :hard_constraint_ok, :failed_constraints, :converged), Tuple{Float64, Float64, Bool, Vector{Symbol}, Bool}}[]
+    point_results = Union{Nothing, SolverResult}[]
     candidate_labels = String[]
 
     for candidate in candidates
@@ -200,12 +200,15 @@ function attempt_with_candidates(candidates;
         end
     end
 
+    isempty(governance_candidates) && return nothing, join_messages(messages)
+
+    has_success = any(c -> c.converged, governance_candidates)
     selected = Main.Models.select_pressure_max_candidate(governance_candidates, nothing, nothing)
     selected_idx = Int(selected.selected_index)
     selection_note = "governance.selection=$(selected.selection_reason);seed=$(candidate_labels[selected_idx])"
     push!(messages, selection_note)
 
-    selected_result = point_results[selected_idx]
+    selected_result = has_success ? point_results[selected_idx] : nothing
     return selected_result, join_messages(messages)
 end
 

--- a/src/models/scans/ScanCommon.jl
+++ b/src/models/scans/ScanCommon.jl
@@ -30,9 +30,45 @@ end
 quote_csv(msg::AbstractString) = isempty(msg) ? "" : string('"', msg, '"')
 quote_csv(::Nothing) = ""
 
+@inline function _normalized_fallback_reason(msg::AbstractString)
+    if occursin("weighted-block fallback rescued", msg)
+        return "weighted_block_rescued"
+    elseif occursin("seed[", msg) && occursin(" failed", msg)
+        return "seed_failed"
+    end
+    return ""
+end
+
+@inline function _message_rank(msg::AbstractString)
+    if startswith(msg, "governance.selection=")
+        return 1
+    elseif startswith(msg, "fallback.reason=")
+        return 2
+    end
+    return 3
+end
+
 function join_messages(messages)
-    filtered = filter(!isempty, messages)
-    return isempty(filtered) ? "" : join(filtered, " | ")
+    filtered = filter(!isempty, String.(messages))
+    isempty(filtered) && return ""
+
+    normalized = String[]
+    for msg in filtered
+        if startswith(msg, "governance.selection=")
+            push!(normalized, msg)
+            continue
+        end
+        fallback_reason = _normalized_fallback_reason(msg)
+        if !isempty(fallback_reason)
+            push!(normalized, "fallback.reason=$(fallback_reason)")
+            continue
+        end
+        push!(normalized, msg)
+    end
+
+    sort!(normalized; by=_message_rank)
+    unique_msgs = unique(normalized)
+    return join(unique_msgs, " | ")
 end
 
 function format_candidate_failure(label, message, result)
@@ -125,27 +161,47 @@ function attempt_with_candidates(candidates;
     is_success::Function,
 )
     messages = String[]
+    governance_candidates = NamedTuple[]
+    point_results = Any[]
+    candidate_labels = String[]
 
     for candidate in candidates
         result, msg = solve_point(candidate.state)
+        refine_msg = ""
+        promote_msg = ""
 
         if is_success(result)
-            refined, refine_msg = refine(result)
-            result = refined
-
+            result, refine_msg = refine(result)
             result, promote_msg = promote(result)
-
-            !isempty(msg) && push!(messages, msg)
-            !isempty(promote_msg) && push!(messages, promote_msg)
-            !isempty(refine_msg) && push!(messages, refine_msg)
-
-            return result, join_messages(messages)
         end
 
-        push!(messages, format_candidate_failure(candidate.label, msg, result))
+        success = is_success(result)
+        if success
+            !isempty(msg) && push!(messages, msg)
+            !isempty(refine_msg) && push!(messages, refine_msg)
+            !isempty(promote_msg) && push!(messages, promote_msg)
+        else
+            push!(messages, format_candidate_failure(candidate.label, msg, result))
+        end
+
+        push!(candidate_labels, String(candidate.label))
+        push!(point_results, result)
+        push!(governance_candidates, (
+            pressure=(result === nothing ? -Inf : result.pressure),
+            residual_norm=(result === nothing ? Inf : result.residual_norm),
+            hard_constraint_ok=success,
+            failed_constraints=(success ? Symbol[] : Symbol[:scan_candidate_failed]),
+            converged=success,
+        ))
     end
 
-    return nothing, join_messages(messages)
+    selected = Main.Models.select_pressure_max_candidate(governance_candidates, nothing, nothing)
+    selected_idx = Int(selected.selected_index)
+    selection_note = "governance.selection=$(selected.selection_reason);seed=$(candidate_labels[selected_idx])"
+    push!(messages, selection_note)
+
+    selected_result = point_results[selected_idx]
+    return selected_result, join_messages(messages)
 end
 
 """FixedSeedStrategy(seed)

--- a/src/models/scans/ScanCommon.jl
+++ b/src/models/scans/ScanCommon.jl
@@ -159,6 +159,7 @@ function attempt_with_candidates(candidates;
     refine::Function,
     promote::Function,
     is_success::Function,
+    stop_on_first_success::Bool=true,
 )
     messages = String[]
     governance_candidates = NamedTuple[]
@@ -193,6 +194,10 @@ function attempt_with_candidates(candidates;
             failed_constraints=(success ? Symbol[] : Symbol[:scan_candidate_failed]),
             converged=success,
         ))
+
+        if stop_on_first_success && success
+            break
+        end
     end
 
     selected = Main.Models.select_pressure_max_candidate(governance_candidates, nothing, nothing)

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -45,6 +45,15 @@ const SolverResult = ImplicitSolver.SolverResult
     ]
 end
 
+function solver_migration_status(old_entry::AbstractString)
+    for entry in solver_migration_map()
+        if entry.old_entry == old_entry
+            return (; entry..., unified_entry=entry.new_entry, route=:compat_shim, deprecation_ready=true)
+        end
+    end
+    throw(ArgumentError("unknown solver compatibility entry: $(old_entry)"))
+end
+
 function solve_constraint(model::AbstractQCDModel, mode::FixedMu, T_fm::Real; μ_fm::Real, kwargs...)
     # COMPAT: unified primary entrypoint; legacy fixedmu helper retained for migration window.
     return solve_fixedmu_constraint(model, T_fm, μ_fm; kwargs...)

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -48,7 +48,15 @@ end
 function solver_migration_status(old_entry::AbstractString)
     for entry in solver_migration_map()
         if entry.old_entry == old_entry
-            return (; entry..., unified_entry=entry.new_entry, route=:compat_shim, deprecation_ready=true)
+            return (
+                old_entry=entry.old_entry,
+                unified_entry=entry.new_entry,
+                status=entry.status,
+                removal_wave=entry.removal_wave,
+                removal_threshold=entry.removal_threshold,
+                route=:compat_shim,
+                deprecation_ready=true,
+            )
         end
     end
     throw(ArgumentError("unknown solver compatibility entry: $(old_entry)"))

--- a/tests/integration/models/test_waveb_compat_routing_smoke.jl
+++ b/tests/integration/models/test_waveb_compat_routing_smoke.jl
@@ -1,0 +1,28 @@
+using Test
+using StaticArrays
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+@testset "Wave-B compat routing smoke" begin
+    @test isdefined(Main.Models, :solver_migration_status)
+
+    status = Main.Models.solver_migration_status("Models.solve_fixedmu_constraint")
+    @test status.status == :active
+    @test status.route == :compat_shim
+    @test status.unified_entry == "Models.solve_constraint(model, FixedMu(), T; μ_fm=...)"
+
+    m = Main.Models.create_model(:NJL)
+    T = 0.5
+    seed = Float64.(Main.Models.gap_initial_guess(m, T, SVector{3}(0.0, 0.0, 0.0)))
+
+    via_unified = Main.Models.solve_constraint(m, Main.Models.FixedMu(), T; μ_fm=0.0, seed_guess=seed, p_num=24, t_num=6)
+    via_legacy = Main.Models.solve_fixedmu_constraint(m, T, 0.0; seed_guess=seed, p_num=24, t_num=6)
+
+    @test via_unified.converged == via_legacy.converged
+    @test isapprox(via_unified.pressure, via_legacy.pressure; rtol=1e-10, atol=1e-12)
+    @test isapprox(via_unified.rho_norm, via_legacy.rho_norm; rtol=1e-10, atol=1e-12)
+end

--- a/tests/regression/pnjl/test_waveb_scan_governance_stability.jl
+++ b/tests/regression/pnjl/test_waveb_scan_governance_stability.jl
@@ -1,0 +1,68 @@
+using Test
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+function _read_last_data_line(path::AbstractString)
+    lines = readlines(path)
+    length(lines) >= 2 || error("expected data rows in $(path)")
+    return lines[end]
+end
+
+@testset "Wave-B scan governance stability" begin
+    @testset "Tmu scan emits governance selection tag" begin
+        outdir = mktempdir()
+        out = joinpath(outdir, "tmu_waveb_governance.csv")
+        stats = Main.Models.run_tmu_scan(
+            T_values=[150.0],
+            mu_values=[0.0],
+            xi_values=[0.0],
+            output_path=out,
+            overwrite=true,
+            resume=false,
+            use_phase_aware=false,
+            solver_backend=:legacy,
+            p_num=12,
+            t_num=4,
+            iterations=60,
+        )
+        @test stats.total == 1
+        line = _read_last_data_line(out)
+        @test occursin("governance.selection=", line)
+    end
+
+    @testset "Trho scan emits governance selection tag" begin
+        outdir = mktempdir()
+        out = joinpath(outdir, "trho_waveb_governance.csv")
+        stats = Main.Models.run_trho_scan(
+            T_values=[150.0],
+            rho_values=[0.2],
+            xi_values=[0.0],
+            output_path=out,
+            overwrite=true,
+            resume=false,
+            reverse_rho=false,
+            seed_policy=:candidates,
+            solver_backend=:legacy,
+            p_num=12,
+            t_num=4,
+            iterations=60,
+        )
+        @test stats.total == 1
+        line = _read_last_data_line(out)
+        @test occursin("governance.selection=", line)
+    end
+
+    @testset "fallback reason tags are normalized and ordered" begin
+        msg = Main.Models.ScanCommon.join_messages([
+            "seed[quark] failed (iterations=20, residual=0.100000, converged=false): bad",
+            "hybrid weighted-block fallback rescued",
+            "governance.selection=pressure_max_under_constraints;seed=hadron",
+        ])
+
+        @test msg == "governance.selection=pressure_max_under_constraints;seed=hadron | fallback.reason=seed_failed | fallback.reason=weighted_block_rescued"
+    end
+end

--- a/tests/regression/pnjl/test_waveb_scan_governance_stability.jl
+++ b/tests/regression/pnjl/test_waveb_scan_governance_stability.jl
@@ -14,46 +14,48 @@ end
 
 @testset "Wave-B scan governance stability" begin
     @testset "Tmu scan emits governance selection tag" begin
-        outdir = mktempdir()
-        out = joinpath(outdir, "tmu_waveb_governance.csv")
-        stats = Main.Models.run_tmu_scan(
-            T_values=[150.0],
-            mu_values=[0.0],
-            xi_values=[0.0],
-            output_path=out,
-            overwrite=true,
-            resume=false,
-            use_phase_aware=false,
-            solver_backend=:legacy,
-            p_num=12,
-            t_num=4,
-            iterations=60,
-        )
-        @test stats.total == 1
-        line = _read_last_data_line(out)
-        @test occursin("governance.selection=", line)
+        mktempdir() do outdir
+            out = joinpath(outdir, "tmu_waveb_governance.csv")
+            stats = Main.Models.run_tmu_scan(
+                T_values=[150.0],
+                mu_values=[0.0],
+                xi_values=[0.0],
+                output_path=out,
+                overwrite=true,
+                resume=false,
+                use_phase_aware=false,
+                solver_backend=:legacy,
+                p_num=12,
+                t_num=4,
+                iterations=60,
+            )
+            @test stats.total == 1
+            line = _read_last_data_line(out)
+            @test occursin("governance.selection=", line)
+        end
     end
 
     @testset "Trho scan emits governance selection tag" begin
-        outdir = mktempdir()
-        out = joinpath(outdir, "trho_waveb_governance.csv")
-        stats = Main.Models.run_trho_scan(
-            T_values=[150.0],
-            rho_values=[0.2],
-            xi_values=[0.0],
-            output_path=out,
-            overwrite=true,
-            resume=false,
-            reverse_rho=false,
-            seed_policy=:candidates,
-            solver_backend=:legacy,
-            p_num=12,
-            t_num=4,
-            iterations=60,
-        )
-        @test stats.total == 1
-        line = _read_last_data_line(out)
-        @test occursin("governance.selection=", line)
+        mktempdir() do outdir
+            out = joinpath(outdir, "trho_waveb_governance.csv")
+            stats = Main.Models.run_trho_scan(
+                T_values=[150.0],
+                rho_values=[0.2],
+                xi_values=[0.0],
+                output_path=out,
+                overwrite=true,
+                resume=false,
+                reverse_rho=false,
+                seed_policy=:candidates,
+                solver_backend=:legacy,
+                p_num=12,
+                t_num=4,
+                iterations=60,
+            )
+            @test stats.total == 1
+            line = _read_last_data_line(out)
+            @test occursin("governance.selection=", line)
+        end
     end
 
     @testset "fallback reason tags are normalized and ordered" begin


### PR DESCRIPTION
## Summary
- Converge Wave-B scan candidate handling onto shared governance selection, and add stable `governance.selection=*` diagnostics in scan outputs.
- Keep compatibility entrypoints non-breaking while adding deprecation-ready migration status querying via `Models.solver_migration_status`.
- Normalize fallback diagnostics into deterministic `fallback.reason=*` tags and ordering, and add Wave-B targeted regression/integration smoke coverage plus task-sheet evidence updates.

## Review Focus
- Validate scan diagnostics compatibility impact: message normalization now prefers `governance.selection` + `fallback.reason` tags.
- Confirm deprecation-ready migration query shape for compatibility tooling (`solver_migration_status`).
- Confirm no breaking change to legacy `solve_fixed*` entrypoints.

## Verification
- julia --project=. -e 'include("tests/regression/pnjl/test_waveb_scan_governance_stability.jl")'
- julia --project=. -e 'include("tests/integration/models/test_waveb_compat_routing_smoke.jl")'
- julia --project=. -e 'ENV["UNIT_PROFILE"]="smoke"; include("tests/unit/runtests.jl")'
- julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'
- julia --project=. -e 'ENV["REGRESSION_PROFILE"]="smoke"; include("tests/regression/runtests.jl")'
- julia --project=. scripts/dev/check_docs_consistency.jl
- julia --project=. scripts/dev/check_active_docs_governance.jl