### PR TITLE
feat(models/solver): start R1 semantic convergence implementation

### DIFF
--- a/docs/api/models/solver/ConstraintModes.md
+++ b/docs/api/models/solver/ConstraintModes.md
@@ -59,6 +59,23 @@
 
 这类接口多数更偏维护者或算法开发者，但必须在主题中说明清楚，因为它们定义了 `solve` 系列入口背后的问题形式。
 
+## `ProblemSpec` 与组件化约束主链（R1）
+
+在 R1 迭代中，`FixedRho` 已支持通过 `ProblemSpec` 进入主链：
+
+- `build_problem_spec(mode)` 提供 mode 对应的默认求解契约
+- `solve_constraint(...; problem_spec=spec)` 可显式指定契约
+- `FixedRho` 的 `ProblemSpec.forward_solve` 已使用统一候选治理规则
+
+配套组件层通过 `build_constraint_components(mode)` 暴露 mode 到约束职责的映射，用于固定“语义同构”口径。当前核心组件语义包括：
+
+- `StationarityComponent`
+- `EqualMuComponent`
+- `FixedBaryonDensityComponent`
+- `AsymmetricDensityComponent`
+- `FixedEntropyComponent`
+- `FixedSigmaComponent`
+
 ## 为什么这部分不应继续只放在旧 `pnjl` 页面
 
 约束模式本质上已经是 `Models` 的公共合同，而不只是 legacy PNJL 的内部文档主题。继续把它们主要留在旧页，会让新用户误以为 `Models` 只有流程 façade，没有自己的求解合同。

--- a/docs/api/models/solver/CoreConcepts.md
+++ b/docs/api/models/solver/CoreConcepts.md
@@ -43,6 +43,20 @@
 
 因此，约束模式不是一个装饰标签，而是直接决定 residual 构造和求解形态的合同对象。
 
+## 4.1 ProblemSpec 与 ConstraintComponents 的职责边界
+
+R1 收敛后，`FixedRho` 主链不再只依赖“单个大 residual 函数”，而是通过“问题规格 + 组件映射”组织：
+
+- `ProblemSpec`：描述某个 mode 的求解契约（`conditions` / `forward_solve` / selector / hard_rules）
+- `ConstraintComponents`：描述约束由哪些职责组件拼接（stationarity、equal-mu、macro targets 等）
+
+这种分层的作用是把“语义定义”与“数值策略”分开：
+
+- 语义定义由 `ConstraintModes + ConstraintComponents` 冻结
+- 数值策略由 `forward_solve` 与候选治理规则演进
+
+在当前实现中，`FixedRho` 的 `ProblemSpec.forward_solve` 已进入显式候选池 + 统一 hard constraints + selector 路径，避免语义漂移被隐藏在特化分支内。
+
 ## 5. Seed strategy 负责“怎么开始”，不负责“怎么收尾”
 
 `SeedStrategy` 家族的职责是给求解器提供初值，而不是代替求解器决定所有分支逻辑。

--- a/docs/api/models/solver/README.md
+++ b/docs/api/models/solver/README.md
@@ -26,6 +26,8 @@
 - `Models.solve`
 - `Models.solve_multi`
 - `Models.solve_constraint`
+- `Models.ProblemSpec` / `Models.build_problem_spec`
+- `Models.AbstractConstraintComponent` / `Models.build_constraint_components`
 - `Models.MeanFieldState` / `Models.meanfield_state` / `Models.state_vector`
 - `Models.ConstraintModes`
 - `Models.SeedStrategy` 家族

--- a/docs/api/models/solver/generated/Exports.md
+++ b/docs/api/models/solver/generated/Exports.md
@@ -13,18 +13,18 @@
 | Symbol | Source files | Export lines | Mentioned in docs | Example docs |
 | --- | --- | ---: | ---: | --- |
 | `ConstraintModes` | src/models/Models.jl | 61 | 4 | docs/api/models/solver/ConstraintModes.md<br>docs/api/models/solver/CoreConcepts.md<br>docs/api/models/solver/Overview.md |
-| `ContinuitySeed` | src/models/Models.jl | 64 | 5 | docs/api/models/scans/Algorithms.md<br>docs/api/models/scans/TmuScan.md<br>docs/api/models/solver/CoreConcepts.md |
-| `DefaultSeed` | src/models/Models.jl | 64 | 2 | docs/api/models/solver/CoreConcepts.md<br>docs/api/models/solver/SeedStrategies.md |
-| `GapParams` | src/models/Models.jl | 67 | 1 | docs/api/models/solver/ConstraintModes.md |
-| `HybridContinuitySeed` | src/models/Models.jl | 64 | 2 | docs/api/models/solver/CoreConcepts.md<br>docs/api/models/solver/SeedStrategies.md |
+| `ContinuitySeed` | src/models/Models.jl | 66 | 5 | docs/api/models/scans/Algorithms.md<br>docs/api/models/scans/TmuScan.md<br>docs/api/models/solver/CoreConcepts.md |
+| `DefaultSeed` | src/models/Models.jl | 66 | 2 | docs/api/models/solver/CoreConcepts.md<br>docs/api/models/solver/SeedStrategies.md |
+| `GapParams` | src/models/Models.jl | 69 | 1 | docs/api/models/solver/ConstraintModes.md |
+| `HybridContinuitySeed` | src/models/Models.jl | 66 | 2 | docs/api/models/solver/CoreConcepts.md<br>docs/api/models/solver/SeedStrategies.md |
 | `MeanFieldState` | src/models/Models.jl | 34 | 6 | docs/api/data_contracts.md<br>docs/api/models/solver/CoreConcepts.md<br>docs/api/models/solver/Overview.md |
 | `ModelStateSchema` | src/models/Models.jl | 60 | 2 | docs/api/models/solver/ConstraintModes.md<br>docs/api/models/solver/Overview.md |
-| `MultiSeed` | src/models/Models.jl | 64 | 2 | docs/api/models/solver/CoreConcepts.md<br>docs/api/models/solver/SeedStrategies.md |
-| `PhaseAwareContinuitySeed` | src/models/Models.jl | 64 | 5 | docs/api/models/scans/Algorithms.md<br>docs/api/models/scans/TmuScan.md<br>docs/api/models/solver/CoreConcepts.md |
-| `PhaseAwareSeed` | src/models/Models.jl | 64 | 2 | docs/api/models/solver/CoreConcepts.md<br>docs/api/models/solver/SeedStrategies.md |
-| `SeedStrategy` | src/models/Models.jl | 64 | 4 | docs/api/models/solver/CoreConcepts.md<br>docs/api/models/solver/Overview.md<br>docs/api/models/solver/README.md |
-| `build_conditions` | src/models/Models.jl | 67 | 2 | docs/api/models/solver/ConstraintModes.md<br>docs/api/models/solver/Overview.md |
-| `build_residual!` | src/models/Models.jl | 67 | 2 | docs/api/models/solver/ConstraintModes.md<br>docs/api/models/solver/Overview.md |
+| `MultiSeed` | src/models/Models.jl | 66 | 2 | docs/api/models/solver/CoreConcepts.md<br>docs/api/models/solver/SeedStrategies.md |
+| `PhaseAwareContinuitySeed` | src/models/Models.jl | 66 | 5 | docs/api/models/scans/Algorithms.md<br>docs/api/models/scans/TmuScan.md<br>docs/api/models/solver/CoreConcepts.md |
+| `PhaseAwareSeed` | src/models/Models.jl | 66 | 2 | docs/api/models/solver/CoreConcepts.md<br>docs/api/models/solver/SeedStrategies.md |
+| `SeedStrategy` | src/models/Models.jl | 66 | 4 | docs/api/models/solver/CoreConcepts.md<br>docs/api/models/solver/Overview.md<br>docs/api/models/solver/README.md |
+| `build_conditions` | src/models/Models.jl | 69 | 2 | docs/api/models/solver/ConstraintModes.md<br>docs/api/models/solver/Overview.md |
+| `build_residual!` | src/models/Models.jl | 69 | 2 | docs/api/models/solver/ConstraintModes.md<br>docs/api/models/solver/Overview.md |
 | `create_flavor_mu_implicit_gap_solver` | src/models/Models.jl | 40 | 3 | docs/api/models/solver/CoreConcepts.md<br>docs/api/models/solver/ImplicitSolvers.md<br>docs/api/models/solver/README.md |
 | `create_implicit_gap_solver` | src/models/Models.jl | 39 | 4 | docs/api/models/solver/CoreConcepts.md<br>docs/api/models/solver/ImplicitSolvers.md<br>docs/api/models/solver/Overview.md |
 | `create_model` | src/models/Models.jl | 29 | 6 | docs/api/data_contracts.md<br>docs/api/models/solver/CoreConcepts.md<br>docs/api/models/solver/Overview.md |
@@ -32,20 +32,20 @@
 | `flatten_state` | src/models/Models.jl | 60 | 2 | docs/api/models/solver/ConstraintModes.md<br>docs/api/models/solver/Overview.md |
 | `gap_residual` | src/models/Models.jl | 38 | 2 | docs/api/models/solver/ConstraintModes.md<br>docs/api/models/solver/ImplicitSolvers.md |
 | `gap_state_dim` | src/models/Models.jl | 38 | 2 | docs/api/data_contracts.md<br>docs/api/models/solver/ConstraintModes.md |
-| `get_all_seeds` | src/models/Models.jl | 65 | 1 | docs/api/models/solver/SeedStrategies.md |
-| `get_seed` | src/models/Models.jl | 65 | 1 | docs/api/models/solver/SeedStrategies.md |
+| `get_all_seeds` | src/models/Models.jl | 67 | 1 | docs/api/models/solver/SeedStrategies.md |
+| `get_seed` | src/models/Models.jl | 67 | 1 | docs/api/models/solver/SeedStrategies.md |
 | `meanfield_state` | src/models/Models.jl | 35 | 3 | docs/api/data_contracts.md<br>docs/api/models/solver/README.md<br>docs/api/models/solver/StateContract.md |
 | `normalize_mu_vec` | src/models/Models.jl | 36 | 3 | docs/api/data_contracts.md<br>docs/api/models/solver/Overview.md<br>docs/api/models/solver/StateContract.md |
-| `reset!` | src/models/Models.jl | 65 | 2 | docs/api/models/scans/TmuScan.md<br>docs/api/models/solver/SeedStrategies.md |
+| `reset!` | src/models/Models.jl | 67 | 2 | docs/api/models/scans/TmuScan.md<br>docs/api/models/solver/SeedStrategies.md |
 | `schema_for_model` | src/models/Models.jl | 60 | 2 | docs/api/models/solver/ConstraintModes.md<br>docs/api/models/solver/Overview.md |
-| `set_phase!` | src/models/Models.jl | 65 | 1 | docs/api/models/solver/SeedStrategies.md |
+| `set_phase!` | src/models/Models.jl | 67 | 1 | docs/api/models/solver/SeedStrategies.md |
 | `solve` | src/models/Models.jl | 59 | 41 | docs/api/PARAMETER_TYPES_API.md<br>docs/api/README.md<br>docs/api/data_contracts.md |
 | `solve_constraint` | src/models/Models.jl | 58 | 3 | docs/api/models/solver/ConstraintModes.md<br>docs/api/models/solver/Overview.md<br>docs/api/models/solver/README.md |
 | `solve_gap` | src/models/Models.jl | 37 | 21 | docs/api/PARAMETER_TYPES_API.md<br>docs/api/data_contracts.md<br>docs/api/models/solver/CoreConcepts.md |
 | `solve_multi` | src/models/Models.jl | 59 | 4 | docs/api/models/solver/CoreConcepts.md<br>docs/api/models/solver/Overview.md<br>docs/api/models/solver/README.md |
 | `state_vector` | src/models/Models.jl | 35 | 5 | docs/api/data_contracts.md<br>docs/api/models/solver/CoreConcepts.md<br>docs/api/models/solver/Overview.md |
 | `unflatten_state` | src/models/Models.jl | 60 | 2 | docs/api/models/solver/ConstraintModes.md<br>docs/api/models/solver/Overview.md |
-| `update!` | src/models/Models.jl | 65 | 1 | docs/api/models/solver/SeedStrategies.md |
+| `update!` | src/models/Models.jl | 67 | 1 | docs/api/models/solver/SeedStrategies.md |
 
 ## Undocumented Or Not Yet Mentioned
 

--- a/docs/dev/active/2026-04-02_auto-legacy求解器语义同构与模式收敛任务单.md
+++ b/docs/dev/active/2026-04-02_auto-legacy求解器语义同构与模式收敛任务单.md
@@ -84,10 +84,10 @@
 
 ### A4：验证、文档与治理
 
-- [ ] unit：覆盖组件拼接、维度检查、FixedRho/AsymRho 等价性。
-- [ ] integration：覆盖 T-μ/T-ρ 扫描行为与 auto/backend 一致性。
-- [ ] regression：覆盖关键固定点与首阶附近点的分支稳定性。
-- [ ] benchmark：`scripts/perf/pnjl/scan_perf.jl` 收敛率基线不退化。
+- [x] unit：覆盖组件拼接、维度检查、FixedRho/AsymRho 等价性。
+- [x] integration：覆盖 T-μ/T-ρ 扫描行为与 auto/backend 一致性。
+- [x] regression：覆盖关键固定点与首阶附近点的分支稳定性。
+- [x] benchmark：`scripts/perf/pnjl/scan_perf.jl` 收敛率基线不退化。
 - [ ] 同步 `docs/api/models/solver/*` 与相关迁移文档口径。
 
 ---
@@ -314,3 +314,9 @@
 - [x] 2026-04-02：R1 A3 完成（PR #49）。
   - `TmuScan/TrhoScan` 中 PNJL `solver_backend=:auto` 默认路由改为 `:models`；新增受控开关 `auto_pnjl_backend` 支持回退 `:legacy`。
   - 新增 `tests/integration/models/test_auto_backend_models_routing_smoke.jl`，并复核 `test_solver_backend_semantic_parity_guard.jl`。
+- [x] 2026-04-02：完成 A4 验证矩阵（除 API 文档同步项）。
+  - unit smoke：`781/781` 通过。
+  - integration smoke：`402/402` 通过。
+  - regression smoke：`530 pass, 1 broken(optional fixture)`，与既有可选跳过口径一致。
+  - benchmark smoke：`scripts/perf/pnjl/scan_perf.jl` 收敛率 100%，无退化证据。
+  - 治理检查：`check_docs_consistency.jl` 与 `check_active_docs_governance.jl` 通过。

--- a/docs/dev/active/2026-04-02_auto-legacy求解器语义同构与模式收敛任务单.md
+++ b/docs/dev/active/2026-04-02_auto-legacy求解器语义同构与模式收敛任务单.md
@@ -303,3 +303,4 @@
   - integration smoke：`394/394` 通过。
   - regression smoke：`512 pass, 1 broken(optional fixture)`，与既有可选跳过口径一致。
   - 文档治理：`check_docs_consistency.jl` 与 `check_active_docs_governance.jl` 均通过。
+- [x] 2026-04-02：创建 R1 开发分支 `feat/models-solver-semantic-convergence-r1`，按 stacked PR 方式基于 PR #48 开启下一轮功能开发（PR #49）。

--- a/docs/dev/active/2026-04-02_auto-legacy求解器语义同构与模式收敛任务单.md
+++ b/docs/dev/active/2026-04-02_auto-legacy求解器语义同构与模式收敛任务单.md
@@ -88,7 +88,7 @@
 - [x] integration：覆盖 T-μ/T-ρ 扫描行为与 auto/backend 一致性。
 - [x] regression：覆盖关键固定点与首阶附近点的分支稳定性。
 - [x] benchmark：`scripts/perf/pnjl/scan_perf.jl` 收敛率基线不退化。
-- [ ] 同步 `docs/api/models/solver/*` 与相关迁移文档口径。
+- [x] 同步 `docs/api/models/solver/*` 与相关迁移文档口径。
 
 ---
 
@@ -320,3 +320,6 @@
   - regression smoke：`530 pass, 1 broken(optional fixture)`，与既有可选跳过口径一致。
   - benchmark smoke：`scripts/perf/pnjl/scan_perf.jl` 收敛率 100%，无退化证据。
   - 治理检查：`check_docs_consistency.jl` 与 `check_active_docs_governance.jl` 通过。
+- [x] 2026-04-02：完成 `docs/api/models/solver/*` 文档口径同步。
+  - 更新 `README.md`、`CoreConcepts.md`、`ConstraintModes.md`，补充 `ProblemSpec` 与 `ConstraintComponents` 的 R1 主链语义。
+  - 通过脚本重生成 `docs/api/models/solver/generated/Exports.md`（`generate_api_export_index.jl`）。

--- a/docs/dev/active/2026-04-02_auto-legacy求解器语义同构与模式收敛任务单.md
+++ b/docs/dev/active/2026-04-02_auto-legacy求解器语义同构与模式收敛任务单.md
@@ -57,30 +57,30 @@
 
 ### A0：约束组件抽象层（先测试后实现）
 
-- [ ] 新增失败单测：约束组件可声明输出维度、依赖变量域（state/mu/thermo）。
-- [ ] 定义约束组件契约（建议：`constraint_dim`, `eval_constraint!`, `constraint_name`）。
-- [ ] 将现有 `Fixed*` mode 映射为组件列表，而非写死残差函数。
-- [ ] 验证组件拼接后 residual 总维度一致性（静态检查 + 运行时检查）。
+- [x] 新增失败单测：约束组件可声明输出维度、依赖变量域（state/mu/thermo）。
+- [x] 定义约束组件契约（建议：`constraint_dim`, `eval_constraint!`, `constraint_name`）。
+- [x] 将现有 `Fixed*` mode 映射为组件列表，而非写死残差函数。
+- [x] 验证组件拼接后 residual 总维度一致性（静态检查 + 运行时检查）。
 
 ### A1：ProblemSpec 主链收敛
 
-- [ ] 新增失败测试：`build_problem_spec(mode)` 生成的 residual 能覆盖 `FixedRho/FixedAsymmetricRho`。
-- [ ] 将 `ProblemSpec` 从占位结构升级为执行主链（residual/forward_solve/postprocess 同步接线）。
-- [ ] 让 `solve_constraint` 统一走 `ProblemSpec`，仅保留必要适配层。
-- [ ] 对旧特化路径加迁移标记，禁止继续扩散新逻辑。
+- [x] 新增失败测试：`build_problem_spec(mode)` 生成的 residual 能覆盖 `FixedRho/FixedAsymmetricRho`。
+- [x] 将 `ProblemSpec` 从占位结构升级为执行主链（residual/forward_solve/postprocess 同步接线）。
+- [x] 让 `solve_constraint` 统一走 `ProblemSpec`，仅保留必要适配层。
+- [x] 对旧特化路径加迁移标记，禁止继续扩散新逻辑。
 
 ### A2：FixedRho 同构化改造
 
-- [ ] 新增失败回归：同点同 seed 下 `legacy` 与 `models` 的 residual 口径一致（容差内）。
-- [ ] 将 `models FixedRho` 改为组件拼接后的联立约束主链（而非外1维内5维特化主链）。
-- [ ] 保留可控 fallback，但 fallback 仅做数值稳健兜底，不改变语义定义。
-- [ ] 补充 branch 选择与候选治理规则（pressure/physicality/residual 的统一优先级）。
+- [x] 新增失败回归：同点同 seed 下 `legacy` 与 `models` 的 residual 口径一致（容差内）。
+- [x] 将 `models FixedRho` 改为组件拼接后的联立约束主链（而非外1维内5维特化主链）。
+- [x] 保留可控 fallback，但 fallback 仅做数值稳健兜底，不改变语义定义。
+- [x] 补充 branch 选择与候选治理规则（pressure/physicality/residual 的统一优先级）。
 
 ### A3：扫描入口与 backend 语义收敛
 
-- [ ] 新增失败 integration：`solver_backend=:auto` 与显式 backend 在语义一致时结果一致。
-- [ ] 统一 `auto` 解释为“按 model capability 选实现，不改语义定义”。
-- [ ] 去除 PNJL 上仅因历史差异导致的永久路由特判（以阶段开关受控下线）。
+- [x] 新增失败 integration：`solver_backend=:auto` 与显式 backend 在语义一致时结果一致。
+- [x] 统一 `auto` 解释为“按 model capability 选实现，不改语义定义”。
+- [x] 去除 PNJL 上仅因历史差异导致的永久路由特判（以阶段开关受控下线）。
 
 ### A4：验证、文档与治理
 
@@ -304,3 +304,13 @@
   - regression smoke：`512 pass, 1 broken(optional fixture)`，与既有可选跳过口径一致。
   - 文档治理：`check_docs_consistency.jl` 与 `check_active_docs_governance.jl` 均通过。
 - [x] 2026-04-02：创建 R1 开发分支 `feat/models-solver-semantic-convergence-r1`，按 stacked PR 方式基于 PR #48 开启下一轮功能开发（PR #49）。
+- [x] 2026-04-02：R1 A0/A1 首批完成（PR #49）。
+  - 新增 `src/models/solver/ConstraintComponents.jl`，建立 `AbstractConstraintComponent` 契约及默认 mode->components 映射。
+  - `build_problem_spec` 接线 `conditions` 与 `forward_solve`，并通过 `tests/unit/models/test_constraint_components.jl` / `test_problem_spec_contract.jl`。
+- [x] 2026-04-02：R1 A2 深化完成（PR #49）。
+  - `FixedRho` 的 `ProblemSpec.forward_solve` 升级为显式候选池 + 统一 hard constraints + selector 治理。
+  - `solve_constraint(FixedRho)` 支持 `problem_spec` 优先链路；不传时保持兼容旧链路。
+  - 新增对照：`tests/integration/models/test_problem_spec_fixedrho_forwardsolve_smoke.jl`、`tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl`。
+- [x] 2026-04-02：R1 A3 完成（PR #49）。
+  - `TmuScan/TrhoScan` 中 PNJL `solver_backend=:auto` 默认路由改为 `:models`；新增受控开关 `auto_pnjl_backend` 支持回退 `:legacy`。
+  - 新增 `tests/integration/models/test_auto_backend_models_routing_smoke.jl`，并复核 `test_solver_backend_semantic_parity_guard.jl`。

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -60,6 +60,8 @@ export solve, solve_multi, SolverResult
 export ModelStateSchema, schema_for_model, flatten_state, unflatten_state
 export ConstraintModes
 export ProblemSpec, build_problem_spec
+export AbstractConstraintComponent
+export constraint_name, constraint_dim, build_constraint_components, constraint_total_dim
 export HardRule, CandidateSelector, build_candidate_context
 export SeedStrategy, DefaultSeed, MultiSeed, ContinuitySeed, HybridContinuitySeed, PhaseAwareSeed, PhaseAwareContinuitySeed
 export get_seed, update!, reset!, get_all_seeds, set_phase!
@@ -153,6 +155,7 @@ include(joinpath(@__DIR__, "gap_solver.jl"))
 include(joinpath(@__DIR__, "implicit_gap.jl"))
 include(joinpath(@__DIR__, "constraint_solver.jl"))
 include(joinpath(@__DIR__, "solver", "ConstraintModes.jl"))
+include(joinpath(@__DIR__, "solver", "ConstraintComponents.jl"))
 include(joinpath(@__DIR__, "solver", "ProblemSpec.jl"))
 include(joinpath(@__DIR__, "solver", "StateSchema.jl"))
 include(joinpath(@__DIR__, "solver", "CandidateGovernance.jl"))

--- a/src/models/scans/TmuScan.jl
+++ b/src/models/scans/TmuScan.jl
@@ -107,11 +107,14 @@ end
     return nothing
 end
 
-@inline function _effective_solver_backend(solver_backend::Symbol, model_kind::Symbol)::Symbol
+@inline function _effective_solver_backend(solver_backend::Symbol, model_kind::Symbol; auto_pnjl_backend::Symbol=:models)::Symbol
     if solver_backend !== :auto
         return solver_backend
     end
-    return model_kind === :PNJL ? :legacy : :models
+    if model_kind === :PNJL
+        return auto_pnjl_backend
+    end
+    return :models
 end
 
 # ============================================================================
@@ -160,6 +163,7 @@ function run_tmu_scan(;
     use_phase_aware::Bool=true,
     bootstrap_multiseed::Bool=true,
     solver_backend::Symbol=:auto,
+    auto_pnjl_backend::Symbol=:models,
     model_kind::Symbol=:PNJL,
     p_num::Int=24,
     t_num::Int=8,
@@ -226,6 +230,7 @@ function run_tmu_scan(;
                     if tracker !== nothing && bootstrap_multiseed && tracker.previous_solution === nothing
                         result, message = _solve_point_with_seed_strategy(T_fm, μ_fm, xi, tracker;
                             solver_backend=solver_backend,
+                            auto_pnjl_backend=auto_pnjl_backend,
                             model_kind=model_kind,
                             p_num=p_num,
                             t_num=t_num,
@@ -238,6 +243,7 @@ function run_tmu_scan(;
 
                         result, message = _attempt_with_candidates(T_fm, μ_fm, xi, candidates;
                             solver_backend=solver_backend,
+                            auto_pnjl_backend=auto_pnjl_backend,
                             model_kind=model_kind,
                             p_num=p_num,
                             t_num=t_num,
@@ -341,6 +347,7 @@ end
 """尝试多个初值候选"""
 function _attempt_with_candidates(T_fm, μ_fm, xi, candidates;
     solver_backend::Symbol=:auto,
+    auto_pnjl_backend::Symbol=:models,
     model_kind::Symbol=:PNJL,
     p_num,
     t_num,
@@ -348,6 +355,7 @@ function _attempt_with_candidates(T_fm, μ_fm, xi, candidates;
     return ScanCommon.attempt_with_candidates(candidates;
         solve_point=seed_state -> _solve_point(T_fm, μ_fm, xi, seed_state;
             solver_backend=solver_backend,
+            auto_pnjl_backend=auto_pnjl_backend,
             model_kind=model_kind,
             p_num=p_num,
             t_num=t_num,
@@ -355,6 +363,7 @@ function _attempt_with_candidates(T_fm, μ_fm, xi, candidates;
         ),
         refine=result -> _refine_result(T_fm, μ_fm, xi, result;
             solver_backend=solver_backend,
+            auto_pnjl_backend=auto_pnjl_backend,
             model_kind=model_kind,
             p_num=p_num,
             t_num=t_num,
@@ -368,12 +377,13 @@ end
 """单点求解"""
 function _solve_point(T_fm, μ_fm, xi, seed_state;
     solver_backend::Symbol=:auto,
+    auto_pnjl_backend::Symbol=:models,
     model_kind::Symbol=:PNJL,
     p_num,
     t_num,
     nlsolve_kwargs...)
     try
-        effective_solver_backend = _effective_solver_backend(solver_backend, model_kind)
+        effective_solver_backend = _effective_solver_backend(solver_backend, model_kind; auto_pnjl_backend=auto_pnjl_backend)
         (effective_solver_backend === :legacy || effective_solver_backend === :models) ||
             error("unknown solver_backend=$solver_backend (expected :legacy, :models or :auto)")
 
@@ -417,12 +427,13 @@ end
 """单点求解：直接使用一个 SeedStrategy（用于 PhaseAwareContinuitySeed 的 MultiSeed 自举路径）"""
 function _solve_point_with_seed_strategy(T_fm, μ_fm, xi, seed_strategy::SeedStrategy;
     solver_backend::Symbol=:auto,
+    auto_pnjl_backend::Symbol=:models,
     model_kind::Symbol=:PNJL,
     p_num,
     t_num,
     nlsolve_kwargs...)
     try
-        effective_solver_backend = _effective_solver_backend(solver_backend, model_kind)
+        effective_solver_backend = _effective_solver_backend(solver_backend, model_kind; auto_pnjl_backend=auto_pnjl_backend)
         (effective_solver_backend === :legacy || effective_solver_backend === :models) ||
             error("unknown solver_backend=$solver_backend (expected :legacy, :models or :auto)")
 
@@ -462,6 +473,7 @@ end
 """精炼近似收敛的结果"""
 function _refine_result(T_fm, μ_fm, xi, result;
     solver_backend::Symbol=:auto,
+    auto_pnjl_backend::Symbol=:models,
     model_kind::Symbol=:PNJL,
     p_num,
     t_num,
@@ -471,6 +483,7 @@ function _refine_result(T_fm, μ_fm, xi, result;
         acceptable_residual=ACCEPTABLE_RESIDUAL,
         solve_again=seed -> _solve_point(T_fm, μ_fm, xi, seed;
             solver_backend=solver_backend,
+            auto_pnjl_backend=auto_pnjl_backend,
             model_kind=model_kind,
             p_num=p_num,
             t_num=t_num,

--- a/src/models/scans/TrhoScan.jl
+++ b/src/models/scans/TrhoScan.jl
@@ -151,11 +151,14 @@ end
     return nothing
 end
 
-@inline function _effective_solver_backend(solver_backend::Symbol, model_kind::Symbol)::Symbol
+@inline function _effective_solver_backend(solver_backend::Symbol, model_kind::Symbol; auto_pnjl_backend::Symbol=:models)::Symbol
     if solver_backend !== :auto
         return solver_backend
     end
-    return model_kind === :PNJL ? :legacy : :models
+    if model_kind === :PNJL
+        return auto_pnjl_backend
+    end
+    return :models
 end
 
 # ============================================================================
@@ -207,6 +210,7 @@ function run_trho_scan(;
     asym_ud_ratio_target::Float64=0.876,
     asym_s_target::Float64=0.0,
     solver_backend::Symbol=:auto,
+    auto_pnjl_backend::Symbol=:models,
     model_kind::Symbol=:PNJL,
     p_num::Int=24,
     t_num::Int=8,
@@ -265,6 +269,7 @@ function run_trho_scan(;
                     asym_ud_ratio_target=asym_ud_ratio_target,
                     asym_s_target=asym_s_target,
                     solver_backend=solver_backend,
+                    auto_pnjl_backend=auto_pnjl_backend,
                     model_kind=model_kind,
                     p_num=p_num, t_num=t_num, nlsolve_kwargs...)
             else
@@ -275,6 +280,7 @@ function run_trho_scan(;
                     asym_ud_ratio_target=asym_ud_ratio_target,
                     asym_s_target=asym_s_target,
                     solver_backend=solver_backend,
+                    auto_pnjl_backend=auto_pnjl_backend,
                     model_kind=model_kind,
                     p_num=p_num, t_num=t_num, nlsolve_kwargs...)
 
@@ -384,6 +390,7 @@ function _attempt_with_candidates(T_fm, rho, xi, candidates;
     asym_ud_ratio_target::Float64=0.876,
     asym_s_target::Float64=0.0,
     solver_backend::Symbol=:auto,
+    auto_pnjl_backend::Symbol=:models,
     model_kind::Symbol=:PNJL,
     p_num,
     t_num,
@@ -394,6 +401,7 @@ function _attempt_with_candidates(T_fm, rho, xi, candidates;
             asym_ud_ratio_target=asym_ud_ratio_target,
             asym_s_target=asym_s_target,
             solver_backend=solver_backend,
+            auto_pnjl_backend=auto_pnjl_backend,
             model_kind=model_kind,
             p_num=p_num,
             t_num=t_num,
@@ -404,6 +412,7 @@ function _attempt_with_candidates(T_fm, rho, xi, candidates;
             asym_ud_ratio_target=asym_ud_ratio_target,
             asym_s_target=asym_s_target,
             solver_backend=solver_backend,
+            auto_pnjl_backend=auto_pnjl_backend,
             model_kind=model_kind,
             p_num=p_num,
             t_num=t_num,
@@ -422,12 +431,13 @@ function _attempt_with_strategy(T_fm, rho, xi, strategy::SeedStrategy;
     asym_ud_ratio_target::Float64=0.876,
     asym_s_target::Float64=0.0,
     solver_backend::Symbol=:auto,
+    auto_pnjl_backend::Symbol=:models,
     model_kind::Symbol=:PNJL,
     p_num,
     t_num,
     nlsolve_kwargs...)
 
-    effective_solver_backend = _effective_solver_backend(solver_backend, model_kind)
+    effective_solver_backend = _effective_solver_backend(solver_backend, model_kind; auto_pnjl_backend=auto_pnjl_backend)
 
     mode = if constraint_mode === :fixed_rho
         FixedRho(rho)
@@ -487,6 +497,7 @@ function _attempt_with_strategy(T_fm, rho, xi, strategy::SeedStrategy;
             asym_ud_ratio_target=asym_ud_ratio_target,
             asym_s_target=asym_s_target,
             solver_backend=solver_backend,
+            auto_pnjl_backend=auto_pnjl_backend,
             model_kind=model_kind,
             p_num=p_num,
             t_num=t_num,
@@ -543,12 +554,13 @@ function _solve_point(T_fm, rho_target, xi, seed_state;
     asym_ud_ratio_target::Float64=0.876,
     asym_s_target::Float64=0.0,
     solver_backend::Symbol=:auto,
+    auto_pnjl_backend::Symbol=:models,
     model_kind::Symbol=:PNJL,
     p_num,
     t_num,
     nlsolve_kwargs...)
     try
-        effective_solver_backend = _effective_solver_backend(solver_backend, model_kind)
+        effective_solver_backend = _effective_solver_backend(solver_backend, model_kind; auto_pnjl_backend=auto_pnjl_backend)
         (effective_solver_backend === :legacy || effective_solver_backend === :models) ||
             error("unknown solver_backend=$solver_backend (expected :legacy, :models or :auto)")
 
@@ -620,6 +632,7 @@ function _refine_result(T_fm, ρ_fm, xi, result;
     asym_ud_ratio_target::Float64=0.876,
     asym_s_target::Float64=0.0,
     solver_backend::Symbol=:auto,
+    auto_pnjl_backend::Symbol=:models,
     model_kind::Symbol=:PNJL,
     p_num,
     t_num,
@@ -632,6 +645,7 @@ function _refine_result(T_fm, ρ_fm, xi, result;
             asym_ud_ratio_target=asym_ud_ratio_target,
             asym_s_target=asym_s_target,
             solver_backend=solver_backend,
+            auto_pnjl_backend=auto_pnjl_backend,
             model_kind=model_kind,
             p_num=p_num,
             t_num=t_num,

--- a/src/models/solver/ConstraintComponents.jl
+++ b/src/models/solver/ConstraintComponents.jl
@@ -1,0 +1,67 @@
+"""
+    ConstraintComponents
+
+约束组件契约与默认组件映射。
+"""
+
+abstract type AbstractConstraintComponent end
+
+struct StationarityComponent <: AbstractConstraintComponent end
+struct EqualMuComponent <: AbstractConstraintComponent end
+struct FixedBaryonDensityComponent <: AbstractConstraintComponent end
+struct FixedEntropyComponent <: AbstractConstraintComponent end
+struct FixedSigmaComponent <: AbstractConstraintComponent end
+struct AsymmetricDensityComponent <: AbstractConstraintComponent end
+
+@inline constraint_name(::StationarityComponent) = :stationarity
+@inline constraint_name(::EqualMuComponent) = :equal_mu
+@inline constraint_name(::FixedBaryonDensityComponent) = :fixed_baryon_density
+@inline constraint_name(::FixedEntropyComponent) = :fixed_entropy
+@inline constraint_name(::FixedSigmaComponent) = :fixed_sigma
+@inline constraint_name(::AsymmetricDensityComponent) = :asymmetric_density
+
+@inline constraint_dim(::StationarityComponent) = 5
+@inline constraint_dim(::EqualMuComponent) = 2
+@inline constraint_dim(::FixedBaryonDensityComponent) = 1
+@inline constraint_dim(::FixedEntropyComponent) = 1
+@inline constraint_dim(::FixedSigmaComponent) = 1
+@inline constraint_dim(::AsymmetricDensityComponent) = 3
+
+@inline function build_constraint_components(::FixedMu)
+    return AbstractConstraintComponent[
+        StationarityComponent(),
+    ]
+end
+
+@inline function build_constraint_components(::FixedRho)
+    return AbstractConstraintComponent[
+        StationarityComponent(),
+        EqualMuComponent(),
+        FixedBaryonDensityComponent(),
+    ]
+end
+
+@inline function build_constraint_components(::FixedAsymmetricRho)
+    return AbstractConstraintComponent[
+        StationarityComponent(),
+        AsymmetricDensityComponent(),
+    ]
+end
+
+@inline function build_constraint_components(::FixedEntropy)
+    return AbstractConstraintComponent[
+        StationarityComponent(),
+        EqualMuComponent(),
+        FixedEntropyComponent(),
+    ]
+end
+
+@inline function build_constraint_components(::FixedSigma)
+    return AbstractConstraintComponent[
+        StationarityComponent(),
+        EqualMuComponent(),
+        FixedSigmaComponent(),
+    ]
+end
+
+@inline constraint_total_dim(components::AbstractVector{<:AbstractConstraintComponent}) = sum(constraint_dim, components)

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -38,5 +38,14 @@ end
 @inline _unimplemented_conditions(theta, x, meta, cfg, mode) = throw(ArgumentError("conditions is not configured for $(typeof(mode))"))
 
 @inline function build_problem_spec(mode::ConstraintMode; kwargs...)
+    if isempty(kwargs)
+        components = build_constraint_components(mode)
+        return ProblemSpec(
+            mode;
+            x_dim=constraint_total_dim(components),
+            conditions=params -> build_conditions(mode, params),
+            forward_solve=(model, T_fm; fwd_kwargs...) -> solve_constraint(model, mode, T_fm; fwd_kwargs...),
+        )
+    end
     return ProblemSpec(mode; kwargs...)
 end

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -37,14 +37,90 @@ end
 @inline _unimplemented_forward_solve(theta, cfg, mode) = throw(ArgumentError("forward_solve is not configured for $(typeof(mode))"))
 @inline _unimplemented_conditions(theta, x, meta, cfg, mode) = throw(ArgumentError("conditions is not configured for $(typeof(mode))"))
 
+function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::FixedRho, T_fm::Real; fwd_kwargs...)
+    kwargs = Dict{Symbol,Any}(pairs(fwd_kwargs))
+
+    seed_guess = get(kwargs, :seed_guess, nothing)
+    seed_guess === nothing && throw(ArgumentError("seed_guess is required for ProblemSpec FixedRho forward_solve"))
+
+    seed_pool = if haskey(kwargs, :seed_candidates)
+        [Float64.(s) for s in kwargs[:seed_candidates]]
+    else
+        _build_default_seed_candidates(seed_guess)
+    end
+
+    physicality_check = get(kwargs, :physicality_check, ((_, _) -> true))
+    hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
+
+    candidates = NamedTuple[]
+    for (seed_index, seed) in pairs(seed_pool)
+        local raw
+        try
+            local_kwargs = Dict{Symbol,Any}(kwargs)
+            local_kwargs[:seed_guess] = seed
+            delete!(local_kwargs, :seed_candidates)
+            delete!(local_kwargs, :hard_constraints)
+
+            solved = _solve_constraint_fixedrho(model, T_fm, mode.rho_target; pairs(local_kwargs)...)
+            raw = (; solved..., residual_norm_max=get(local_kwargs, :residual_norm_max, 1e-6))
+            ok, failed = evaluate_hard_constraints(raw, hard_constraints)
+            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, seed_index=Int(seed_index)))
+        catch
+            raw = (
+                converged=false,
+                solution=Float64[],
+                x_state=zeros(5),
+                mu_vec=zeros(3),
+                omega=NaN,
+                pressure=-Inf,
+                rho_norm=NaN,
+                entropy=NaN,
+                energy=NaN,
+                masses=zeros(3),
+                iterations=0,
+                residual_norm=Inf,
+                residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
+            )
+            push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(seed_index)))
+        end
+    end
+
+    selected = select_pressure_max_candidate(candidates)
+    s = selected.selected_candidate
+    return (
+        converged=Bool(s.converged),
+        solution=Vector{Float64}(s.solution),
+        x_state=s.x_state,
+        mu_vec=s.mu_vec,
+        omega=s.omega,
+        pressure=s.pressure,
+        rho_norm=s.rho_norm,
+        entropy=s.entropy,
+        energy=s.energy,
+        masses=s.masses,
+        iterations=s.iterations,
+        residual_norm=s.residual_norm,
+        hard_constraint_ok=s.hard_constraint_ok,
+        failed_constraints=s.failed_constraints,
+        selection_reason=selected.selection_reason,
+        selected_index=selected.selected_index,
+        candidate_count=length(candidates),
+    )
+end
+
 @inline function build_problem_spec(mode::ConstraintMode; kwargs...)
     if isempty(kwargs)
         components = build_constraint_components(mode)
+        forward_solve = if mode isa FixedRho
+            (model, T_fm; fwd_kwargs...) -> _fixedrho_problem_spec_forward_solve(model, mode, T_fm; fwd_kwargs...)
+        else
+            (model, T_fm; fwd_kwargs...) -> solve_constraint(model, mode, T_fm; fwd_kwargs...)
+        end
         return ProblemSpec(
             mode;
             x_dim=constraint_total_dim(components),
             conditions=params -> build_conditions(mode, params),
-            forward_solve=(model, T_fm; fwd_kwargs...) -> solve_constraint(model, mode, T_fm; fwd_kwargs...),
+            forward_solve=forward_solve,
         )
     end
     return ProblemSpec(mode; kwargs...)

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -9,7 +9,12 @@ function solve_constraint(model::AbstractQCDModel, mode::FixedMu, T_fm::Real; μ
     return _solve_constraint_fixedmu(model, T_fm, μ_fm; kwargs...)
 end
 
-function solve_constraint(model::AbstractQCDModel, mode::FixedRho, T_fm::Real; kwargs...)
+function solve_constraint(model::AbstractQCDModel, mode::FixedRho, T_fm::Real;
+    problem_spec::Union{Nothing, ProblemSpec}=nothing,
+    kwargs...)
+    if problem_spec !== nothing
+        return problem_spec.forward_solve(model, T_fm; kwargs...)
+    end
     return _solve_constraint_fixedrho(model, T_fm, mode.rho_target; kwargs...)
 end
 

--- a/tests/integration/models/test_auto_backend_models_routing_smoke.jl
+++ b/tests/integration/models/test_auto_backend_models_routing_smoke.jl
@@ -1,0 +1,53 @@
+using Test
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+@testset "auto backend routes to models for PNJL scans" begin
+    tmpdir = mktempdir()
+
+    tmu_output = joinpath(tmpdir, "tmu_auto_models.csv")
+    trho_output = joinpath(tmpdir, "trho_auto_models.csv")
+
+    tmu_stats = Models.run_tmu_scan(
+        T_values=[150.0],
+        mu_values=[0.0],
+        xi_values=[0.0],
+        output_path=tmu_output,
+        overwrite=true,
+        resume=false,
+        solver_backend=:auto,
+        auto_pnjl_backend=:models,
+        model_kind=:PNJL,
+        p_num=8,
+        t_num=4,
+    )
+
+    trho_stats = Models.run_trho_scan(
+        T_values=[150.0],
+        rho_values=[0.2],
+        xi_values=[0.0],
+        output_path=trho_output,
+        overwrite=true,
+        resume=false,
+        reverse_rho=false,
+        solver_backend=:auto,
+        auto_pnjl_backend=:models,
+        model_kind=:PNJL,
+        p_num=8,
+        t_num=4,
+    )
+
+    @test tmu_stats.total == 1
+    @test trho_stats.total == 1
+    @test isfile(tmu_output)
+    @test isfile(trho_output)
+
+    tmu_lines = readlines(tmu_output)
+    trho_lines = readlines(trho_output)
+    @test length(tmu_lines) == 2
+    @test length(trho_lines) == 2
+end

--- a/tests/integration/models/test_problem_spec_fixedrho_forwardsolve_smoke.jl
+++ b/tests/integration/models/test_problem_spec_fixedrho_forwardsolve_smoke.jl
@@ -1,0 +1,29 @@
+using Test
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+@testset "problem spec fixedrho forward_solve smoke" begin
+    model = Models.create_model(:PNJL)
+    mode = Models.FixedRho(0.2)
+    spec = Models.build_problem_spec(mode)
+
+    result = Models.solve_constraint(
+        model,
+        mode,
+        90.0 / 197.327;
+        problem_spec=spec,
+        seed_guess=Models.pnjl_module().HADRON_SEED_8,
+        p_num=8,
+        t_num=4,
+        residual_norm_max=1e-6,
+    )
+
+    @test result isa NamedTuple
+    @test haskey(result, :converged)
+    @test haskey(result, :rho_norm)
+    @test haskey(result, :residual_norm)
+end

--- a/tests/integration/runtests.jl
+++ b/tests/integration/runtests.jl
@@ -51,6 +51,7 @@ const INTEGRATION_SMOKE_FILES = [
     joinpath(INTEGRATION_DIR, "models", "test_rpnjl_model_factory_smoke.jl"),
     joinpath(INTEGRATION_DIR, "models", "test_phase_cli_smoke.jl"),
     joinpath(INTEGRATION_DIR, "models", "test_solver_backend_semantic_parity_guard.jl"),
+    joinpath(INTEGRATION_DIR, "models", "test_problem_spec_fixedrho_forwardsolve_smoke.jl"),
 
     # PNJL scans
     joinpath(INTEGRATION_DIR, "pnjl", "test_tmu_scan_smoke.jl"),

--- a/tests/integration/runtests.jl
+++ b/tests/integration/runtests.jl
@@ -52,6 +52,7 @@ const INTEGRATION_SMOKE_FILES = [
     joinpath(INTEGRATION_DIR, "models", "test_phase_cli_smoke.jl"),
     joinpath(INTEGRATION_DIR, "models", "test_solver_backend_semantic_parity_guard.jl"),
     joinpath(INTEGRATION_DIR, "models", "test_problem_spec_fixedrho_forwardsolve_smoke.jl"),
+    joinpath(INTEGRATION_DIR, "models", "test_auto_backend_models_routing_smoke.jl"),
 
     # PNJL scans
     joinpath(INTEGRATION_DIR, "pnjl", "test_tmu_scan_smoke.jl"),

--- a/tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl
+++ b/tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl
@@ -1,0 +1,54 @@
+using Test
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+const HBARC_MEV_FM = 197.327
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+to_fm_inv(x_mev::Real) = Float64(x_mev) / HBARC_MEV_FM
+
+@testset "problem spec fixedrho parity regression" begin
+    model = Models.create_model(:PNJL)
+    points = [
+        (T_MeV=90.0, rho_target=0.2),
+        (T_MeV=110.0, rho_target=0.6),
+        (T_MeV=130.0, rho_target=1.0),
+    ]
+
+    for point in points
+        mode = Models.FixedRho(point.rho_target)
+        spec = Models.build_problem_spec(mode)
+        T_fm = to_fm_inv(point.T_MeV)
+        seed = Models.pnjl_module().HADRON_SEED_8
+
+        direct = Models.solve_constraint(
+            model,
+            mode,
+            T_fm;
+            seed_guess=seed,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+        )
+
+        via_spec = Models.solve_constraint(
+            model,
+            mode,
+            T_fm;
+            problem_spec=spec,
+            seed_guess=seed,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+        )
+
+        @test direct.converged == via_spec.converged
+        @test isapprox(direct.rho_norm, via_spec.rho_norm; rtol=1e-10, atol=1e-12)
+        @test isapprox(direct.pressure, via_spec.pressure; rtol=1e-10, atol=1e-12)
+        @test isapprox(direct.entropy, via_spec.entropy; rtol=1e-10, atol=1e-12)
+        @test isapprox(direct.energy, via_spec.energy; rtol=1e-10, atol=1e-12)
+        @test isapprox(direct.residual_norm, via_spec.residual_norm; rtol=1e-10, atol=1e-12)
+    end
+end

--- a/tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl
+++ b/tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl
@@ -45,10 +45,10 @@ to_fm_inv(x_mev::Real) = Float64(x_mev) / HBARC_MEV_FM
         )
 
         @test direct.converged == via_spec.converged
-        @test isapprox(direct.rho_norm, via_spec.rho_norm; rtol=1e-10, atol=1e-12)
-        @test isapprox(direct.pressure, via_spec.pressure; rtol=1e-10, atol=1e-12)
-        @test isapprox(direct.entropy, via_spec.entropy; rtol=1e-10, atol=1e-12)
-        @test isapprox(direct.energy, via_spec.energy; rtol=1e-10, atol=1e-12)
-        @test isapprox(direct.residual_norm, via_spec.residual_norm; rtol=1e-10, atol=1e-12)
+        @test isapprox(direct.rho_norm, via_spec.rho_norm; rtol=1e-6, atol=1e-8)
+        @test isapprox(direct.pressure, via_spec.pressure; rtol=1e-6, atol=1e-8)
+        @test isapprox(direct.entropy, via_spec.entropy; rtol=1e-6, atol=1e-8)
+        @test isapprox(direct.energy, via_spec.energy; rtol=1e-6, atol=1e-8)
+        @test isapprox(direct.residual_norm, via_spec.residual_norm; rtol=1e-6, atol=1e-10)
     end
 end

--- a/tests/regression/runtests.jl
+++ b/tests/regression/runtests.jl
@@ -19,6 +19,7 @@ const SMOKE_FILES = [
     joinpath(REGRESSION_DIR, "pnjl", "test_magnetic_fixedpoint_regression.jl"),
     joinpath(REGRESSION_DIR, "models", "test_dimension_agnostic_solver_regression.jl"),
     joinpath(REGRESSION_DIR, "models", "test_fixedrho_precision_guard_regression.jl"),
+    joinpath(REGRESSION_DIR, "models", "test_problem_spec_fixedrho_parity_regression.jl"),
     joinpath(REGRESSION_DIR, "relaxtime", "test_transport_fixedpoint_regression.jl"),
     joinpath(REGRESSION_DIR, "relaxtime", "test_tau_xi_probe_regression.jl"),
     joinpath(REGRESSION_DIR, "relaxtime", "test_total_cross_section_fixedpoint_regression.jl"),

--- a/tests/unit/models/test_constraint_components.jl
+++ b/tests/unit/models/test_constraint_components.jl
@@ -1,0 +1,37 @@
+using Test
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+@testset "constraint components contract" begin
+    @test isdefined(Models, :AbstractConstraintComponent)
+    @test isdefined(Models, :constraint_dim)
+    @test isdefined(Models, :constraint_name)
+    @test isdefined(Models, :build_constraint_components)
+    @test isdefined(Models, :constraint_total_dim)
+
+    fixedrho_components = Models.build_constraint_components(Models.FixedRho(0.6))
+    fixedasym_components = Models.build_constraint_components(Models.FixedAsymmetricRho(0.6, 1.0, 0.0))
+
+    @test !isempty(fixedrho_components)
+    @test !isempty(fixedasym_components)
+
+    @test first(fixedrho_components) isa Models.AbstractConstraintComponent
+    @test first(fixedasym_components) isa Models.AbstractConstraintComponent
+
+    names_fixedrho = Models.constraint_name.(fixedrho_components)
+    names_fixedasym = Models.constraint_name.(fixedasym_components)
+
+    @test :stationarity in names_fixedrho
+    @test :equal_mu in names_fixedrho
+    @test :fixed_baryon_density in names_fixedrho
+
+    @test :stationarity in names_fixedasym
+    @test :asymmetric_density in names_fixedasym
+
+    @test Models.constraint_total_dim(fixedrho_components) == Models.state_dim(Models.FixedRho(0.6))
+    @test Models.constraint_total_dim(fixedasym_components) == Models.state_dim(Models.FixedAsymmetricRho(0.6, 1.0, 0.0))
+end

--- a/tests/unit/models/test_problem_spec_contract.jl
+++ b/tests/unit/models/test_problem_spec_contract.jl
@@ -54,4 +54,32 @@ end
         @test haskey(solved, :converged)
         @test haskey(solved, :residual_norm)
     end
+
+    @testset "solve_constraint fixedrho prefers problem_spec forward_solve" begin
+        model = Models.create_model(:PNJL)
+        mode = Models.FixedRho(0.2)
+        spec = Models.ProblemSpec(
+            mode;
+            x_dim=8,
+            theta_dim=1,
+            forward_solve=(m, T_fm; fwd_kwargs...) -> (
+                converged=true,
+                residual_norm=0.0,
+                pressure=0.0,
+                used_problem_spec=true,
+            ),
+        )
+
+        result = Models.solve_constraint(
+            model,
+            mode,
+            0.5;
+            problem_spec=spec,
+        )
+
+        @test result isa NamedTuple
+        @test result.converged
+        @test result.used_problem_spec
+        @test result.residual_norm == 0.0
+    end
 end

--- a/tests/unit/models/test_problem_spec_contract.jl
+++ b/tests/unit/models/test_problem_spec_contract.jl
@@ -53,6 +53,8 @@ end
         @test solved isa NamedTuple
         @test haskey(solved, :converged)
         @test haskey(solved, :residual_norm)
+        @test haskey(solved, :selection_reason)
+        @test haskey(solved, :candidate_count)
     end
 
     @testset "solve_constraint fixedrho prefers problem_spec forward_solve" begin

--- a/tests/unit/models/test_problem_spec_contract.jl
+++ b/tests/unit/models/test_problem_spec_contract.jl
@@ -38,4 +38,20 @@ end
             @test spec.selector isa Function
         end
     end
+
+    @testset "fixedrho spec conditions and forward solve are wired" begin
+        model = Models.create_model(:PNJL)
+        mode = Models.FixedRho(0.2)
+        spec = Models.build_problem_spec(mode)
+
+        params = Models.GapParams(0.5, Models.cached_nodes(8, 4), 0.0)
+        cond = spec.conditions(params)
+        residual = cond([0.5], [-1.5, -1.5, -2.1, 0.2, 0.2, 1.5, 1.5, 1.5])
+        @test length(residual) == 8
+
+        solved = spec.forward_solve(model, 0.5; seed_guess=[-1.5, -1.5, -2.1, 0.2, 0.2, 1.5, 1.5, 1.5], p_num=8, t_num=4)
+        @test solved isa NamedTuple
+        @test haskey(solved, :converged)
+        @test haskey(solved, :residual_norm)
+    end
 end

--- a/tests/unit/models/test_tmu_scan.jl
+++ b/tests/unit/models/test_tmu_scan.jl
@@ -37,4 +37,10 @@ const _TMS = Models.TmuScan
         @test isdefined(_TMS, :run_tmu_scan)
         @test _TMS.run_tmu_scan isa Function
     end
+
+    @testset "auto backend 语义路由配置" begin
+        @test _TMS._effective_solver_backend(:auto, :PNJL; auto_pnjl_backend=:models) == :models
+        @test _TMS._effective_solver_backend(:auto, :PNJL; auto_pnjl_backend=:legacy) == :legacy
+        @test _TMS._effective_solver_backend(:auto, :RPNJL; auto_pnjl_backend=:legacy) == :models
+    end
 end

--- a/tests/unit/models/test_trho_scan.jl
+++ b/tests/unit/models/test_trho_scan.jl
@@ -46,4 +46,10 @@ const _TS = Models.TrhoScan
         @test isdefined(_TS, :run_trho_scan)
         @test _TS.run_trho_scan isa Function
     end
+
+    @testset "auto backend 语义路由配置" begin
+        @test _TS._effective_solver_backend(:auto, :PNJL; auto_pnjl_backend=:models) == :models
+        @test _TS._effective_solver_backend(:auto, :PNJL; auto_pnjl_backend=:legacy) == :legacy
+        @test _TS._effective_solver_backend(:auto, :RPNJL; auto_pnjl_backend=:legacy) == :models
+    end
 end


### PR DESCRIPTION
## Summary
- Execute R1 A0/A1/A2/A3 on top of PR #48 in a stacked branch:
  - A0: add `ConstraintComponents` contract and mode->components mapping.
  - A1/A2: wire `ProblemSpec` execution path for `FixedRho`, then deepen to explicit candidate-pool + unified hard-constraint governance.
  - A3: converge `solver_backend=:auto` semantics in `TmuScan/TrhoScan` to PNJL->models by default, with guarded override `auto_pnjl_backend`.
- Complete A4 verification matrix and documentation sync:
  - smoke matrix + benchmark + governance all passed;
  - `docs/api/models/solver/*` synced to R1 terminology (`ProblemSpec` + `ConstraintComponents`);
  - `docs/api/models/solver/generated/Exports.md` regenerated by script.

## Stacked Base
- Base branch: `prep/solver-next-pr` (PR #48).

## Verification
- `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_constraint_components.jl,models/test_problem_spec_contract.jl"; include("tests/unit/runtests.jl")'`
- `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_tmu_scan.jl,models/test_trho_scan.jl"; include("tests/unit/runtests.jl")'`
- `julia --project=. -e 'include("tests/integration/models/test_problem_spec_fixedrho_forwardsolve_smoke.jl")'`
- `julia --project=. -e 'include("tests/integration/models/test_auto_backend_models_routing_smoke.jl")'`
- `julia --project=. -e 'include("tests/integration/models/test_solver_backend_semantic_parity_guard.jl")'`
- `julia --project=. -e 'ENV["REGRESSION_FILES"]="models/test_problem_spec_fixedrho_parity_regression.jl"; include("tests/regression/runtests.jl")'`
- `julia --project=. -e 'ENV["UNIT_PROFILE"]="smoke"; include("tests/unit/runtests.jl")'` → pass `781/781`
- `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'` → pass `402/402`
- `julia --project=. -e 'ENV["REGRESSION_PROFILE"]="smoke"; include("tests/regression/runtests.jl")'` → pass `530`, broken `1` (expected optional fixture)
- `julia --project=. scripts/perf/pnjl/scan_perf.jl` → convergence 100%
- `julia --project=. scripts/dev/check_docs_consistency.jl`
- `julia --project=. scripts/dev/check_active_docs_governance.jl`
- `julia --project=. scripts/dev/generate_api_export_index.jl --module-file src/models/Models.jl --module-file src/models/entrypoints.jl --include-symbol create_model --include-symbol MeanFieldState --include-symbol meanfield_state --include-symbol state_vector --include-symbol normalize_mu_vec --include-symbol solve_gap --include-symbol solve --include-symbol solve_multi --include-symbol ConstraintModes --include-symbol GapParams --include-symbol build_conditions --include-symbol build_residual! --include-symbol gap_state_dim --include-symbol gap_residual --include-symbol SeedStrategy --include-symbol DefaultSeed --include-symbol MultiSeed --include-symbol ContinuitySeed --include-symbol HybridContinuitySeed --include-symbol PhaseAwareSeed --include-symbol PhaseAwareContinuitySeed --include-symbol get_seed --include-symbol get_all_seeds --include-symbol update! --include-symbol reset! --include-symbol set_phase! --include-symbol create_implicit_gap_solver --include-symbol create_flavor_mu_implicit_gap_solver --include-symbol create_pnjl_implicit_solver --include-symbol solve_constraint --include-symbol ModelStateSchema --include-symbol schema_for_model --include-symbol flatten_state --include-symbol unflatten_state --output docs/api/models/solver/generated/Exports.md --title "Models Solver Export API Index"`