### PR TITLE
feat(models/scans): complete Wave-C scan/workflow model-driven convergence

### DIFF
--- a/docs/dev/active/2026-04-01_PNJL求解器解耦Wave-C任务单.md
+++ b/docs/dev/active/2026-04-01_PNJL求解器解耦Wave-C任务单.md
@@ -8,17 +8,17 @@
 
 ## 1. 目标
 
-- [ ] 将 Wave-B 统一治理能力延伸到扫描/工作流脚本主入口。
-- [ ] 收敛模型特化扫描 SOP 到 unified model-driven 路径。
-- [ ] 固化 Wave-C 迁移状态与稳定性回归基线。
+- [x] 将 Wave-B 统一治理能力延伸到扫描/工作流脚本主入口。
+- [x] 收敛模型特化扫描 SOP 到 unified model-driven 路径。
+- [x] 固化 Wave-C 迁移状态与稳定性回归基线。
 
 ## 2. 范围
 
 ### 2.1 本期范围
 
-- [ ] script/workflow 侧统一路由并轨。
-- [ ] 兼容适配层 migration 状态查询与台账同步。
-- [ ] model-driven 扫描输出稳定性回归。
+- [x] script/workflow 侧统一路由并轨。
+- [x] 兼容适配层 migration 状态查询与台账同步。
+- [x] model-driven 扫描输出稳定性回归。
 
 ### 2.2 非范围
 
@@ -29,44 +29,44 @@
 
 ### C1：脚本与工作流统一路由
 
-- [ ] 为 script 路径与 unified 路径等价性补失败 smoke。
-- [ ] 将 scan 脚本入口收敛到统一 model-driven API。
-- [ ] 保持 CLI/外部调用签名兼容。
+- [x] 为 script 路径与 unified 路径等价性补失败 smoke。
+- [x] 将 scan 脚本入口收敛到统一 model-driven API。
+- [x] 保持 CLI/外部调用签名兼容。
 
 ### C2：SOP 分叉收敛与迁移治理
 
-- [ ] 为兼容适配路由与迁移状态查询补失败测试。
-- [ ] 统一旧 SOP 为 compat adapter（unified-first）。
-- [ ] 更新/维护 Wave-C 扫描与工作流迁移映射台账：`docs/dev/active/2026-04-01_扫描与工作流兼容层迁移映射表_Wave-C.md`。
+- [x] 为兼容适配路由与迁移状态查询补失败测试。
+- [x] 统一旧 SOP 为 compat adapter（unified-first）。
+- [x] 更新/维护 Wave-C 扫描与工作流迁移映射台账：`docs/dev/active/2026-04-01_扫描与工作流兼容层迁移映射表_Wave-C.md`。
 
 ### C3：model-driven 稳定性回归
 
-- [ ] 为 representative points 补失败回归。
-- [ ] 统一诊断与输出顺序，保证断言稳定。
-- [ ] 验证回归可重复通过。
+- [x] 为 representative points 补失败回归。
+- [x] 统一诊断与输出顺序，保证断言稳定。
+- [x] 验证回归可重复通过。
 
 ### C4：文档治理同步
 
-- [ ] 回填 Wave-C 任务单证据与勾选状态。
-- [ ] 同步迁移状态、删除门槛与风险备注。
-- [ ] 通过 docs/governance 检查。
+- [x] 回填 Wave-C 任务单证据与勾选状态。
+- [x] 同步迁移状态、删除门槛与风险备注。
+- [x] 通过 docs/governance 检查。
 
 ## 4. 验收标准
 
-- [ ] 扫描/工作流新调用方默认走 unified model-driven 路径。
-- [ ] legacy SOP 保持 non-breaking 且行为可追溯。
-- [ ] model-driven 扫描回归稳定可复现。
-- [ ] smoke + docs/governance 通过。
+- [x] 扫描/工作流新调用方默认走 unified model-driven 路径。
+- [x] legacy SOP 保持 non-breaking 且行为可追溯。
+- [x] model-driven 扫描回归稳定可复现。
+- [x] smoke + docs/governance 通过。
 
 ## 5. 验证命令
 
-- [ ] `julia --project=. -e 'include("tests/integration/models/test_wavec_scan_workflow_parity_smoke.jl")'`
-- [ ] `julia --project=. -e 'include("tests/regression/pnjl/test_wavec_model_driven_scan_stability.jl")'`
-- [ ] `julia --project=. -e 'ENV["UNIT_PROFILE"]="smoke"; include("tests/unit/runtests.jl")'`
-- [ ] `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`
-- [ ] `julia --project=. -e 'ENV["REGRESSION_PROFILE"]="smoke"; include("tests/regression/runtests.jl")'`
-- [ ] `julia --project=. scripts/dev/check_docs_consistency.jl`
-- [ ] `julia --project=. scripts/dev/check_active_docs_governance.jl`
+- [x] `julia --project=. -e 'include("tests/integration/models/test_wavec_scan_workflow_parity_smoke.jl")'`
+- [x] `julia --project=. -e 'include("tests/regression/pnjl/test_wavec_model_driven_scan_stability.jl")'`
+- [x] `julia --project=. -e 'ENV["UNIT_PROFILE"]="smoke"; include("tests/unit/runtests.jl")'`
+- [x] `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`
+- [x] `julia --project=. -e 'ENV["REGRESSION_PROFILE"]="smoke"; include("tests/regression/runtests.jl")'`
+- [x] `julia --project=. scripts/dev/check_docs_consistency.jl`
+- [x] `julia --project=. scripts/dev/check_active_docs_governance.jl`
 
 ## 5.1 默认零上下文 agent 执行约束
 
@@ -82,10 +82,12 @@
 
 ## 6. DoD
 
-- [ ] 任务项与验收项全部勾选。
-- [ ] 关键验证命令可复现通过。
-- [ ] Wave-C 迁移台账与状态文档同步更新。
+- [x] 任务项与验收项全部勾选。
+- [x] 关键验证命令可复现通过。
+- [x] Wave-C 迁移台账与状态文档同步更新。
 
 ## 7. 执行记录
 
 - [x] 2026-04-01：创建 Wave-C 任务单草案，承接 archived 分层草案（Wave-C：扫描收敛阶段）与 Wave-B 已完成状态。
+- [x] 2026-04-01：完成 C1→C2→C3（TDD）：新增 `tests/integration/models/test_wavec_scan_workflow_parity_smoke.jl` 与 `tests/regression/pnjl/test_wavec_model_driven_scan_stability.jl`，脚本入口 `run_tmu_scan/run_dense_trho_scan/run_adaptive_trho_scan` 收敛到 model-driven 参数化路由（含 `model_kind` 兼容参数）并保持 non-breaking；新增 `Models.scan_workflow_migration_map/status` 迁移查询面并同步台账。
+- [x] 2026-04-01：完成 C4/C5 验证收口：定向测试 + unit/integration/regression smoke + docs governance 全部通过。

--- a/docs/dev/active/2026-04-01_PNJL求解器解耦Wave-D任务单.md
+++ b/docs/dev/active/2026-04-01_PNJL求解器解耦Wave-D任务单.md
@@ -1,0 +1,84 @@
+# PNJL求解器解耦 Wave-D 任务单
+
+> 执行主线说明：本任务单用于 Wave-D 的唯一执行主线（勾选、证据、验收）。
+> 设计与实现参考：
+> - `docs/superpowers/specs/2026-04-01-pnjl-solver-decoupling-wave-d-design.md`
+> - `docs/superpowers/plans/2026-04-01-pnjl-solver-decoupling-wave-d-implementation-plan.md`
+> - `docs/dev/archived/2026-03-31_PNJL求解器解耦框架约束与分层草案.md`
+
+## 1. 目标
+
+- [ ] 在阈值满足前提下完成 compat 入口清理（删除或硬弃用）。
+- [ ] 保持 solver/scan/workflow 统一 model-driven 主路径唯一性。
+- [ ] 固化 Wave-D 清理后治理可追溯性与稳定性回归基线。
+
+## 2. 范围
+
+### 2.1 本期范围
+
+- [ ] solver + scan/workflow 兼容入口阈值化清理。
+- [ ] migration 状态由 deprecation-ready 收敛到 removed/hard-deprecated。
+- [ ] 清理后 deterministic 回归与 smoke 验证。
+- [ ] 稳定公共入口变更同步更新 `docs/api/`。
+
+### 2.2 非范围
+
+- [ ] 不更换求解后端。
+- [ ] 不新增无关模型功能范围。
+
+## 3. 任务分解
+
+### D1：失败测试先行（兼容清理契约）
+
+- [ ] 为 legacy 入口清理后的期望行为补失败 integration 测试。
+- [ ] 为清理后输出稳定性补失败 regression 测试。
+- [ ] 验证失败原因与 Wave-D 目标一致。
+
+### D2：阈值化清理执行（删除或硬弃用）
+
+- [ ] `solve_fixed*` 及高风险 compat 路由默认先 hard-deprecate，阈值满足后再 remove。
+- [ ] 保留 migration 状态查询可用并标注 removed/hard-deprecated。
+- [ ] 确保统一主路径行为不变（unified-first）。
+
+### D3：迁移台账与治理同步
+
+- [ ] 更新 Wave-D 迁移映射台账：`docs/dev/active/2026-04-01_扫描与工作流兼容层迁移映射表_Wave-D.md`。
+- [ ] 回填删除门槛满足证据与回退说明。
+- [ ] 保持 docs 治理检查通过。
+
+### D4：验证矩阵与收口
+
+- [ ] 运行定向 Wave-D integration/regression。
+- [ ] 运行 unit/integration/regression smoke。
+- [ ] 运行 docs governance checks。
+- [ ] 运行 `scripts/dev/check_unit_skip_policy.jl` 并记录结果。
+- [ ] 回填任务单证据与勾选状态。
+
+## 4. 验收标准
+
+- [ ] compat 清理动作均有阈值证据与迁移映射可追溯。
+- [ ] unified model-driven 主路径为唯一稳定入口。
+- [ ] 清理后 regression/smoke 结果稳定可复现。
+- [ ] docs/governance 通过。
+
+## 5. 验证命令
+
+- [ ] `julia --project=. -e 'include("tests/integration/models/test_waved_compat_cleanup_smoke.jl")'`
+- [ ] `julia --project=. -e 'include("tests/regression/pnjl/test_waved_cleanup_stability.jl")'`
+- [ ] `julia --project=. -e 'ENV["UNIT_PROFILE"]="smoke"; include("tests/unit/runtests.jl")'`
+- [ ] `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`
+- [ ] `julia --project=. -e 'ENV["REGRESSION_PROFILE"]="smoke"; include("tests/regression/runtests.jl")'`
+- [ ] `julia --project=. scripts/dev/check_docs_consistency.jl`
+- [ ] `julia --project=. scripts/dev/check_active_docs_governance.jl`
+- [ ] `julia --project=. scripts/dev/check_unit_skip_policy.jl`
+- [ ] `docs/api/` 变更核对（如涉及稳定公共入口）
+
+## 6. DoD
+
+- [ ] 任务项与验收项全部勾选。
+- [ ] 关键验证命令可复现通过。
+- [ ] Wave-D 迁移台账与状态文档同步更新。
+
+## 7. 执行记录
+
+- [x] 2026-04-01：创建 Wave-D 三件套草案（active/spec/plan），基于 2026-03-31 分层草案与 Wave-C 收口现状，作为下一 PR 的执行主线。

--- a/docs/dev/active/2026-04-01_扫描与工作流兼容层迁移映射表_Wave-C.md
+++ b/docs/dev/active/2026-04-01_扫描与工作流兼容层迁移映射表_Wave-C.md
@@ -10,9 +10,9 @@
 
 | 兼容路径（脚本/SOP） | 统一入口 | Wave-C 状态 | 删除门槛（后续波次） | 目标波次 |
 |---|---|---|---|---|
-| `scripts/pnjl/run_tmu_scan.jl` 模型特化分支 | `Models.run_tmu_scan(...; model_kind=...)` | planned (compat adapter, unified-first) | 脚本调用方统一到 model-driven 参数化入口 + parity 回归稳定 | D |
-| `scripts/pnjl/run_dense_trho_scan.jl` 与 `scripts/pnjl/run_adaptive_trho_scan.jl` 模型特化分支 | `Models.run_trho_scan(...; model_kind=...)` | planned (compat adapter, unified-first) | 脚本调用方统一到 model-driven 参数化入口 + parity 回归稳定 | D |
-| 历史 workflow 直连脚本 SOP | `Models` 统一 workflow entrypoints | planned (compat adapter, unified-first) | workflow 侧无脚本分叉调用 + smoke/regression 稳定 | D |
+| `scripts/pnjl/run_tmu_scan.jl` 模型特化分支 | `Models.run_tmu_scan(...; model_kind=...)` | active (compat adapter, unified-first, deprecation-ready) | 脚本调用方统一到 model-driven 参数化入口 + parity 回归稳定 | D |
+| `scripts/pnjl/run_dense_trho_scan.jl` 与 `scripts/pnjl/run_adaptive_trho_scan.jl` 模型特化分支 | `Models.run_trho_scan(...; model_kind=...)` | active (compat adapter, unified-first, deprecation-ready) | 脚本调用方统一到 model-driven 参数化入口 + parity 回归稳定 | D |
+| 历史 workflow 直连脚本 SOP | `Models` 统一 workflow entrypoints | active (compat adapter, unified-first, deprecation-ready) | workflow 侧无脚本分叉调用 + smoke/regression 稳定 | D |
 
 ## Wave-C 约束
 
@@ -30,3 +30,4 @@
 ## 执行记录
 
 - [x] 2026-04-01：创建 Wave-C 扫描/工作流迁移映射表草案，作为 C2 的状态管理基线。
+- [x] 2026-04-01：实现 `Models.scan_workflow_migration_map/status` 查询面，覆盖 `run_tmu_scan`、`run_dense_trho_scan`、`run_adaptive_trho_scan` 三条 compat adapter 路由；状态更新为 active/deprecation-ready，删除门槛仍保持 Wave-D。

--- a/docs/dev/active/2026-04-01_扫描与工作流兼容层迁移映射表_Wave-D.md
+++ b/docs/dev/active/2026-04-01_扫描与工作流兼容层迁移映射表_Wave-D.md
@@ -1,0 +1,38 @@
+# 扫描与工作流兼容层迁移映射表（Wave-D）
+
+## 目标
+
+在 Wave-C deprecation-ready 基线之上，执行阈值化 compat 清理（删除或硬弃用），并保留迁移审计可追溯性。
+
+主入口：`Models.run_tmu_scan`、`Models.run_trho_scan`、`Models.solve_constraint`（及统一 entrypoints）。
+
+## 迁移映射
+
+状态字段标准枚举：`pending` / `active` / `hard_deprecated` / `removed` / `blocked`
+
+| 兼容路径（脚本/SOP） | 统一入口 | Wave-D 目标状态 | 删除/硬弃用门槛 | 风险与回退 |
+|---|---|---|---|---|
+| `scripts/pnjl/run_tmu_scan.jl` 兼容适配层 | `Models.run_tmu_scan(...; model_kind=...)` | pending (remove or hard-deprecate) | 无外部调用依赖 + 定向 parity + smoke/regression 通过 | 若外部调用未清零，先转 `hard_deprecated` 并保留错误指引 |
+| `scripts/pnjl/run_dense_trho_scan.jl` compat adapter | `Models.run_trho_scan(...; model_kind=...)` | pending (remove or hard-deprecate) | 调用方迁移完成 + 回归稳定 | 回退到 compat adapter 并记录 `blocked` 原因 |
+| `scripts/pnjl/run_adaptive_trho_scan.jl` compat adapter | `Models.run_trho_scan(...; model_kind=...)` | pending (remove or hard-deprecate) | workflow 不再依赖脚本分叉 + smoke/regression 通过 | 保留 thin adapter，延后到下一波次 |
+| 旧 solver helper compat 路由（`solve_fixed*` 族） | `Models.solve_constraint(...)` | pending (hard-deprecate-first) | 统一入口调用覆盖 + 迁移状态可查询 + 回归通过 | 默认先 `hard_deprecated`，阈值满足后再 `removed` |
+
+## Wave-D 约束
+
+- 删除动作必须有阈值证据，不按时间硬删。
+- 统一主路径行为不能被 cleanup 改写。
+- 清理后仍需可查询 migration 状态（含 removed/hard-deprecated）。
+
+## 验证建议
+
+- `julia --project=. -e 'include("tests/integration/models/test_waved_compat_cleanup_smoke.jl")'`
+- `julia --project=. -e 'include("tests/regression/pnjl/test_waved_cleanup_stability.jl")'`
+- `julia --project=. -e 'ENV["UNIT_PROFILE"]="smoke"; include("tests/unit/runtests.jl")'`
+- `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`
+- `julia --project=. -e 'ENV["REGRESSION_PROFILE"]="smoke"; include("tests/regression/runtests.jl")'`
+- `julia --project=. scripts/dev/check_docs_consistency.jl`
+- `julia --project=. scripts/dev/check_active_docs_governance.jl`
+
+## 执行记录
+
+- [x] 2026-04-01：创建 Wave-D 迁移映射表草案，承接 Wave-C active/deprecation-ready 状态，为下一 PR 的清理执行与审计留痕提供基线。

--- a/docs/superpowers/plans/2026-04-01-pnjl-solver-decoupling-wave-d-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-01-pnjl-solver-decoupling-wave-d-implementation-plan.md
@@ -1,0 +1,92 @@
+# PNJL Solver Decoupling Wave-D Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close PNJL decoupling migration by removing or hard-deprecating redundant compatibility entrypoints, preserving unified model-driven routing and governance auditability.
+
+**Architecture:** Keep Wave-A/B/C contracts intact and perform threshold-gated cleanup across solver/scan/workflow compatibility layers.
+
+**Tech Stack:** Julia (`src/models/solver/*`, `src/models/scans/*`, `src/models/entrypoints.jl`, `scripts/pnjl/*`), tests in `tests/unit|integration|regression`, docs in `docs/dev|docs/superpowers`.
+
+---
+
+## File Structure (Planned)
+
+- Modify: `src/models/solver/Solver.jl`
+- Modify: `src/models/entrypoints.jl`
+- Modify: `src/models/scans/TmuScan.jl`
+- Modify: `src/models/scans/TrhoScan.jl`
+- Modify: `src/models/Models.jl`
+- Modify (threshold-gated): `scripts/pnjl/run_tmu_scan.jl`
+- Modify (threshold-gated): `scripts/pnjl/run_dense_trho_scan.jl`
+- Modify (threshold-gated): `scripts/pnjl/run_adaptive_trho_scan.jl`
+- Create/Modify: `tests/integration/models/test_waved_compat_cleanup_smoke.jl`
+- Create/Modify: `tests/regression/pnjl/test_waved_cleanup_stability.jl`
+- Modify: `docs/dev/active/2026-04-01_PNJL求解器解耦Wave-D任务单.md`
+- Create/Modify: `docs/dev/active/2026-04-01_扫描与工作流兼容层迁移映射表_Wave-D.md`
+
+## Chunk 1: Solver/Scan Compatibility Cleanup Gate
+
+### Task D1: Add failing tests for post-Wave-C compatibility removal contract
+
+**Files:**
+- Create/Modify: `tests/integration/models/test_waved_compat_cleanup_smoke.jl`
+- Create/Modify: `tests/regression/pnjl/test_waved_cleanup_stability.jl`
+
+- [ ] **Step 1: Add failing integration tests for legacy entry behavior after cleanup threshold**
+- [ ] **Step 2: Add failing regression for diagnostics/output stability under cleaned routes**
+- [ ] **Step 3: Verify failures are expected (missing/old compat behavior)**
+
+## Chunk 2: Threshold-Gated Removal / Hard Deprecation
+
+### Task D2: Execute compat cleanup in solver + scan/workflow entrypoints
+
+**Files:**
+- Modify: `src/models/solver/Solver.jl`
+- Modify: `src/models/entrypoints.jl`
+- Modify: `src/models/scans/TmuScan.jl`
+- Modify: `src/models/scans/TrhoScan.jl`
+- Modify: `src/models/Models.jl`
+- Modify (if thresholds pass): `scripts/pnjl/run_tmu_scan.jl`
+- Modify (if thresholds pass): `scripts/pnjl/run_dense_trho_scan.jl`
+- Modify (if thresholds pass): `scripts/pnjl/run_adaptive_trho_scan.jl`
+
+- [ ] **Step 1: Apply hard-deprecate-first policy for `solve_fixed*` and high-risk compat paths; remove only after thresholds pass**
+- [ ] **Step 2: Keep migration metadata queryable with explicit `removed/hard_deprecated` state**
+- [ ] **Step 3: Ensure primary unified model-driven path remains unchanged for callers**
+- [ ] **Step 4: Re-run targeted tests and verify green**
+
+## Chunk 3: Migration Mapping and Governance Sync
+
+### Task D3: Sync migration docs and deletion thresholds evidence
+
+**Files:**
+- Modify: `docs/dev/active/2026-04-01_扫描与工作流兼容层迁移映射表_Wave-D.md`
+- Modify: `docs/dev/active/2026-04-01_PNJL求解器解耦Wave-D任务单.md`
+
+- [ ] **Step 1: Update mapping states (`active/deprecation-ready` -> `removed/hard_deprecated`)**
+- [ ] **Step 2: Backfill evidence for each removed/deprecated compat entry**
+- [ ] **Step 3: Record rollback note for high-risk cleanup points**
+- [ ] **Step 4: Sync `docs/api/` for any stable public entrypoint behavior changes**
+
+## Chunk 4: Verification Matrix and Closure
+
+### Task D4: Execute Wave-D verification matrix
+
+**Files:**
+- Create/Modify tests listed above
+
+- [ ] **Step 1: Run targeted Wave-D tests**
+  - `julia --project=. -e 'include("tests/integration/models/test_waved_compat_cleanup_smoke.jl")'`
+  - `julia --project=. -e 'include("tests/regression/pnjl/test_waved_cleanup_stability.jl")'`
+- [ ] **Step 2: Run unit smoke profile**
+  - `julia --project=. -e 'ENV["UNIT_PROFILE"]="smoke"; include("tests/unit/runtests.jl")'`
+- [ ] **Step 3: Run integration smoke profile**
+  - `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`
+- [ ] **Step 4: Run regression smoke profile**
+  - `julia --project=. -e 'ENV["REGRESSION_PROFILE"]="smoke"; include("tests/regression/runtests.jl")'`
+- [ ] **Step 5: Run docs/governance checks**
+  - `julia --project=. scripts/dev/check_unit_skip_policy.jl`
+  - `julia --project=. scripts/dev/check_docs_consistency.jl`
+  - `julia --project=. scripts/dev/check_active_docs_governance.jl`
+- [ ] **Step 6: Update Wave-D task sheet completion evidence**

--- a/docs/superpowers/specs/2026-04-01-pnjl-solver-decoupling-wave-d-design.md
+++ b/docs/superpowers/specs/2026-04-01-pnjl-solver-decoupling-wave-d-design.md
@@ -1,0 +1,69 @@
+# PNJL Solver Decoupling Wave-D Design
+
+## Context
+
+Wave-A/B/C established the decoupling baseline:
+
+1. Wave-A froze contract boundaries (`ProblemSpec`, constraint mode, governance hooks).
+2. Wave-B converged solver governance and compatibility routing metadata.
+3. Wave-C converged scan/workflow script routes to model-driven unified entrypoints, and kept compat adapters deprecation-ready.
+
+Wave-D should finish the migration by converting "deprecation-ready" into "deprecation-executed" under controlled governance.
+
+## Goals
+
+1. Remove redundant compatibility wrappers and duplicate entrypoints that are no longer needed after Wave-C.
+2. Keep a single model-driven primary path for solver + scan + workflow orchestration.
+3. Preserve auditability: every removal must map to migration evidence, tests, and docs updates.
+4. Freeze post-cleanup stability with deterministic regression/smoke coverage.
+
+## Non-Goals
+
+1. No solver backend replacement.
+2. No new model feature scope beyond migration cleanup.
+3. No broad refactor unrelated to decoupling closure and governance hardening.
+
+## Design Decisions
+
+### D1: Compatibility removal is threshold-gated, not time-gated
+
+Wave-D only removes adapters that satisfy explicit thresholds: call-site migration complete, parity coverage green, docs mapping synced.
+
+### D2: Primary path uniqueness is enforced at entrypoint level
+
+`Models.solve_constraint` + model-driven scan/workflow entrypoints remain the only stable public path. For `solve_fixed*` compat helpers, Wave-D default policy is hard-deprecate first, then remove only after thresholds are satisfied.
+
+### D3: Governance metadata must remain queryable after cleanup
+
+Even after deleting compat code, migration status query surfaces should continue to report historical mapping and removal status for auditability.
+
+### D4: Cleanup must be regression-first
+
+Every adapter removal/change is preceded by failing tests that capture expected post-removal behavior (or explicit deprecation behavior), then minimal implementation, then full smoke/governance verification.
+
+## Target Artifacts
+
+1. Wave-D active task sheet with ordered checkpoints.
+2. Wave-D implementation plan with TDD-first chunks.
+3. Updated migration mapping (state from `active/deprecation-ready` -> `removed` or `hard-deprecated`).
+4. Targeted integration/regression tests for post-cleanup stability.
+5. API docs sync notes for stable public entrypoint changes (`docs/api/`).
+
+## Verification Strategy
+
+Wave-D minimum matrix:
+
+1. targeted adapter-removal/deprecation tests,
+2. scan/workflow and solver routing regression checks,
+3. unit/integration/regression smoke reruns,
+4. docs governance checks.
+5. API docs consistency checks for exported stable entrypoints.
+
+## Risks and Mitigations
+
+1. Risk: hidden external dependency still calls compat path.
+   - Mitigation: keep explicit migration map + failure messaging + staged removal order.
+2. Risk: cleanup changes diagnostic outputs and breaks baselines.
+   - Mitigation: lock deterministic message normalization and update baselines only with evidence.
+3. Risk: over-cleanup crosses Wave-D scope.
+   - Mitigation: restrict file list and enforce non-goal checks in task sheet.

--- a/scripts/pnjl/run_adaptive_trho_scan.jl
+++ b/scripts/pnjl/run_adaptive_trho_scan.jl
@@ -7,8 +7,8 @@
 using CSV
 
 const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", ".."))
-include(joinpath(PROJECT_ROOT, "src", "constants", "Constants_PNJL.jl"))
-include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+Base.include(@__MODULE__, joinpath(PROJECT_ROOT, "src", "constants", "Constants_PNJL.jl"))
+Base.include(@__MODULE__, joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
 Models.pnjl_module()
 
 const PNJL = Models.pnjl_module()
@@ -32,6 +32,7 @@ struct AdaptiveCLIOptions
     t_num::Int
     seed_path::String
     seed_policy::Symbol
+    model_kind::Symbol
 end
 
 function parse_args(args::Vector{String})
@@ -51,6 +52,7 @@ function parse_args(args::Vector{String})
         :t_num => 8,
         :seed_path => DEFAULT_SEED_PATH,
         :seed_policy => :hybrid_continuity,
+        :model_kind => :PNJL,
     )
     i = 1
     while i <= length(args)
@@ -91,6 +93,8 @@ function parse_args(args::Vector{String})
             opts[:seed_path] = require_value()
         elseif arg == "--seed-policy"
             opts[:seed_policy] = Symbol(lowercase(require_value()))
+        elseif arg == "--model-kind"
+            opts[:model_kind] = Symbol(uppercase(require_value()))
         elseif arg in ("-h", "--help")
             print_usage()
             exit(0)
@@ -115,6 +119,7 @@ function parse_args(args::Vector{String})
         Int(opts[:t_num]),
         String(opts[:seed_path]),
         Symbol(opts[:seed_policy]),
+        Symbol(opts[:model_kind]),
     )
 end
 
@@ -134,6 +139,7 @@ function print_usage()
     println("  --p-num / --t-num <int>   透传给 TrhoScan 的积分节点")
     println("  --seed-path <path>        自定义连续种子文件")
     println("  --seed-policy <symbol>    Trho seed policy (default hybrid_continuity)")
+    println("  --model-kind <symbol>     Model kind (default PNJL, supports RPNJL)")
 end
 
 function _maybe_float(row, key::Symbol)
@@ -175,13 +181,13 @@ function load_curves(path::AbstractString; xi::Float64, tol::Float64, tmin, tmax
     return grouped
 end
 
-function plan_refinement(curves::Dict{Float64, Vector{Tuple{Float64, Float64}}}, config::AdaptiveRhoConfig)
+function plan_refinement(curves::Dict{Float64, Vector{Tuple{Float64, Float64}}}, config::AdaptiveRhoRefinement.AdaptiveRhoConfig)
     plan = Dict{Float64, Vector{Float64}}()
     for (T, samples) in curves
         length(samples) < 2 && continue
         rho_vals = Float64[s[1] for s in samples]
         mu_vals = Float64[s[2] for s in samples]
-        suggestions = suggest_refinement_points(rho_vals, mu_vals; config=config)
+        suggestions = AdaptiveRhoRefinement.suggest_refinement_points(rho_vals, mu_vals; config=config)
         if isempty(suggestions)
             continue
         end
@@ -199,7 +205,7 @@ function plan_refinement(curves::Dict{Float64, Vector{Tuple{Float64, Float64}}},
 end
 
 function run_adaptive_scan(opts::AdaptiveCLIOptions)
-    config = AdaptiveRhoConfig(; slope_tol=opts.slope_tol, min_gap=opts.min_gap, max_points=opts.max_points)
+    config = AdaptiveRhoRefinement.AdaptiveRhoConfig(; slope_tol=opts.slope_tol, min_gap=opts.min_gap, max_points=opts.max_points)
     source_path = opts.source
     for pass in 1:opts.passes
         curves = load_curves(source_path; xi=opts.xi, tol=opts.xi_tol, tmin=opts.tmin, tmax=opts.tmax)
@@ -219,6 +225,7 @@ function run_adaptive_scan(opts::AdaptiveCLIOptions)
                   output_path=opts.output,
                   seed_path=opts.seed_path,
                   seed_policy=opts.seed_policy,
+                  model_kind=opts.model_kind,
                   overwrite=false,
                   resume=opts.resume,
                   p_num=opts.p_num,
@@ -230,9 +237,11 @@ function run_adaptive_scan(opts::AdaptiveCLIOptions)
     end
 end
 
-function main()
-    opts = parse_args(copy(ARGS))
+function main(args=ARGS)
+    opts = parse_args(copy(args))
     run_adaptive_scan(opts)
 end
 
-main()
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/scripts/pnjl/run_adaptive_trho_scan.jl
+++ b/scripts/pnjl/run_adaptive_trho_scan.jl
@@ -103,6 +103,8 @@ function parse_args(args::Vector{String})
         end
         i += 1
     end
+    model_kind = Symbol(opts[:model_kind])
+    model_kind in (:PNJL, :RPNJL) || throw(ArgumentError("invalid --model-kind=$(model_kind), accepted: PNJL|RPNJL"))
     return AdaptiveCLIOptions(
         String(opts[:source]),
         String(opts[:output]),
@@ -119,7 +121,7 @@ function parse_args(args::Vector{String})
         Int(opts[:t_num]),
         String(opts[:seed_path]),
         Symbol(opts[:seed_policy]),
-        Symbol(opts[:model_kind]),
+        model_kind,
     )
 end
 

--- a/scripts/pnjl/run_dense_trho_scan.jl
+++ b/scripts/pnjl/run_dense_trho_scan.jl
@@ -8,8 +8,8 @@ results to the main CSV for CEP/Maxwell analysis.
 """
 
 const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", ".."))
-include(joinpath(PROJECT_ROOT, "src", "constants", "Constants_PNJL.jl"))
-include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+Base.include(@__MODULE__, joinpath(PROJECT_ROOT, "src", "constants", "Constants_PNJL.jl"))
+Base.include(@__MODULE__, joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
 
 using .Models: run_trho_scan, build_default_rho_grid
 
@@ -32,6 +32,7 @@ struct DenseScanOptions
     p_num::Int
     t_num::Int
     seed_policy::Symbol
+    model_kind::Symbol
 end
 
 function parse_args(args::Vector{String})
@@ -54,6 +55,7 @@ function parse_args(args::Vector{String})
         :p_num => 24,
         :t_num => 8,
         :seed_policy => :hybrid_continuity,
+        :model_kind => :PNJL,
     )
     i = 1
     while i <= length(args)
@@ -110,6 +112,8 @@ function parse_args(args::Vector{String})
             opts[:t_num] = parse(Int, require_value())
         elseif arg == "--seed-policy"
             opts[:seed_policy] = Symbol(lowercase(require_value()))
+        elseif arg == "--model-kind"
+            opts[:model_kind] = Symbol(uppercase(require_value()))
         elseif arg in ("-h", "--help")
             print_usage()
             exit(0)
@@ -148,6 +152,7 @@ function parse_args(args::Vector{String})
         Int(opts[:p_num]),
         Int(opts[:t_num]),
         Symbol(opts[:seed_policy]),
+        Symbol(opts[:model_kind]),
     )
 end
 
@@ -172,6 +177,7 @@ function print_usage()
     println("  --p-num <int>               Momentum grid size (pass-through)")
     println("  --t-num <int>               Theta grid size (pass-through)")
     println("  --seed-policy <symbol>      Trho seed policy (default hybrid_continuity)")
+    println("  --model-kind <symbol>       Model kind (default PNJL, supports RPNJL)")
     println("  -h, --help                  Show this help text")
 end
 
@@ -201,7 +207,8 @@ function run_dense_scan(opts::DenseScanOptions)
           output_path=opts.output,
           overwrite=opts.overwrite,
           resume=opts.resume,
-            seed_policy=opts.seed_policy,
+          seed_policy=opts.seed_policy,
+          model_kind=opts.model_kind,
           p_num=opts.p_num,
           t_num=opts.t_num,
     )
@@ -209,9 +216,11 @@ function run_dense_scan(opts::DenseScanOptions)
     println("Output written to $(stats.output)")
 end
 
-function main()
-    opts = parse_args(copy(ARGS))
+function main(args=ARGS)
+    opts = parse_args(copy(args))
     run_dense_scan(opts)
 end
 
-main()
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/scripts/pnjl/run_dense_trho_scan.jl
+++ b/scripts/pnjl/run_dense_trho_scan.jl
@@ -133,6 +133,8 @@ function parse_args(args::Vector{String})
     opts[:medium_step] > 0 || error("medium_step must be positive")
     opts[:fine_step] > 0 || error("fine_step must be positive")
     opts[:ultra_step] > 0 || error("ultra_step must be positive")
+    model_kind = Symbol(opts[:model_kind])
+    model_kind in (:PNJL, :RPNJL) || throw(ArgumentError("invalid --model-kind=$(model_kind), accepted: PNJL|RPNJL"))
     return DenseScanOptions(
         String(opts[:output]),
         Float64.(xi_vals),
@@ -152,7 +154,7 @@ function parse_args(args::Vector{String})
         Int(opts[:p_num]),
         Int(opts[:t_num]),
         Symbol(opts[:seed_policy]),
-        Symbol(opts[:model_kind]),
+        model_kind,
     )
 end
 

--- a/scripts/pnjl/run_tmu_scan.jl
+++ b/scripts/pnjl/run_tmu_scan.jl
@@ -26,6 +26,7 @@ PNJL T-μ 参数空间扫描脚本
     --overwrite       覆盖已有文件
     --no_phase_aware  禁用相变感知策略
     --solver_backend=models 求解后端：models | legacy | auto（默认 models）
+    --model_kind=PNJL  模型类型：PNJL | RPNJL（默认 PNJL）
     --p_num=24        动量积分节点数
     --t_num=8         角度积分节点数
     --verbose         详细输出
@@ -63,6 +64,7 @@ PNJL T-μ 参数空间扫描脚本
     --overwrite       覆盖已有文件
     --no_phase_aware  禁用相变感知策略
     --solver_backend=models 求解后端：models | legacy | auto（默认 models）
+    --model_kind=PNJL  模型类型：PNJL | RPNJL（默认 PNJL）
     --p_num=24        动量积分节点数
     --t_num=8         角度积分节点数
     --verbose         详细输出
@@ -76,8 +78,8 @@ using Printf
 using Dates
 
 # 加载模块
-include(joinpath(@__DIR__, "..", "..", "src", "constants", "Constants_PNJL.jl"))
-include(joinpath(@__DIR__, "..", "..", "src", "models", "Models.jl"))
+Base.include(@__MODULE__, joinpath(@__DIR__, "..", "..", "src", "constants", "Constants_PNJL.jl"))
+Base.include(@__MODULE__, joinpath(@__DIR__, "..", "..", "src", "models", "Models.jl"))
 
 using .Models: run_tmu_scan
 
@@ -104,6 +106,7 @@ if !isdefined(Main, :ScriptTmuScanConfig)
         overwrite::Bool
         use_phase_aware::Bool
         solver_backend::Symbol
+        model_kind::Symbol
         p_num::Int
         t_num::Int
         verbose::Bool
@@ -126,6 +129,7 @@ function parse_args(args)
     overwrite = false
     use_phase_aware = true
     solver_backend = :models
+    model_kind = :PNJL
     p_num = 24
     t_num = 8
     verbose = false
@@ -162,6 +166,8 @@ function parse_args(args)
             use_phase_aware = false
         elseif startswith(arg, "--solver_backend=")
             solver_backend = Symbol(arg[18:end])
+        elseif startswith(arg, "--model_kind=")
+            model_kind = Symbol(uppercase(arg[14:end]))
         elseif startswith(arg, "--p_num=")
             p_num = parse(Int, arg[9:end])
         elseif startswith(arg, "--t_num=")
@@ -178,6 +184,7 @@ function parse_args(args)
 
     mode in (:scan, :point) || throw(ArgumentError("invalid --mode=$(mode), accepted: scan|point"))
     solver_backend in (:models, :legacy, :auto) || throw(ArgumentError("invalid --solver_backend=$(solver_backend), accepted: models|legacy|auto"))
+    model_kind in (:PNJL, :RPNJL) || throw(ArgumentError("invalid --model_kind=$(model_kind), accepted: PNJL|RPNJL"))
     
     # 默认输出路径
     if isempty(output_path)
@@ -189,7 +196,7 @@ function parse_args(args)
         mode,
         xi, T_min, T_max, T_step, mu_min, mu_max, mu_step,
         T_mev, mu_mev,
-        output_path, resume, overwrite, use_phase_aware, solver_backend, p_num, t_num, verbose
+        output_path, resume, overwrite, use_phase_aware, solver_backend, model_kind, p_num, t_num, verbose
     )
 end
 
@@ -217,6 +224,7 @@ function main(args=ARGS)
     end
     println("  积分节点: p_num=$(config.p_num), t_num=$(config.t_num)")
     println("  求解后端: $(config.solver_backend)")
+    println("  模型类型: $(config.model_kind)")
     println("  相变感知: $(config.use_phase_aware ? "启用" : "禁用")")
     println("  断点续扫: $(config.resume ? "启用" : "禁用")")
     println("  输出文件: $(config.output_path)")
@@ -286,6 +294,7 @@ function main(args=ARGS)
         resume = config.resume,
         use_phase_aware = config.use_phase_aware,
         solver_backend = config.solver_backend,
+        model_kind = config.model_kind,
         p_num = config.p_num,
         t_num = config.t_num,
         progress_cb = progress_cb

--- a/src/models/entrypoints.jl
+++ b/src/models/entrypoints.jl
@@ -10,6 +10,7 @@ Models 统一流程入口（阶段 C）：
 """
 
 export run_tmu_scan, run_trho_scan, build_default_rho_grid
+export scan_workflow_migration_map, scan_workflow_migration_status
 export default_scan_numeric_options, solve_pnjl_point
 export solve_gap_and_transport, solve_transport_from_equilibrium
 export solve_gap_and_meson_point
@@ -39,6 +40,49 @@ end
         error("MesonMassWorkflow module loaded but required API (solve_gap_and_meson_point) is missing")
     end
     return workflow
+end
+
+@inline function scan_workflow_migration_map()
+    return [
+        (
+            old_entry="scripts/pnjl/run_tmu_scan.jl",
+            new_entry="Models.run_tmu_scan(...; model_kind=...)",
+            status=:active,
+            removal_wave=:D,
+            removal_threshold="script callers fully migrate to model-driven entrypoint and parity regression remains stable",
+        ),
+        (
+            old_entry="scripts/pnjl/run_dense_trho_scan.jl",
+            new_entry="Models.run_trho_scan(...; model_kind=...)",
+            status=:active,
+            removal_wave=:D,
+            removal_threshold="script callers fully migrate to model-driven entrypoint and parity regression remains stable",
+        ),
+        (
+            old_entry="scripts/pnjl/run_adaptive_trho_scan.jl",
+            new_entry="Models.run_trho_scan(...; model_kind=...)",
+            status=:active,
+            removal_wave=:D,
+            removal_threshold="workflow routes no longer rely on script SOP forks and smoke/regression stay stable",
+        ),
+    ]
+end
+
+function scan_workflow_migration_status(old_entry::AbstractString)
+    for entry in scan_workflow_migration_map()
+        if entry.old_entry == old_entry
+            return (
+                old_entry=entry.old_entry,
+                unified_entry=entry.new_entry,
+                status=entry.status,
+                removal_wave=entry.removal_wave,
+                removal_threshold=entry.removal_threshold,
+                route=:compat_adapter,
+                deprecation_ready=true,
+            )
+        end
+    end
+    throw(ArgumentError("unknown scan/workflow compatibility entry: $(old_entry)"))
 end
 
 function run_tmu_scan(args...; kwargs...)

--- a/src/models/scans/TmuScan.jl
+++ b/src/models/scans/TmuScan.jl
@@ -95,6 +95,9 @@ end
         throw(ArgumentError("solver_backend must be :legacy, :models or :auto, got $(solver_backend)"))
     (model_kind === :PNJL || model_kind === :RPNJL) ||
         throw(ArgumentError("model_kind must be :PNJL or :RPNJL, got $(model_kind)"))
+    if solver_backend === :legacy && model_kind !== :PNJL
+        throw(ArgumentError("legacy solver_backend only supports model_kind = :PNJL, got $(model_kind)"))
+    end
     return nothing
 end
 

--- a/src/models/scans/TmuScan.jl
+++ b/src/models/scans/TmuScan.jl
@@ -86,13 +86,15 @@ const HEADER = join((
     return nothing
 end
 
-@inline function _validate_tmu_scan_inputs(T_values, mu_values, xi_values, solver_backend::Symbol)
+@inline function _validate_tmu_scan_inputs(T_values, mu_values, xi_values, solver_backend::Symbol, model_kind::Symbol)
     _validate_real_vector(:T_values, T_values)
     _validate_real_vector(:mu_values, mu_values)
     _validate_real_vector(:xi_values, xi_values)
 
     (solver_backend === :legacy || solver_backend === :models || solver_backend === :auto) ||
         throw(ArgumentError("solver_backend must be :legacy, :models or :auto, got $(solver_backend)"))
+    (model_kind === :PNJL || model_kind === :RPNJL) ||
+        throw(ArgumentError("model_kind must be :PNJL or :RPNJL, got $(model_kind)"))
     return nothing
 end
 
@@ -146,12 +148,13 @@ function run_tmu_scan(;
     use_phase_aware::Bool=true,
     bootstrap_multiseed::Bool=true,
     solver_backend::Symbol=:legacy,
+    model_kind::Symbol=:PNJL,
     p_num::Int=24,
     t_num::Int=8,
     progress_cb::Union{Nothing, Function}=nothing,
     nlsolve_kwargs...
 )
-    _validate_tmu_scan_inputs(T_values, mu_values, xi_values, solver_backend)
+    _validate_tmu_scan_inputs(T_values, mu_values, xi_values, solver_backend, model_kind)
 
     mkpath(dirname(output_path))
     completed = (resume && !overwrite && isfile(output_path)) ? ScanCommon.load_completed_keys3(output_path; digits=6) : Set{NTuple{3, Float64}}()
@@ -211,6 +214,7 @@ function run_tmu_scan(;
                     if tracker !== nothing && bootstrap_multiseed && tracker.previous_solution === nothing
                         result, message = _solve_point_with_seed_strategy(T_fm, μ_fm, xi, tracker;
                             solver_backend=solver_backend,
+                            model_kind=model_kind,
                             p_num=p_num,
                             t_num=t_num,
                             nlsolve_kwargs...)
@@ -222,6 +226,7 @@ function run_tmu_scan(;
 
                         result, message = _attempt_with_candidates(T_fm, μ_fm, xi, candidates;
                             solver_backend=solver_backend,
+                            model_kind=model_kind,
                             p_num=p_num,
                             t_num=t_num,
                             nlsolve_kwargs...)
@@ -324,18 +329,21 @@ end
 """尝试多个初值候选"""
 function _attempt_with_candidates(T_fm, μ_fm, xi, candidates;
     solver_backend::Symbol=:legacy,
+    model_kind::Symbol=:PNJL,
     p_num,
     t_num,
     nlsolve_kwargs...)
     return ScanCommon.attempt_with_candidates(candidates;
         solve_point=seed_state -> _solve_point(T_fm, μ_fm, xi, seed_state;
             solver_backend=solver_backend,
+            model_kind=model_kind,
             p_num=p_num,
             t_num=t_num,
             nlsolve_kwargs...,
         ),
         refine=result -> _refine_result(T_fm, μ_fm, xi, result;
             solver_backend=solver_backend,
+            model_kind=model_kind,
             p_num=p_num,
             t_num=t_num,
             nlsolve_kwargs...,
@@ -348,6 +356,7 @@ end
 """单点求解"""
 function _solve_point(T_fm, μ_fm, xi, seed_state;
     solver_backend::Symbol=:legacy,
+    model_kind::Symbol=:PNJL,
     p_num,
     t_num,
     nlsolve_kwargs...)
@@ -363,7 +372,7 @@ function _solve_point(T_fm, μ_fm, xi, seed_state;
         result = if effective_solver_backend === :models
             _solve_with_models(FixedMu(), T_fm, μ_fm;
                 xi=xi,
-                model_kind=:PNJL,
+                model_kind=model_kind,
                 seed_strategy=strategy,
                 p_num=p_num,
                 t_num=t_num,
@@ -382,7 +391,7 @@ function _solve_point(T_fm, μ_fm, xi, seed_state;
             solver_backend=effective_solver_backend,
             p_num=p_num,
             t_num=t_num,
-            model_kind=:PNJL,
+            model_kind=model_kind,
         )
         return result, ""
     catch err
@@ -396,6 +405,7 @@ end
 """单点求解：直接使用一个 SeedStrategy（用于 PhaseAwareContinuitySeed 的 MultiSeed 自举路径）"""
 function _solve_point_with_seed_strategy(T_fm, μ_fm, xi, seed_strategy::SeedStrategy;
     solver_backend::Symbol=:legacy,
+    model_kind::Symbol=:PNJL,
     p_num,
     t_num,
     nlsolve_kwargs...)
@@ -407,7 +417,7 @@ function _solve_point_with_seed_strategy(T_fm, μ_fm, xi, seed_strategy::SeedStr
         result = if effective_solver_backend === :models
             _solve_with_models(FixedMu(), T_fm, μ_fm;
                 xi=xi,
-                model_kind=:PNJL,
+                model_kind=model_kind,
                 seed_strategy=seed_strategy,
                 p_num=p_num,
                 t_num=t_num,
@@ -426,7 +436,7 @@ function _solve_point_with_seed_strategy(T_fm, μ_fm, xi, seed_strategy::SeedStr
             solver_backend=effective_solver_backend,
             p_num=p_num,
             t_num=t_num,
-            model_kind=:PNJL,
+            model_kind=model_kind,
         )
         return result, "bootstrap_multiseed"
     catch err
@@ -440,6 +450,7 @@ end
 """精炼近似收敛的结果"""
 function _refine_result(T_fm, μ_fm, xi, result;
     solver_backend::Symbol=:legacy,
+    model_kind::Symbol=:PNJL,
     p_num,
     t_num,
     nlsolve_kwargs...)
@@ -448,6 +459,7 @@ function _refine_result(T_fm, μ_fm, xi, result;
         acceptable_residual=ACCEPTABLE_RESIDUAL,
         solve_again=seed -> _solve_point(T_fm, μ_fm, xi, seed;
             solver_backend=solver_backend,
+            model_kind=model_kind,
             p_num=p_num,
             t_num=t_num,
             nlsolve_kwargs...,

--- a/tests/integration/models/test_wavec_scan_workflow_parity_smoke.jl
+++ b/tests/integration/models/test_wavec_scan_workflow_parity_smoke.jl
@@ -89,6 +89,15 @@ end
     ])
     @test getfield(dense_cfg, :model_kind) == :RPNJL
 
+    dense_err = try
+        getfield(dense_script, :parse_args)(["--model-kind", "bad_model"])
+        nothing
+    catch exc
+        exc
+    end
+    @test dense_err isa ArgumentError
+    @test occursin("accepted: PNJL|RPNJL", sprint(showerror, dense_err))
+
     adaptive_script_path = joinpath(PROJECT_ROOT, "scripts", "pnjl", "run_adaptive_trho_scan.jl")
     adaptive_script = Module(:WaveCAdaptiveScript)
     Base.include(adaptive_script, adaptive_script_path)
@@ -100,4 +109,16 @@ end
         "--model-kind", "pnjl",
     ])
     @test getfield(adaptive_cfg, :model_kind) == :PNJL
+
+    adaptive_err = try
+        getfield(adaptive_script, :parse_args)([
+            "--source", joinpath(PROJECT_ROOT, "data", "outputs", "results", "pnjl", "scan", "trho", "trho_scan.csv"),
+            "--model-kind", "bad_model",
+        ])
+        nothing
+    catch exc
+        exc
+    end
+    @test adaptive_err isa ArgumentError
+    @test occursin("accepted: PNJL|RPNJL", sprint(showerror, adaptive_err))
 end

--- a/tests/integration/models/test_wavec_scan_workflow_parity_smoke.jl
+++ b/tests/integration/models/test_wavec_scan_workflow_parity_smoke.jl
@@ -1,0 +1,103 @@
+using Test
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+@testset "Wave-C scan/workflow parity smoke" begin
+    @test isdefined(Main.Models, :scan_workflow_migration_status)
+
+    migration = Main.Models.scan_workflow_migration_status("scripts/pnjl/run_tmu_scan.jl")
+    @test migration.status == :active
+    @test migration.route == :compat_adapter
+    @test migration.unified_entry == "Models.run_tmu_scan(...; model_kind=...)"
+    @test migration.removal_wave == :D
+
+    tmu_script_path = joinpath(PROJECT_ROOT, "scripts", "pnjl", "run_tmu_scan.jl")
+    tmu_script = Module(:WaveCTmuScript)
+    Base.include(tmu_script, tmu_script_path)
+
+    @test isdefined(tmu_script, :ScriptTmuScanConfig)
+    @test hasfield(getfield(tmu_script, :ScriptTmuScanConfig), :model_kind)
+
+    cfg = getfield(tmu_script, :parse_args)([
+        "--mode=point",
+        "--T_mev=150",
+        "--mu_mev=0",
+        "--xi=0.0",
+        "--no_phase_aware",
+        "--solver_backend=models",
+        "--model_kind=PNJL",
+        "--p_num=8",
+        "--t_num=4",
+        "--verbose",
+    ])
+    @test getfield(cfg, :model_kind) == :PNJL
+
+    mktempdir() do outdir
+        script_out = joinpath(outdir, "script_tmu.csv")
+        unified_out = joinpath(outdir, "unified_tmu.csv")
+
+        via_script = getfield(tmu_script, :main)([
+            "--mode=point",
+            "--T_mev=150",
+            "--mu_mev=0",
+            "--xi=0.0",
+            "--output=$(script_out)",
+            "--overwrite",
+            "--no_phase_aware",
+            "--solver_backend=models",
+            "--model_kind=PNJL",
+            "--p_num=8",
+            "--t_num=4",
+        ])
+
+        via_unified = Main.Models.run_tmu_scan(
+            T_values=[150.0],
+            mu_values=[0.0],
+            xi_values=[0.0],
+            output_path=unified_out,
+            overwrite=true,
+            resume=false,
+            use_phase_aware=false,
+            solver_backend=:models,
+            model_kind=:PNJL,
+            p_num=8,
+            t_num=4,
+        )
+
+        @test via_script.total == via_unified.total == 1
+        @test via_script.success == via_unified.success
+        @test via_script.failure == via_unified.failure
+    end
+
+    dense_script_path = joinpath(PROJECT_ROOT, "scripts", "pnjl", "run_dense_trho_scan.jl")
+    dense_script = Module(:WaveCDenseScript)
+    Base.include(dense_script, dense_script_path)
+    @test isdefined(dense_script, :DenseScanOptions)
+    @test hasfield(getfield(dense_script, :DenseScanOptions), :model_kind)
+
+    dense_cfg = getfield(dense_script, :parse_args)([
+        "--tmin", "130.0",
+        "--tmax", "130.0",
+        "--tstep", "1.0",
+        "--rho-max", "0.2",
+        "--coarse-step", "0.2",
+        "--model-kind", "rpnjl",
+    ])
+    @test getfield(dense_cfg, :model_kind) == :RPNJL
+
+    adaptive_script_path = joinpath(PROJECT_ROOT, "scripts", "pnjl", "run_adaptive_trho_scan.jl")
+    adaptive_script = Module(:WaveCAdaptiveScript)
+    Base.include(adaptive_script, adaptive_script_path)
+    @test isdefined(adaptive_script, :AdaptiveCLIOptions)
+    @test hasfield(getfield(adaptive_script, :AdaptiveCLIOptions), :model_kind)
+
+    adaptive_cfg = getfield(adaptive_script, :parse_args)([
+        "--source", joinpath(PROJECT_ROOT, "data", "outputs", "results", "pnjl", "scan", "trho", "trho_scan.csv"),
+        "--model-kind", "pnjl",
+    ])
+    @test getfield(adaptive_cfg, :model_kind) == :PNJL
+end

--- a/tests/regression/pnjl/test_wavec_model_driven_scan_stability.jl
+++ b/tests/regression/pnjl/test_wavec_model_driven_scan_stability.jl
@@ -13,6 +13,29 @@ function _read_data_line(path::AbstractString)
 end
 
 @testset "Wave-C model-driven scan stability" begin
+    @testset "legacy backend rejects non-PNJL model_kind" begin
+        err = try
+            Main.Models.run_tmu_scan(
+                T_values=[150.0],
+                mu_values=[0.0],
+                xi_values=[0.0],
+                output_path=joinpath(mktempdir(), "legacy_guard.csv"),
+                overwrite=true,
+                resume=false,
+                use_phase_aware=false,
+                solver_backend=:legacy,
+                model_kind=:RPNJL,
+                p_num=8,
+                t_num=4,
+            )
+            nothing
+        catch exc
+            exc
+        end
+        @test err isa ArgumentError
+        @test occursin("legacy solver_backend only supports model_kind = :PNJL", sprint(showerror, err))
+    end
+
     @testset "Tmu model-driven outputs stay deterministic" begin
         mktempdir() do outdir
             out_pnjl_a = joinpath(outdir, "tmu_pnjl_a.csv")

--- a/tests/regression/pnjl/test_wavec_model_driven_scan_stability.jl
+++ b/tests/regression/pnjl/test_wavec_model_driven_scan_stability.jl
@@ -14,26 +14,28 @@ end
 
 @testset "Wave-C model-driven scan stability" begin
     @testset "legacy backend rejects non-PNJL model_kind" begin
-        err = try
-            Main.Models.run_tmu_scan(
-                T_values=[150.0],
-                mu_values=[0.0],
-                xi_values=[0.0],
-                output_path=joinpath(mktempdir(), "legacy_guard.csv"),
-                overwrite=true,
-                resume=false,
-                use_phase_aware=false,
-                solver_backend=:legacy,
-                model_kind=:RPNJL,
-                p_num=8,
-                t_num=4,
-            )
-            nothing
-        catch exc
-            exc
+        mktempdir() do outdir
+            err = try
+                Main.Models.run_tmu_scan(
+                    T_values=[150.0],
+                    mu_values=[0.0],
+                    xi_values=[0.0],
+                    output_path=joinpath(outdir, "legacy_guard.csv"),
+                    overwrite=true,
+                    resume=false,
+                    use_phase_aware=false,
+                    solver_backend=:legacy,
+                    model_kind=:RPNJL,
+                    p_num=8,
+                    t_num=4,
+                )
+                nothing
+            catch exc
+                exc
+            end
+            @test err isa ArgumentError
+            @test occursin("legacy solver_backend only supports model_kind = :PNJL", sprint(showerror, err))
         end
-        @test err isa ArgumentError
-        @test occursin("legacy solver_backend only supports model_kind = :PNJL", sprint(showerror, err))
     end
 
     @testset "Tmu model-driven outputs stay deterministic" begin

--- a/tests/regression/pnjl/test_wavec_model_driven_scan_stability.jl
+++ b/tests/regression/pnjl/test_wavec_model_driven_scan_stability.jl
@@ -1,0 +1,76 @@
+using Test
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+function _read_data_line(path::AbstractString)
+    lines = readlines(path)
+    length(lines) == 2 || error("expected exactly one data row in $(path)")
+    return lines[2]
+end
+
+@testset "Wave-C model-driven scan stability" begin
+    @testset "Tmu model-driven outputs stay deterministic" begin
+        mktempdir() do outdir
+            out_pnjl_a = joinpath(outdir, "tmu_pnjl_a.csv")
+            out_pnjl_b = joinpath(outdir, "tmu_pnjl_b.csv")
+            out_rpnjl = joinpath(outdir, "tmu_rpnjl.csv")
+
+            stats_pnjl_a = Main.Models.run_tmu_scan(
+                T_values=[150.0],
+                mu_values=[0.0],
+                xi_values=[0.0],
+                output_path=out_pnjl_a,
+                overwrite=true,
+                resume=false,
+                use_phase_aware=false,
+                solver_backend=:models,
+                model_kind=:PNJL,
+                p_num=8,
+                t_num=4,
+            )
+            stats_pnjl_b = Main.Models.run_tmu_scan(
+                T_values=[150.0],
+                mu_values=[0.0],
+                xi_values=[0.0],
+                output_path=out_pnjl_b,
+                overwrite=true,
+                resume=false,
+                use_phase_aware=false,
+                solver_backend=:models,
+                model_kind=:PNJL,
+                p_num=8,
+                t_num=4,
+            )
+            stats_rpnjl = Main.Models.run_tmu_scan(
+                T_values=[150.0],
+                mu_values=[0.0],
+                xi_values=[0.0],
+                output_path=out_rpnjl,
+                overwrite=true,
+                resume=false,
+                use_phase_aware=false,
+                solver_backend=:models,
+                model_kind=:RPNJL,
+                p_num=8,
+                t_num=4,
+            )
+
+            @test stats_pnjl_a.total == 1
+            @test stats_pnjl_b.total == 1
+            @test stats_rpnjl.total == 1
+
+            line_pnjl_a = _read_data_line(out_pnjl_a)
+            line_pnjl_b = _read_data_line(out_pnjl_b)
+            line_rpnjl = _read_data_line(out_rpnjl)
+            @test line_pnjl_a == line_pnjl_b
+            @test occursin("governance.selection=", line_pnjl_a)
+            @test occursin("governance.selection=", line_rpnjl)
+
+            @test length(split(line_pnjl_a, ',')) == length(split(line_rpnjl, ','))
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- Converge Wave-C scan script adapters (`run_tmu_scan`, `run_dense_trho_scan`, `run_adaptive_trho_scan`) onto unified model-driven entrypoints with `model_kind` pass-through while keeping non-breaking CLI compatibility.
- Add Wave-C migration governance query surface (`Models.scan_workflow_migration_map/status`) and synchronize active task/evidence plus migration mapping docs.
- Add Wave-C parity/stability coverage via targeted integration/regression tests, then verify with targeted tests + unit/integration/regression smoke + docs governance checks.

## Verification
- `julia --project=. -e 'include("tests/integration/models/test_wavec_scan_workflow_parity_smoke.jl")'`
- `julia --project=. -e 'include("tests/regression/pnjl/test_wavec_model_driven_scan_stability.jl")'`
- `julia --project=. -e 'ENV["UNIT_PROFILE"]="smoke"; include("tests/unit/runtests.jl")'`
- `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`
- `julia --project=. -e 'ENV["REGRESSION_PROFILE"]="smoke"; include("tests/regression/runtests.jl")'`
- `julia --project=. scripts/dev/check_docs_consistency.jl`
- `julia --project=. scripts/dev/check_active_docs_governance.jl`