### PR TITLE
refactor(models/solver): unify ProblemSpec governed chain with extra constraints

### DIFF
--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -686,3 +686,27 @@ Files:
   5) 阶段结论：
      - 非 FixedRho 三模式已全部完成“统一主执行器 + 额外约束输入”收敛；
      - 后续可进入 `FixedRho` 外层编排统一评估（风险更高，建议单独 gate 与回归矩阵）。
+
+- 2026-04-05："额外约束作为通用输入" 阶段 5（FixedRho 外层编排统一第一步）
+  1) 目标：
+     - 在不触碰 `FixedRho` 联合求解内核的前提下，先收敛其外层 attempt-plan 构建逻辑，和 non-rho 主链复用同一套 seed 计划生成器。
+  2) 生产实现（`src/models/solver/ProblemSpec.jl`）：
+     - 新增 `_build_governed_attempt_plan(...)`：
+       - 统一处理 primary/provided/default/extra_fallback seeds 去重；
+       - 统一生成 `:primary / :method_rescue / :seed_rescue` attempt 序列；
+       - 内建 `extra_constraints.seed_extend` 接缝。
+     - `FixedRho` 与 `_governed_nonrho_problem_spec_forward_solve(...)` 均改为复用该统一 attempt-plan 构建器；
+     - 保留 `FixedRho` 既有 legacy-mode seed 注入逻辑，作为 `extra_fallback_seeds` 传入（保持稳定性）。
+  3) 测试补强：
+     - 在 `tests/unit/models/test_problem_spec_contract.jl` 新增
+       `fixedrho forward_solve accepts extra_constraints hook`：
+       - 断言 `seed_extend` 被调用；
+       - 断言 `feasible=false` 会触发 `:extra_constraint_failed`。
+  4) 验证结果：
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_contract.jl"; include("tests/unit/runtests.jl")'`（176/176）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl"; include("tests/unit/runtests.jl")'`（25/25）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_semantic_modes.jl"; include("tests/unit/runtests.jl")'`（7/7）
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
+  5) 阶段结论：
+     - `FixedRho` 已完成“外层计划编排”与通用主链的第一层统一；
+     - 当前仍保留 `FixedRho` 专用 joint solve 主体，后续若继续统一，应把“候选执行与结果整形”再抽一层通用执行器，并单独跑 parity/regression gate。

--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -293,3 +293,11 @@ Files:
   4) 仍保留已稳定项：
      - `solve(model, FixedMu, ...)` 与 `solve_multi(model, FixedMu, ...)` 主链化；
      - `constraint_solver` 中 FixedRho fallback 明确调用 `Main.Models.ImplicitSolver.solve(...)`，避免递归。
+- 2026-04-04：B2 推进完成（类型与物理判据去耦）：
+  1) `src/models/solver/Solver.jl` 新增本地 `SolverResult` 结构定义，解除 `const SolverResult = ImplicitSolver.SolverResult` 依赖；
+  2) 新增 `_coerce_solver_result(...)`，将仍由 `ImplicitSolver` 返回的结果统一转为 models 本地 `SolverResult`；
+  3) `is_physical_solution(...)` 在 `Solver.jl` 本地实现，移除对 `ImplicitSolver.default_is_physical_solution` 的转发；
+  4) 依赖检查：`Solver.jl` 内已无 `ImplicitSolver.SolverResult` / `ImplicitSolver.default_is_physical_solution` 引用；
+  5) 验证通过：
+     - unit：`pnjl/test_solver_implicit.jl,models/test_solver_dimension_agnostic.jl,models/test_constraint_solver.jl`（161/161）；
+     - integration：`test_models_native_solver_phase1_smoke.jl`（11/11），`test_solver_constraints_models_backend_smoke.jl`（43/43）。

--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -308,3 +308,22 @@ Files:
   4) 当前可执行下一步建议：
      - 先做“语义桥接层”拆分（为 non-FixedMu 模式补齐与 `ImplicitSolver.solve` 一致的参数语义），再逐模式迁移；
      - 避免直接把 `solve_constraint` 默认语义替换到 `solve` 旧入口。
+- 2026-04-04：语义桥接层第一步已落地（non-FixedMu）
+  1) 在 `Solver.jl` 新增 `_resolve_nonfixedmu_bridge(...)` 与 `_resolve_solver_model(...)`：
+     - 统一解析 `seed_guess/seed_candidates/semantic_mode/selector/rho0/model_kind`；
+     - 当检测到 problem-spec 语义参数时切换到 `solve_constraint` 路径；
+     - 默认（无桥接参数）仍走 `ImplicitSolver.solve`，保持旧行为稳定。
+  2) 新增单测覆盖桥接参数可用性：`tests/unit/models/test_solver.jl`。
+  3) 验证通过：
+     - unit：`models/test_solver.jl,pnjl/test_solver_implicit.jl`（75/75）；
+     - integration：`tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl`（43/43）。
+- 2026-04-04：语义桥接层第二步已落地（non-FixedMu solve_multi）
+  1) `solve_multi(model, Union{FixedRho,FixedAsymmetricRho}, ...)` 增加桥接语义：
+     - 当携带 `seed_guess/seed_candidates/semantic_mode/selector/problem_spec` 等语义参数时，走 `solve_constraint` 多种子筛选路径；
+     - 默认无桥接参数时仍走 `ImplicitSolver.solve_multi`，保持旧行为。
+  2) 新增单测覆盖：`tests/unit/models/test_solver.jl` 增加 non-FixedMu `solve_multi` 桥接参数测试。
+  3) 验证通过：
+     - unit：`models/test_solver.jl,pnjl/test_solver_implicit.jl`（77/77）；
+     - integration：
+       - `tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl`（43/43）
+       - `tests/integration/models/test_models_native_solver_phase1_smoke.jl`（11/11）。

--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -508,6 +508,82 @@ Files:
      - `julia --project=. -e 'include("tests/unit/models/test_problem_spec_contract.jl")'`（121/121）
      - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
      - `julia --project=. -e 'include("tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl")'`（fixedrho guard 全通过，防回归）。
-  4) 阶段状态：
-     - 非 `FixedMu` 三个模式（`FixedRho` / `FixedEntropy` / `FixedSigma` / `FixedAsymmetricRho`）已统一到“懒触发 attempts + continuity-aware 默认方法”的策略骨架；
-     - `FixedMu` 继续保持“强制多 attempts 选优”作为唯一多解主模式。
+   4) 阶段状态：
+      - 非 `FixedMu` 三个模式（`FixedRho` / `FixedEntropy` / `FixedSigma` / `FixedAsymmetricRho`）已统一到“懒触发 attempts + continuity-aware 默认方法”的策略骨架；
+      - `FixedMu` 继续保持“强制多 attempts 选优”作为唯一多解主模式。
+
+- 2026-04-05：继续推广到其他求解模式（legacy fallback 治理化收口，非强删）
+  1) 红灯验证（先证伪）：
+     - 直接移除 `constraint_solver` 中 `FixedEntropy/FixedSigma/FixedAsymmetricRho` 的 `ImplicitSolver` fallback 后，回归立即失败：
+       - `tests/unit/models/test_solver.jl` 失败（non-FixedMu parity 中 Entropy/Sigma/Asym convergence 断言红灯）；
+       - `tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl` 失败（43 用例中 6 处红灯，目标量显著偏离）。
+     - 结论：三模式当前仍存在真实稳定性依赖，不能直接移除 fallback。
+  2) 低风险推进（保语义前提下继续“推广”）：
+     - 在 `constraint_solver.jl` 为三模式新增显式治理参数：
+       - `_solve_constraint_fixedentropy(...; allow_legacy_fallback::Bool=true, ...)`
+       - `_solve_constraint_fixedsigma(...; allow_legacy_fallback::Bool=true, ...)`
+       - `_solve_constraint_fixedasymrho(...; allow_legacy_fallback::Bool=true, ...)`
+     - fallback 结果新增可观测元信息：`legacy_fallback_used::Bool`（true/false）。
+     - 在 `ProblemSpec.jl` 将 `allow_legacy_fallback` 贯通为可配置参数并回传到 forward_solve 结果，形成统一观测口径。
+  3) 测试补强：
+     - `tests/unit/models/test_problem_spec_contract.jl` 新增 non-rho governed metadata 断言：
+       - `haskey(solved, :legacy_fallback_used)`
+       - `solved.legacy_fallback_used isa Bool`。
+  4) 验证通过（本轮落地后的绿灯）：
+     - `julia --project=. -e 'include("tests/unit/models/test_solver.jl")'`（25/25）
+     - `julia --project=. -e 'include("tests/unit/models/test_problem_spec_contract.jl")'`（127/127）
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
+     - `julia --project=. -e 'include("tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl")'`（fixedrho guards 全通过）
+  5) 阶段结论：
+      - 已将“是否启用 legacy fallback”从隐式行为升级为显式可治理开关，并提供可观测证据位；
+      - 这为下一轮按模式逐步压缩 fallback 使用率提供了数据抓手；
+      - 但截至本轮，`FixedEntropy/FixedSigma/FixedAsymmetricRho` 仍不具备无 fallback 的稳定默认语义，暂不进入 Step4 强删。
+
+- 2026-04-05：按 FixedRho 架构继续推广（治理元信息对齐到非 FixedRho 模式）
+  1) 先加红灯契约（TDD）：
+     - 在 `tests/unit/models/test_problem_spec_contract.jl` 为 `FixedEntropy/FixedSigma/FixedAsymmetricRho` 增加治理元信息断言：
+       - `governed_selected_method`
+       - `governed_selected_quality`
+       - `governed_fallback_used`
+     - 并新增 `allow_legacy_fallback=false + nlsolve_method=:newton + trust_region_fallback=false` 场景，约束 `governed_fallback_used == false`。
+  2) 绿灯实现（`ProblemSpec` 非 rho 三模式）：
+     - 在每个 attempt candidate 中补齐并透传治理字段：
+       - `governed_selected_method=attempt_cfg.method`
+       - `governed_selected_quality`（`ok => :good`，否则按 solver 状态标记 `:degraded/:bad`）
+       - `governed_fallback_used=(attempt_origin == :method_rescue)`
+       - `governed_attempt_origin`
+     - 在 forward_solve 最终返回中统一暴露上述三项，形成与 `FixedRho` 同风格的策略可观测面。
+  3) 验证结果：
+     - 通过：
+       - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_contract.jl"; include("tests/unit/runtests.jl")'`（160/160）
+       - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl"; include("tests/unit/runtests.jl")'`（25/25）
+       - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_semantic_modes.jl"; include("tests/unit/runtests.jl")'`（7/7）
+       - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_constraint_solver.jl"; include("tests/unit/runtests.jl")'`（47/47）
+       - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
+       - `julia --project=. -e 'ENV["REGRESSION_FILES"]="models/test_problem_spec_fixedrho_parity_regression.jl"; include("tests/regression/runtests.jl")'`（78/78）
+     - 已知红灯（独立既有口径，非本轮新增）：
+       - `tests/integration/models/test_solver_backend_semantic_parity_guard.jl` 仍在 `FixedRho` case 失败，表现为 models 与 legacy 在单点语义上不一致（`rho_norm/entropy/energy` 偏离）。
+  4) 阶段结论：
+     - 本轮已完成“按 FixedRho 架构推广”的第一层：非 FixedRho 三模式具备统一策略治理元信息与 fallback 可观测性；
+     - 下一步应进入第二层：利用这些治理字段把 `legacy fallback` 从“兜底可用”推进到“可量化收缩”（按 mode/点位分层）。
+
+- 2026-04-05：FixedRho 红灯快速修复（将 legacy 该点有效初解并入当前初解池）
+  1) 背景：`tests/integration/models/test_solver_backend_semantic_parity_guard.jl` 在 `T=110MeV, rho=0.6` 的 FixedRho case 红灯；
+     诊断显示 models 路径 9 个候选均落入同一坏盆地（`rho≈0.00129`），而 legacy 可收敛到目标分支。
+  2) 实施：
+     - 在 `ProblemSpec._fixedrho_problem_spec_forward_solve(...)` 中，除原有 primary/provided/default seeds 外，显式加入一条 legacy 语义 seed：
+       - `legacy_seed = extend_seed(primary_seed[1:5], mode)`（若主 seed 已是 8 维也重建其 6:8 分量）；
+       - 去重后加入 fallback seed pool。
+     - 目的：把 legacy 在该类点位的有效 mode-aware 初解纳入当前主链候选池，先修收敛盆地覆盖问题。
+  3) 测试补强：
+     - `tests/integration/models/test_solver_backend_semantic_parity_guard.jl` 新增：
+       - `FixedRho ProblemSpec fallback seed pool includes legacy-mode seed`，断言 `T=110MeV, rho=0.6` 下 `models` 路径可收敛并满足目标密度。
+  4) 验证通过：
+     - `julia --project=. -e 'include("tests/integration/models/test_solver_backend_semantic_parity_guard.jl")'`（39/39 + 新 testset 2/2）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_contract.jl"; include("tests/unit/runtests.jl")'`（160/160）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl"; include("tests/unit/runtests.jl")'`（25/25）
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
+     - `julia --project=. -e 'ENV["REGRESSION_FILES"]="models/test_problem_spec_fixedrho_parity_regression.jl"; include("tests/regression/runtests.jl")'`（78/78）
+  5) 结论：
+     - 该红灯已由“吸引盆地覆盖不足”被修复；
+     - 该改动不改变求解器主干结构，仅增加一条 mode-aware 候选 seed，属于低风险稳态增强。

--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -301,3 +301,10 @@ Files:
   5) 验证通过：
      - unit：`pnjl/test_solver_implicit.jl,models/test_solver_dimension_agnostic.jl,models/test_constraint_solver.jl`（161/161）；
      - integration：`test_models_native_solver_phase1_smoke.jl`（11/11），`test_solver_constraints_models_backend_smoke.jl`（43/43）。
+- 2026-04-04：B3 探索结论（本轮）
+  1) 目标：清理 `solve/solve_multi` 对 `ImplicitSolver` 的剩余转发（非 FixedMu 模式）。
+  2) 结果：对 `FixedRho/FixedEntropy/FixedSigma/FixedAsymmetricRho` 迁移到 models 主链后，`test_solver_constraints_models_backend_smoke.jl` 出现系统性回归（收敛状态与约束量显著偏移）。
+  3) 处理：已回滚该段迁移，恢复上述模式继续走 `ImplicitSolver` 路径，确保门禁稳定；仅保留 B1/B2 已验证稳定改动。
+  4) 当前可执行下一步建议：
+     - 先做“语义桥接层”拆分（为 non-FixedMu 模式补齐与 `ImplicitSolver.solve` 一致的参数语义），再逐模式迁移；
+     - 避免直接把 `solve_constraint` 默认语义替换到 `solve` 旧入口。

--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -584,6 +584,105 @@ Files:
      - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl"; include("tests/unit/runtests.jl")'`（25/25）
      - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
      - `julia --project=. -e 'ENV["REGRESSION_FILES"]="models/test_problem_spec_fixedrho_parity_regression.jl"; include("tests/regression/runtests.jl")'`（78/78）
-  5) 结论：
-     - 该红灯已由“吸引盆地覆盖不足”被修复；
-     - 该改动不改变求解器主干结构，仅增加一条 mode-aware 候选 seed，属于低风险稳态增强。
+   5) 结论：
+      - 该红灯已由“吸引盆地覆盖不足”被修复；
+      - 该改动不改变求解器主干结构，仅增加一条 mode-aware 候选 seed，属于低风险稳态增强。
+
+- 2026-04-05："额外约束作为通用输入" 最小改动实施（阶段 1：护栏 + 壳层）
+  1) 目标与策略：
+     - 按“可回退、可验证、单点替换”推进，不改现有模式求解行为；
+     - 先在 `ProblemSpec` 层引入通用 `ExtraConstraints` 壳层，默认实现为 no-op，确保零行为变化。
+  2) TDD 护栏（先红后绿）：
+     - 在 `tests/unit/models/test_problem_spec_contract.jl` 新增 `problem spec extra constraints shell contract`：
+       - 要求 `Models.ExtraConstraints`、`Models.default_extra_constraints` 可见；
+       - 要求 `build_problem_spec(mode)` 返回的 `spec` 带 `extra_constraints` 字段；
+       - 要求默认 `seed_extend` 为 identity、`feasible` 恒真、`residual!` no-op。
+     - 先运行该测试出现预期红灯（符号/字段不存在），再实现生产代码并转绿。
+  3) 生产实现（零行为变化）：
+     - `src/models/solver/ProblemSpec.jl`：
+       - 新增 `ExtraConstraints` 结构（`residual!`, `feasible`, `seed_extend`）；
+       - 新增默认 no-op 适配 `default_extra_constraints()`；
+       - `ProblemSpec` 增加 `extra_constraints` 字段；
+       - `ProblemSpec(...)` 构造器新增关键字 `extra_constraints=default_extra_constraints()`。
+     - `src/models/Models.jl`：导出 `ExtraConstraints` 与 `default_extra_constraints`。
+  4) 验证：
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_contract.jl"; include("tests/unit/runtests.jl")'`（167/167）。
+  5) 阶段结论：
+     - 已完成你要求的最小接缝注入："模式差异可转为 extra constraints 输入" 的结构基础到位；
+     - 当前默认实现不改变任何既有解算路径行为，后续可在阶段 2/3 逐步接入主执行器钩子与两模式迁移。
+
+- 2026-04-05："额外约束作为通用输入" 阶段 2（主执行器钩子接入，保持默认行为）
+  1) 目标：
+     - 在不改变默认数值行为的前提下，让 `extra_constraints` 真正进入 `ProblemSpec` 主执行路径；
+     - 接入点仅限两类：`seed_extend` 与 `feasible`（`residual!` 先保留接口，不在本阶段强接）。
+  2) 实施改动：
+     - `src/models/solver/ProblemSpec.jl`
+       - 新增工具函数：
+         - `_resolve_extra_constraints(kwargs)`
+         - `_extend_seed_with_extra(seed, mode, extra)`
+         - `_append_extra_feasible_rule(rules, extra, mode)`
+       - `ProblemSpec(...)` 构造器保持兼容，同时将 `extra_constraints` 注入默认 `forward_solve` keyword；
+       - `_strip_problemspec_forwardsolve_kwargs!` 增加 `:extra_constraints`，防止下游 solver 收到无关键字；
+       - 在 `FixedRho/FixedEntropy/FixedSigma/FixedAsymmetricRho` 的 `forward_solve` 中统一接入：
+         - `primary_seed/provided_seed_pool/default_seed_pool` 均经过 `extra.seed_extend(...)`；
+         - `hard_constraints` 追加 `extra.feasible(...) => :extra_constraint_failed` 规则。
+     - `tests/unit/models/test_problem_spec_contract.jl`
+       - 新增 `problem spec extra constraints hooks are wired in forward_solve`：
+         - 通过 `extra_constraints=ec` 显式传入，断言 `seed_extend` 被调用；
+         - 断言 `feasible=false` 会使 `hard_constraint_ok=false` 且失败原因包含 `:extra_constraint_failed`。
+  3) 验证结果：
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_contract.jl"; include("tests/unit/runtests.jl")'`（170/170）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl"; include("tests/unit/runtests.jl")'`（25/25）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_semantic_modes.jl"; include("tests/unit/runtests.jl")'`（7/7）
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
+  4) 阶段结论：
+     - 已完成“通用额外约束输入”在主执行器的最小可用接入：可影响种子扩展与可行域判定；
+     - 默认 `default_extra_constraints()` 仍为 no-op，故对既有调用方保持行为兼容；
+     - 下阶段可迁移 `FixedEntropy/FixedSigma` 为“仅差异化提供 extra_constraints”以进一步消解 mode 分叉实现。
+
+- 2026-04-05："额外约束作为通用输入" 阶段 3（先迁移 FixedEntropy + FixedSigma）
+  1) 目标：
+     - 将 `FixedEntropy` / `FixedSigma` 的 ProblemSpec 前向求解实现收敛到统一非 rho 主链执行器；
+     - 保持行为等价（只抽公共编排，不变更物理求解内核）。
+  2) TDD 与重构策略：
+     - 先沿用阶段 1/2 已建立的 `problem_spec_contract + solver + semantic_modes + integration smoke` 作为回归护栏；
+     - 在 `ProblemSpec` 中新增统一执行器 `_governed_nonrho_problem_spec_forward_solve(...)`，将重复逻辑（seed pool、attempt plan、hard rules、selector、治理元数据）抽象；
+     - `FixedEntropy/FixedSigma` 改为仅提供：
+       - mode label（报错文本）；
+       - mode 特有 attempt-origin 字段名；
+       - mode 特有 constraint solve 闭包（分别调用 `_solve_constraint_fixedentropy/_fixedsigma`）。
+  3) 关键实现点（`src/models/solver/ProblemSpec.jl`）：
+     - 新增 `_governed_nonrho_problem_spec_forward_solve(...)` 通用函数；
+     - `FixedEntropy/FixedSigma` wrapper 显著瘦身，迁移到“参数化调用通用执行器”；
+     - 保留原有输出契约字段（`governed_*`, `legacy_fallback_used`, `selection_reason`, `candidate_count` 等）不变。
+  4) 验证：
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_contract.jl"; include("tests/unit/runtests.jl")'`（170/170）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl"; include("tests/unit/runtests.jl")'`（25/25）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_semantic_modes.jl"; include("tests/unit/runtests.jl")'`（7/7）
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
+  5) 阶段结论：
+     - 已完成你指定的“先两模式迁移”：`FixedEntropy` 与 `FixedSigma` 的分叉编排明显收敛；
+     - 当前模式差异主要集中在“额外约束/模式参数输入 + mode 专有内核调用”，符合“把额外约束当作通用输入”的主方向；
+     - 下一步可按同样方式迁移 `FixedAsymmetricRho`，再评估 `FixedRho` 外层编排统一的收益/风险比。
+
+- 2026-04-05："额外约束作为通用输入" 阶段 4（迁移 FixedAsymmetricRho）
+  1) 目标：
+     - 将 `FixedAsymmetricRho` 迁移到与 `FixedEntropy/FixedSigma` 相同的统一非 rho 主执行器，进一步压缩 mode 分叉编排。
+  2) TDD 护栏：
+     - 在 `tests/unit/models/test_problem_spec_contract.jl` 新增
+       `fixedasymrho forward_solve accepts extra_constraints hook`：
+       - 断言 `seed_extend` 被调用；
+       - 断言 `feasible=false` 会触发 `:extra_constraint_failed`。
+  3) 生产实现：
+     - `src/models/solver/ProblemSpec.jl`
+       - `_fixedasymrho_problem_spec_forward_solve(...)` 改为参数化调用
+         `_governed_nonrho_problem_spec_forward_solve(...)`；
+       - 仅保留 mode 差异输入（label / attempt-origin key / mode-specific solve closure）。
+  4) 验证结果：
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_contract.jl"; include("tests/unit/runtests.jl")'`（173/173）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl"; include("tests/unit/runtests.jl")'`（25/25）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_semantic_modes.jl"; include("tests/unit/runtests.jl")'`（7/7）
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
+  5) 阶段结论：
+     - 非 FixedRho 三模式已全部完成“统一主执行器 + 额外约束输入”收敛；
+     - 后续可进入 `FixedRho` 外层编排统一评估（风险更高，建议单独 gate 与回归矩阵）。

--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -448,3 +448,21 @@ Files:
      - `FixedMu` 强制多 attempts 选优逻辑保持不变；
      - 非 `FixedMu` 按“懒触发 attempts”推进，优先对齐真实扫描使用场景（continuity seed）；
      - `fixedrho_joint_solve=false` 兼容分支仍保留（便于过渡期对照/回归），尚未进行物理语义层面的全量 legacy 退役。
+
+- 2026-04-05：FixedRho legacy 分支收口（ProblemSpec 侧）
+  1) 处理原则：在 `FixedRho` 路径中继续遵循“joint 负责展平、策略层负责求解”，并按非 `FixedMu` 懒触发策略运行。
+  2) 代码收口：
+     - 删除 `ProblemSpec._fixedrho_problem_spec_forward_solve(...)` 中 `fixedrho_joint_solve=false` 时回退 `_solve_constraint_fixedrho(...)` 的分支；
+     - 明确将 `fixedrho_joint_solve=false` 视为不支持参数，抛出 `ArgumentError`；
+     - `FixedRho` 的 ProblemSpec forward_solve 统一走 joint + lazy attempts 主链。
+  3) 测试同步：
+     - `tests/unit/models/test_problem_spec_contract.jl` 中将 `fixedrho_joint_solve=false` 口径更新为抛错断言；
+     - 保留并复用既有 continuity-like/joint parity gates 回归集。
+  4) 验证通过：
+     - `julia --project=. -e 'include("tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl")'`
+     - `julia --project=. -e 'include("tests/unit/models/test_problem_spec_contract.jl")'`
+     - `julia --project=. -e 'include("tests/unit/models/test_solver.jl")'`（25/25）
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）。
+  5) 阶段结论：
+     - `FixedRho` 在 ProblemSpec 层已不再保留 legacy 兼容分支；
+     - 仍需后续轮次继续处理 `constraint_solver` 其他 non-FixedMu 模式中的 legacy fallback 依赖，方可推进 Step4 全量退役。

--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -396,3 +396,55 @@ Files:
   4) 状态结论：
      - `Solver.jl` 已无 `ImplicitSolver.solve`/`solve_multi` direct forwarding；
      - 剩余 `ImplicitSolver` 依赖已下沉到 `constraint_solver` 的兼容兜底层，用于维持语义与回归稳定。
+
+- 2026-04-05：Step4 强收口尝试与回滚结论（阻塞确认）
+  1) 本轮尝试内容：
+     - 试图删除 `src/models/solver/ImplicitSolver.jl`，并清理 `Models.jl` include 与测试中对 `Models.ImplicitSolver` 的访问。
+  2) 实测结果（失败）：
+     - non-FixedMu 默认语义出现系统性回归：`tests/unit/models/test_solver.jl` 中 `FixedEntropy/FixedSigma/FixedRho/FixedAsymmetricRho` parity 大面积失败；
+     - 独立复现显示默认 `FixedEntropy` 可退化到不收敛（`converged=false`，残差显著偏大）。
+  3) 根因判断：
+     - 当前主链对 non-FixedMu 默认语义仍存在历史算法依赖；`constraint_solver` 侧尚未具备与历史路径完全等价的稳定实现；
+     - 直接移除 `ImplicitSolver` 会破坏既有默认行为与回归基线。
+  4) 处理决定：
+     - 已按低风险策略回滚本轮 Step4 强删尝试，恢复到 `cfb7228` 后的稳定语义状态；
+     - 保持 B3 已完成成果（`Solver.jl` 无 direct forwarding）不变。
+   5) 当前任务单状态：
+      - **未闭环**（Step4 / DoD 尚未满足）；
+      - 下一轮需单独立项完成 non-FixedMu 默认语义等价重构后，方可真正删除 `ImplicitSolver.jl`。
+
+- 2026-04-05：FixedRho joint 策略重构（按“展平与求解策略解耦 + 非 FixedMu 懒触发”执行）
+  1) 根因复核结论：
+     - `ImplicitSolver` 在 `FixedRho` 上是 8 维联合方程单层求解（非双层 μ 外层 + gap 内层）；
+     - 先前 joint 不稳定主因是“求解策略耦合与默认方法不匹配”（非展平方程本身错误）。
+  2) 代码策略调整（`src/models/solver/ProblemSpec.jl`）：
+     - 保留 joint 负责展平残差（`build_residual!(FixedRho, ...)`），求解策略统一走 `solve_root_with_policy(...)`；
+     - `FixedRho` 引入 staged/lazy attempts：
+       - 先 primary 单次尝试；
+       - 失败后才触发 method-rescue / seed-rescue；
+       - 命中满足 hard-constraints 的候选后提前停止（early-stop）；
+     - 方法默认值改为“连续性优先”自适应：
+       - `continuity_seed=true` 默认 `:newton`；
+       - 否则默认 `:trust_region`；
+     - 增补 joint 诊断元信息：
+       - `fixedrho_joint_selected_method`
+       - `fixedrho_joint_selected_quality`
+       - `fixedrho_joint_fallback_used`
+       - `fixedrho_joint_attempt_origin`。
+  3) 测试口径更新：
+     - regression：`tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl`
+       - 新增 continuity-like `joint-only` 稳定性回归（滚动 seed）；
+       - 保留/强化 joint parity gates（no-fallback 与 with-fallback 分支口径）。
+     - unit：`tests/unit/models/test_problem_spec_contract.jl`
+       - 同步 FixedRho forward_solve 合同与元信息断言。
+     - unit：`tests/unit/models/test_solver.jl`
+       - `FixedRho default/bridge semantic parity (single point)` 调整为与默认 seed 语义一致（bridge 使用 `get_seed(...)` 的 mode-extended 初值），避免“手工未扩展 seed”造成非目标分支。
+  4) 本轮验证通过：
+     - `julia --project=. -e 'include("tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl")'`
+     - `julia --project=. -e 'include("tests/unit/models/test_problem_spec_contract.jl")'`
+     - `julia --project=. -e 'include("tests/unit/models/test_solver.jl")'`（25/25）
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）。
+  5) 当前状态与约束：
+     - `FixedMu` 强制多 attempts 选优逻辑保持不变；
+     - 非 `FixedMu` 按“懒触发 attempts”推进，优先对齐真实扫描使用场景（continuity seed）；
+     - `fixedrho_joint_solve=false` 兼容分支仍保留（便于过渡期对照/回归），尚未进行物理语义层面的全量 legacy 退役。

--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -327,3 +327,15 @@ Files:
      - integration：
        - `tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl`（43/43）
        - `tests/integration/models/test_models_native_solver_phase1_smoke.jl`（11/11）。
+- 2026-04-04：B3 主迁移进展（当前轮）
+  1) 已完成：
+     - non-FixedMu `solve` / `solve_multi` 的语义桥接路径可用并稳定（显式语义参数时走主链）；
+     - `solve_multi(FixedRho/FixedAsymmetricRho)` 默认路径改为“多种子 + 调 `solve` 聚合筛选”，不再直接依赖 `ImplicitSolver.solve_multi` 语义。
+  2) 保守回退策略：
+     - `solve` 默认路径（无语义桥接参数）对 `FixedRho/FixedEntropy/FixedSigma/FixedAsymmetricRho` 仍保留 `ImplicitSolver.solve`，以避免已确认的约束回归。
+  3) 当前剩余 direct forwarding（`Solver.jl`）：
+     - `ImplicitSolver.solve(mode, T_fm; ...)`（默认 non-FixedMu path）
+     - `ImplicitSolver.solve_multi(mode, T_fm; ...)`（保护性尾路径，当前主分支不走）
+  4) 下一步建议：
+     - 为 `FixedRho/FixedEntropy/FixedSigma` 建立“默认语义等价桥接”后，再替换默认路径；
+     - 最后再处理 `FixedAsymmetricRho` 默认路径与 weighted-fallback 协同。

--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -1,0 +1,278 @@
+# Models 求解器主链收敛与 ImplicitSolver 退役任务单
+
+更新日期：2026-04-04
+
+目标：
+- 在不改变物理结果与回归基线的前提下，将求解器能力收敛到 models 主链；
+- 最终移除 `src/models/solver/ImplicitSolver.jl` 的运行时依赖。
+
+---
+
+## 0. 当前共识（会话记录）
+
+- `solve_constraint` 主链已存在（`Solver.jl -> ProblemSpec/constraint_solver.jl`）。
+- 扫描链路默认使用 models 路径，但 `Trho` 的 rescue 仍通过 `_solve_weighted_block_fallback` 间接触达 `ImplicitSolver`。
+- 隐式求导主实现已在 `src/models/implicit_gap.jl`（`create_pnjl_implicit_solver` / `solve_pnjl_with_derivatives`）。
+- `ImplicitSolver.solve_with_derivatives` 当前是转发壳。
+
+---
+
+## 1. 迁移步骤（最小风险序列）
+
+### Step 1：断开求解主入口对 `ImplicitSolver` 的硬依赖
+
+- [ ] 将 `src/models/solver/Solver.jl` 中 `solve(...)` / `solve_multi(...)` 从 `ImplicitSolver.*` 转发，改为统一走 `solve_constraint(...)` 主链（必要时保留参数适配层）。
+- [ ] 将 `is_physical_solution` 收敛为 models 主链可见规则，不再经 `ImplicitSolver.default_is_physical_solution` 转发。
+
+验收（最小集）：
+- [ ] `tests/unit/models/test_constraint_solver.jl`
+- [ ] `tests/unit/models/test_problem_spec_contract.jl`
+- [ ] `tests/integration/models/test_solver_auto_backend_semantic_parity.jl`
+
+### Step 2：将 weighted fallback 平移到 models 主链
+
+- [ ] 将 `solve_weighted_block_fallback` 从 `ImplicitSolver` 迁移到 models 侧（建议新建 `src/models/solver/WeightedFallback.jl` 或并入 `constraint_solver.jl`）。
+- [ ] `src/models/scans/TrhoScan.jl` 直接调用 models 侧 fallback 能力，不再经 `Solver.jl` 私有桥 `_solve_weighted_block_fallback`。
+- [ ] 删除 `Solver.jl` 中 `_solve_weighted_block_fallback` 桥接。
+
+验收（最小集）：
+- [ ] `tests/integration/pnjl/test_trho_scan_semantic_modes_smoke.jl`
+- [ ] `tests/integration/pnjl/test_trho_scan_solver_backend_models_smoke.jl`
+- [ ] 对应 regression smoke
+
+### Step 3：收敛隐式求导入口，仅保留 `implicit_gap.jl` 主实现
+
+- [ ] 移除 `ImplicitSolver.solve_with_derivatives` 对外导出（或降级 internal）。
+- [ ] 统一对外入口为 `Models.solve_pnjl_with_derivatives` 与 `Models.create_pnjl_implicit_solver`。
+- [ ] 清理 `Solver.jl` 中与导数相关的重复包装（保留一个稳定入口）。
+
+验收（最小集）：
+- [ ] `tests/unit/models/test_implicit_gap.jl`
+- [ ] `tests/integration/models/test_models_implicitdiff_flavor_mu_smoke.jl`
+- [ ] `tests/unit/pnjl/test_solver_implicit.jl`
+
+### Step 4：移除 `ImplicitSolver` 模块并收口导出/文档
+
+- [ ] 删除 `src/models/solver/ImplicitSolver.jl`。
+- [ ] 清理 `Models.jl` 中 include/export 与所有 `ImplicitSolver.` 调用残留。
+- [ ] 更新 `docs/api/models/solver/*` 与 generated 导出索引。
+
+验收（全量收口）：
+- [ ] unit/integration/regression smoke 全通过
+- [ ] `julia --project=. scripts/dev/check_docs_consistency.jl`
+- [ ] `julia --project=. scripts/dev/check_legacy_solver_switch_leakage.jl`
+
+---
+
+## 2. DoD（完成判据）
+
+- [ ] 全仓代码调用中无 `ImplicitSolver.`（仅允许历史文档文字）。
+- [ ] scan / constraint / derivative 三类能力均通过 models 主链到达。
+- [ ] PR 证据包含：旧入口移除、主链稳定、测试闭环。
+
+---
+
+## 2.5 实现计划（基于当前讨论，待执行）
+
+说明：本计划先聚焦“能力收敛与维度契约化”，不改变物理含义与数值语义。
+
+### Task 1：维度契约最小 API 落地（先统一元信息入口）
+
+目标：把“5/3/8”从散落硬编码收敛为统一访问接口。
+
+Files:
+- Modify: `src/models/solver/StateSchema.jl`
+- Modify: `src/models/solver/ConstraintModes.jl`
+- Modify: `src/models/solver/ConstraintComponents.jl`
+- Test: `tests/unit/models/test_solver_dimension_agnostic.jl`
+
+- [ ] 增加维度访问函数（例如 `state_dim(schema)`, `mu_dim(mode)`, `total_dim(mode, schema)`）。
+- [ ] 在不改行为前提下，为 PNJL/RPNJL 约束模式返回与现状一致的维度。
+- [ ] 在单测中加入维度契约断言，覆盖 FixedMu/FixedRho/FixedEntropy/FixedSigma/FixedAsymmetricRho。
+
+验证命令：
+- `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver_dimension_agnostic.jl"; include("tests/unit/runtests.jl")'`
+
+### Task 2：`Conditions.jl` 去硬编码（A 档第一优先）
+
+目标：让条件函数只依赖 schema+mode，不直接切片 `x[1:5]` / `x[6:8]`。
+
+Files:
+- Modify: `src/models/solver/Conditions.jl`
+- Test: `tests/unit/models/test_problem_spec_contract.jl`
+- Test: `tests/unit/models/test_constraint_solver.jl`
+
+- [x] 让 `build_conditions(::FixedRho, params)` 成为 schema 版 wrapper（内部统一走 schema 路径）。
+- [x] 对 `FixedAsymmetricRho/FixedEntropy/FixedSigma` 同步做 schema 化切片。
+- [x] 将 `_gap_conditions_dynamic` 从“固定 5/3”改为“由 schema/mode 约束验证”，并保留清晰错误信息。
+
+验证命令：
+- `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_contract.jl,models/test_constraint_solver.jl"; include("tests/unit/runtests.jl")'`
+
+### Task 3：`constraint_solver.jl` pack/unpack 统一化（A 档第二优先）
+
+目标：把 candidate / solution 的固定维度构造替换为维度契约 API。
+
+Files:
+- Modify: `src/models/constraint_solver.jl`
+- Modify: `src/models/solver/StateSchema.jl`（如需补 helper）
+- Test: `tests/unit/models/test_constraint_solver.jl`
+
+- [x] 引入统一 `pack_solution(...)` / `unpack_solution(...)` / `empty_candidate(...)` helper。
+- [x] 替换 `_solve_constraint_fixedrho/_fixedentropy/_fixedsigma/_fixedasymrho` 中 `SVector{5}/SVector{3}/Float64[...]` 散点拼装。
+- [x] 保证返回字段与当前契约完全一致。
+
+验证命令：
+- `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_constraint_solver.jl,models/test_problem_spec_contract.jl"; include("tests/unit/runtests.jl")'`
+
+### Task 4：联合方程组试点（FixedRho）
+
+目标：验证“展平求解”在单模式上的可行性与稳定性。
+
+Files:
+- Modify: `src/models/constraint_solver.jl`
+- Modify: `src/models/solver/ProblemSpec.jl`
+- Add/Modify: `tests/integration/models/test_solver_auto_backend_semantic_parity.jl`
+- Add/Modify: `tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl`
+
+- [x] 新增 `FixedRho` 联合残差构造（未知量与方程组一次性求解）。
+- [x] 保留旧路径开关用于 A/B 对比（默认不切换行为）。
+- [x] 输出对比证据：收敛率、残差、耗时、结果偏差（容差内）。
+
+验证命令：
+- `julia --project=. -e 'ENV["INTEGRATION_FILES"]="models/test_solver_auto_backend_semantic_parity.jl"; include("tests/integration/runtests.jl")'`
+- `julia --project=. -e 'ENV["REGRESSION_FILES"]="models/test_problem_spec_fixedrho_parity_regression.jl"; include("tests/regression/runtests.jl")'`
+
+### Task 5：扫描链路与 fallback 对齐（Step 2 衔接）
+
+目标：把 `Trho` rescue 从 `Solver.jl` 私有桥迁走。
+
+Files:
+- Modify: `src/models/scans/TrhoScan.jl`
+- Modify/Add: `src/models/solver/WeightedFallback.jl`（或并入 `constraint_solver.jl`）
+- Modify: `src/models/solver/Solver.jl`
+- Test: `tests/integration/pnjl/test_trho_scan_semantic_modes_smoke.jl`
+
+- [x] 提供 models 侧明确 fallback 能力入口。
+- [x] `TrhoScan` 直接调用该入口，不经 `_solve_weighted_block_fallback`。
+- [x] 删除 `Solver.jl` 私有桥并更新对应测试。
+
+验证命令：
+- `julia --project=. -e 'ENV["INTEGRATION_FILES"]="pnjl/test_trho_scan_semantic_modes_smoke.jl,pnjl/test_trho_scan_solver_backend_models_smoke.jl"; include("tests/integration/runtests.jl")'`
+
+### Task 6：收敛导数入口 + 预备退役 `ImplicitSolver`
+
+目标：导数能力仅保留 `implicit_gap.jl` 主实现对外入口。
+
+Files:
+- Modify: `src/models/solver/Solver.jl`
+- Modify: `src/models/solver/ImplicitSolver.jl`
+- Modify: `src/models/Models.jl`
+- Test: `tests/unit/models/test_implicit_gap.jl`
+
+- [x] 去掉 `ImplicitSolver.solve_with_derivatives` 对外可见性（或降 internal）。
+- [x] 对外 API 统一为 `Models.solve_pnjl_with_derivatives` 与 `Models.create_pnjl_implicit_solver`。
+- [x] 补文档与测试口径一致性。
+
+验证命令：
+- `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_implicit_gap.jl,pnjl/test_solver_implicit.jl"; include("tests/unit/runtests.jl")'`
+
+### Task 7：全量收口与退役检查
+
+目标：确保迁移后可安全删除 `ImplicitSolver.jl`（若本轮覆盖完整则执行删除，否则形成下一轮 gate）。
+
+Files:
+- Modify: `docs/api/models/solver/*`
+- Modify: `docs/api/generated/models/ModelsExportIndex.md`（脚本生成）
+
+- [x] 跑全套 smoke + docs/governance。
+- [x] 生成“剩余 Implicit 依赖点”报告（必须为空才可删文件）。
+- [x] 若不为空，记录 blockers 与下一轮拆分项。
+
+验证命令：
+- `julia --project=. -e 'ENV["UNIT_PROFILE"]="smoke"; include("tests/unit/runtests.jl")'`
+- `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`
+- `julia --project=. -e 'ENV["REGRESSION_PROFILE"]="smoke"; include("tests/regression/runtests.jl")'`
+- `julia --project=. scripts/dev/check_docs_consistency.jl`
+- `julia --project=. scripts/dev/check_legacy_solver_switch_leakage.jl`
+
+---
+
+## 3. 执行记录（append-only）
+
+- 2026-04-04：根据会话共识建立本任务单，记录 Step 1~4 最小风险迁移序列与 DoD。
+- 2026-04-04：补充“联合方程组展平求解”优化路线共识：
+  1) 先抽“按模式生成联合残差方程组”的统一接口，不立即替换全量求解器；
+  2) 先在 `FixedRho` 做展平联合求解试点，与现有路径对比收敛/耗时/稳健性；
+  3) 试点稳定后再推广到 `FixedEntropy/FixedSigma/FixedAsymmetricRho`，最后删除外层-内层分治路径。
+- 2026-04-04：完成 Task2（`Conditions.jl` schema+mode 去硬编码）并补充单测：
+  1) `build_conditions(::FixedRho, params)` 改为 schema wrapper；
+  2) 为 `FixedAsymmetricRho/FixedEntropy/FixedSigma` 新增 schema 版 `build_conditions`；
+  3) `_gap_conditions_dynamic` 增加 schema/mode 维度契约校验与清晰报错；
+  4) 新增 non-rho schema 路径 parity 与 mismatch 报错单测。
+- 2026-04-04：Task3 进行中：
+  1) 在 `constraint_solver.jl` 新增 `_pack_solution/_unpack_solution/_empty_candidate`；
+  2) 已将多个模式返回结果中的 `Float64[...]` 散点拼装替换为 `_pack_solution(...)`；
+  3) 已补充 helper 单测；下一步继续收敛内部 `SVector`/切片构造。
+- 2026-04-04：Task3 收口完成：
+  1) `_solve_constraint_fixedrho/_fixedentropy/_fixedsigma/_fixedasymrho` 返回值统一走 `_pack_solution(...)`；
+  2) 引入 `_to_state_svec/_to_mu_svec/_mass_from_state` 收敛 `SVector` 与 mass 构造散点；
+  3) 目标验证通过：
+     - `models/test_problem_spec_contract.jl` + `models/test_constraint_solver.jl`（155/155）；
+     - `tests/integration/models/test_solver_auto_backend_semantic_parity.jl`（direct include 4/4）。
+- 2026-04-04：Task4 启动（阶段化落地，先 gate 后联合求解）：
+  1) 在 `ProblemSpec` FixedRho forward_solve 增加 `fixedrho_joint_solve::Bool` 参数校验；
+  2) 作为 A/B 开关占位，当前默认和开启时均走现有路径，并回传 `fixedrho_joint_solve_requested/fixedrho_joint_solve_active` 元信息；
+  3) 新增/更新测试覆盖 flag 语义与回归口径：
+     - `tests/unit/models/test_problem_spec_contract.jl`；
+     - `tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl`；
+  4) 验证通过：
+     - unit 目标集（160/160）；
+     - regression 目标集（27/27）。
+- 2026-04-04：Task4 第二阶段完成（FixedRho 联合求解试点）：
+  1) 在 `ProblemSpec` 中新增 `_fixedrho_joint_problem_spec_forward_solve`，基于 `Conditions.build_residual!(FixedRho, ...)` 做 8 维一次性 NLsolve；
+  2) `fixedrho_joint_solve=true` 时优先尝试联合求解；若残差不可接受或失败，自动回退到既有 `_solve_constraint_fixedrho`（保序保稳）；
+  3) 返回元信息扩展：`fixedrho_joint_solve_requested / fixedrho_joint_solve_active / fixedrho_joint_fallback`；
+  4) 新增与更新测试：
+     - `tests/unit/models/test_problem_spec_contract.jl`（joint+fallback 语义覆盖）；
+     - `tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl`（joint flag 回归口径）。
+  5) 验证结果：
+     - unit 目标集：`165/165`；
+     - regression 目标集：`33/33`。
+- 2026-04-04：Task5 完成（Trho fallback 链路对齐）：
+  1) 新增 models 侧 `src/models/solver/WeightedFallback.jl`，导出 `solve_weighted_block_fallback`；
+  2) `src/models/scans/TrhoScan.jl` 改为直接调用 `Main.Models.solve_weighted_block_fallback`；
+  3) 删除 `src/models/solver/Solver.jl` 私有桥 `_solve_weighted_block_fallback`；
+  4) `src/models/Models.jl` 增加 include/export；
+  5) 更新单测口径（`test_solver_dimension_agnostic.jl`）；
+  6) 验证通过：
+     - unit: `models/test_solver_dimension_agnostic.jl,models/test_problem_spec_contract.jl`（163/163）；
+     - integration direct file:
+       - `tests/integration/pnjl/test_trho_scan_semantic_modes_smoke.jl`（6/6）
+       - `tests/integration/pnjl/test_trho_scan_solver_backend_models_smoke.jl`（22/22 分组通过）。
+- 2026-04-04：Task6 完成（导数入口收敛）：
+  1) `src/models/solver/ImplicitSolver.jl` 移除 `solve_with_derivatives` export 与实现；
+  2) `src/models/solver/Solver.jl` 中 `solve_with_derivatives` 改为转发 `solve_pnjl_with_derivatives`（models 主实现）；
+  3) 更新口径测试：`tests/unit/models/test_solver_dimension_agnostic.jl` 增加 `:solve_with_derivatives ∉ names(Models.ImplicitSolver)`；
+  4) 验证通过：
+     - unit 目标集：`models/test_implicit_gap.jl,pnjl/test_solver_implicit.jl,models/test_solver_dimension_agnostic.jl`（123/123）；
+     - integration direct file：`tests/integration/models/test_models_native_solver_phase1_smoke.jl`（11/11）。
+- 2026-04-04：Task7 收口检查完成：
+  1) Smoke 验证：
+     - unit smoke：`781/781`；
+     - integration smoke：`437/437`（首次运行因工具超时中断，重跑 with longer timeout 通过）；
+     - regression smoke：`423/424`，其中 1 个 Broken 为已声明可选跳过（tau xi probe fixture 缺失）；
+  2) Governance：
+     - `scripts/dev/check_docs_consistency.jl` => OK；
+     - `scripts/dev/check_legacy_solver_switch_leakage.jl` => OK；
+  3) “剩余 Implicit 依赖点”清点（`src/`）：
+     - `src/models/solver/Solver.jl` 仍有 `ImplicitSolver.*` 依赖：
+       - `SolverResult = ImplicitSolver.SolverResult`
+       - `solve/solve_multi` 多个入口仍转发 `ImplicitSolver.solve`/`solve_multi`
+       - `is_physical_solution` 仍转发 `ImplicitSolver.default_is_physical_solution`
+       - `src/models/Models.jl` 仍 include `solver/ImplicitSolver.jl`
+  4) 结论：当前 **不可删除** `src/models/solver/ImplicitSolver.jl`。
+  5) 下一轮 blockers（建议拆分）：
+     - B1：将 `solve/solve_multi` 从 `ImplicitSolver` 转发迁移到 models 主链（对应 Step 1 尾项）。
+     - B2：收敛 `SolverResult` 与 `is_physical_solution` 到 models 原生实现，解除对 `ImplicitSolver` 类型/函数依赖。
+     - B3：完成 B1/B2 后再执行模块删除与 include/export 收口。

--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -373,3 +373,26 @@ Files:
      - `julia --project=. -e 'include("tests/integration/models/test_models_native_solver_phase1_smoke.jl")'`（11/11）
   4) 当前 direct forwarding 余量（`Solver.jl`）：
      - `ImplicitSolver.solve(mode, T_fm; ...)`：仅保留在默认 `FixedRho/FixedAsymmetricRho` 路径。
+
+- 2026-04-05：B3 收口完成（Rho/Asym 默认路径）
+  1) 红灯验证（先证伪）：
+     - 在 `tests/unit/models/test_solver.jl` 新增两组 parity 用例：
+       - `FixedRho default/bridge semantic parity (single point)`
+       - `FixedAsymmetricRho default/bridge semantic parity (single point)`
+     - 初始失败，确认默认路径与桥接主链在该两模式上仍存在语义差距。
+  2) 绿灯修复（最小收口）：
+     - `constraint_solver.jl`：
+       - `_solve_constraint_fixedasymrho` 增加 PNJL 兜底（失败时显式回退 `Main.Models.ImplicitSolver.solve(...)`）；
+       - 保持 `_solve_constraint_fixedrho` 既有兜底路径；
+       - 结合上一轮 Entropy/Sigma 兜底，形成 non-FixedMu 主链可用闭环。
+     - `Solver.jl`：
+       - 默认 `solve(model, mode::Union{FixedRho,FixedAsymmetricRho,FixedEntropy,FixedSigma}, ...)` 统一改走 ProblemSpec 主链；
+       - 删除 `solve` 中 non-FixedMu 对 `ImplicitSolver.solve` 的最后 direct forwarding 分支。
+  3) 验证通过：
+     - `julia --project=. -e 'include("tests/unit/models/test_solver.jl")'`（25/25）
+     - `julia --project=. -e 'include("tests/unit/pnjl/test_solver_implicit.jl")'`
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
+     - `julia --project=. -e 'include("tests/integration/models/test_models_native_solver_phase1_smoke.jl")'`（11/11）
+  4) 状态结论：
+     - `Solver.jl` 已无 `ImplicitSolver.solve`/`solve_multi` direct forwarding；
+     - 剩余 `ImplicitSolver` 依赖已下沉到 `constraint_solver` 的兼容兜底层，用于维持语义与回归稳定。

--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -710,3 +710,21 @@ Files:
   5) 阶段结论：
      - `FixedRho` 已完成“外层计划编排”与通用主链的第一层统一；
      - 当前仍保留 `FixedRho` 专用 joint solve 主体，后续若继续统一，应把“候选执行与结果整形”再抽一层通用执行器，并单独跑 parity/regression gate。
+
+- 2026-04-05："额外约束作为通用输入" 阶段 6（候选执行器统一层）
+  1) 目标：
+     - 进一步收敛 `FixedRho` 与 non-rho 的共同外层流程，将“attempt 执行 + hard-rule 评估 + selector 选优”抽成统一执行器。
+  2) 生产实现（`src/models/solver/ProblemSpec.jl`）：
+     - 新增 `_execute_governed_attempt_plan(...)`：
+       - 输入 `attempt_plan + solve_attempt + failure_attempt + hard_constraints + selector`；
+       - 统一处理 candidate 生成、约束评估、提前收敛退出、最终 selector 选取。
+     - `FixedRho` 前向求解与 `_governed_nonrho_problem_spec_forward_solve(...)` 改为复用该统一执行器；
+     - 维持原始输出契约不变（包括 `fixedrho_joint_*` 与 `governed_*` 字段）。
+  3) 验证结果：
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_contract.jl"; include("tests/unit/runtests.jl")'`（176/176）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl"; include("tests/unit/runtests.jl")'`（25/25）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_semantic_modes.jl"; include("tests/unit/runtests.jl")'`（7/7）
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
+  4) 阶段结论：
+     - `FixedRho` 与 non-rho 已在“计划生成 + 候选执行 + 选优治理”三层对齐；
+     - 当前剩余 mode 差异已主要收敛到“内核 solve closure + 结果字段差异（joint metadata）”，符合逐层去分叉目标。

--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -339,3 +339,18 @@ Files:
   4) 下一步建议：
      - 为 `FixedRho/FixedEntropy/FixedSigma` 建立“默认语义等价桥接”后，再替换默认路径；
      - 最后再处理 `FixedAsymmetricRho` 默认路径与 weighted-fallback 协同。
+
+- 2026-04-05：B3 默认路径收口（solve_multi 尾转发移除）
+  1) 已完成：
+     - `Solver.jl` 中 non-FixedMu `solve_multi` 保护性尾路径已移除，不再调用 `ImplicitSolver.solve_multi(mode, T_fm; ...)`；
+     - 该分支改为显式 `ArgumentError("unsupported mode for solve_multi bridge: ...")`，避免静默回落与语义漂移。
+  2) 当前 direct forwarding 余量：
+     - `ImplicitSolver.solve(mode, T_fm; ...)`（默认 non-FixedMu `solve` 路径，保守保留）。
+  3) 验证通过：
+     - `julia --project=. -e 'include("tests/unit/models/test_solver.jl")'`
+     - `julia --project=. -e 'include("tests/unit/pnjl/test_solver_implicit.jl")'`
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`
+     - `julia --project=. -e 'include("tests/integration/models/test_models_native_solver_phase1_smoke.jl")'`
+  4) 下一步建议（保持低风险顺序）：
+     - 为 `FixedEntropy/FixedSigma` 先补“默认语义等价桥接”的最小验证集（点位+多 seed 选择一致性）；
+     - 再尝试替换 `solve` 默认 non-FixedMu 对 `ImplicitSolver.solve` 的最后一处转发。

--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -354,3 +354,22 @@ Files:
   4) 下一步建议（保持低风险顺序）：
      - 为 `FixedEntropy/FixedSigma` 先补“默认语义等价桥接”的最小验证集（点位+多 seed 选择一致性）；
      - 再尝试替换 `solve` 默认 non-FixedMu 对 `ImplicitSolver.solve` 的最后一处转发。
+
+- 2026-04-05：B3 默认路径替换（Entropy/Sigma）
+  1) 红灯验证（先证伪）：
+     - 新增 `tests/unit/models/test_solver.jl` 中两组 parity 用例：
+       - `FixedEntropy default/bridge semantic parity (single point)`
+       - `FixedSigma default/bridge semantic parity (single point)`
+     - 在替换前，测试稳定失败：默认 `solve` 可收敛而桥接 `solve_constraint` 路径不收敛，确认语义差距真实存在。
+  2) 绿灯修复（最小改动）：
+     - 在 `constraint_solver.jl` 的 `_solve_constraint_fixedentropy/_solve_constraint_fixedsigma` 中增加 PNJL 兜底：
+       - 当 models 外层约束求解未达收敛时，显式回退 `Main.Models.ImplicitSolver.solve(...)`；
+       - 回填为统一返回结构，保证 `solve_constraint` 调用方语义稳定。
+     - 在 `Solver.jl` 中将 `FixedEntropy/FixedSigma` 默认 `solve` 路径切至 ProblemSpec 主链（不再走 `ImplicitSolver.solve` 直转发）。
+  3) 验证通过：
+     - `julia --project=. -e 'include("tests/unit/models/test_solver.jl")'`（17/17）
+     - `julia --project=. -e 'include("tests/unit/pnjl/test_solver_implicit.jl")'`
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
+     - `julia --project=. -e 'include("tests/integration/models/test_models_native_solver_phase1_smoke.jl")'`（11/11）
+  4) 当前 direct forwarding 余量（`Solver.jl`）：
+     - `ImplicitSolver.solve(mode, T_fm; ...)`：仅保留在默认 `FixedRho/FixedAsymmetricRho` 路径。

--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -466,3 +466,28 @@ Files:
   5) 阶段结论：
      - `FixedRho` 在 ProblemSpec 层已不再保留 legacy 兼容分支；
      - 仍需后续轮次继续处理 `constraint_solver` 其他 non-FixedMu 模式中的 legacy fallback 依赖，方可推进 Step4 全量退役。
+
+- 2026-04-05：FixedRho 全链路去 legacy + Entropy/Sigma 懒触发策略推广（进行中）
+  1) FixedRho 全链路收口：
+     - `constraint_solver.jl` 中 `_solve_constraint_fixedrho(...)` 已移除对 `Main.Models.ImplicitSolver.solve(...)` 的 PNJL fallback；
+     - 至此 `FixedRho` 在当前主链路径中不再依赖 `ImplicitSolver` 兜底。
+  2) Entropy/Sigma 策略推广（沿用 FixedRho 成熟模式）：
+     - `ProblemSpec._fixedentropy_problem_spec_forward_solve(...)` 与 `_fixedsigma_problem_spec_forward_solve(...)` 改为非 `FixedMu` 懒触发 attempts：
+       - 先 primary 单次尝试；
+       - 失败后触发 method-rescue / seed-rescue；
+       - 命中通过 hard-constraints 的候选后 early-stop；
+     - 默认方法改为 continuity-aware：
+       - `continuity_seed=true` 默认 `:newton`；
+       - 否则默认 `:trust_region`；
+     - 保持 `FixedMu` 强制多 attempts 选优逻辑不变。
+  3) 约束求解器配套改动：
+     - `_solve_constraint_fixedentropy(...)`、`_solve_constraint_fixedsigma(...)` 新增 `nlsolve_method` 参数，并用于外层 nlsolve 方法选择，支持策略层方法切换。
+  4) 本轮验证通过：
+     - `julia --project=. -e 'include("tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl")'`
+     - `julia --project=. -e 'include("tests/unit/models/test_problem_spec_contract.jl")'`
+     - `julia --project=. -e 'include("tests/unit/models/test_solver.jl")'`（25/25）
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）。
+  5) 当前状态：
+     - `FixedRho` 已进入“joint 主链 + 无 legacy fallback”状态并保持回归稳定；
+     - `FixedEntropy/FixedSigma` 已完成“懒触发 attempts + continuity-aware 默认方法”推广；
+     - 下一步按计划进入 `FixedAsymmetricRho` 同策略迁移与收口。

--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -276,3 +276,20 @@ Files:
      - B1：将 `solve/solve_multi` 从 `ImplicitSolver` 转发迁移到 models 主链（对应 Step 1 尾项）。
      - B2：收敛 `SolverResult` 与 `is_physical_solution` 到 models 原生实现，解除对 `ImplicitSolver` 类型/函数依赖。
      - B3：完成 B1/B2 后再执行模块删除与 include/export 收口。
+- 2026-04-04：B1 继续推进（分段迁移）：
+  1) `Solver.jl` 中 `solve(model, FixedMu, ...)` 与 `solve_multi(model, FixedMu, ...)` 已迁移到 models 主链（`solve_constraint + selector`）；
+  2) `FixedRho/FixedEntropy/FixedSigma/FixedAsymmetricRho` 在本轮尝试全量迁移时引入质量回归（integration smoke 失败），已回滚其迁移部分并保持旧行为；
+  3) 为防止递归路径，`constraint_solver.jl` 中 `FixedRho` 失败回退已改为显式调用 `Main.Models.ImplicitSolver.solve(...)`（避免通过 `Main.Models.solve(...)` 再入新分发）；
+  4) 验证通过：
+     - `tests/unit/pnjl/test_solver_implicit.jl` 全通过；
+     - `tests/unit/models/test_solver.jl` 全通过；
+     - `tests/integration/models/test_models_native_solver_phase1_smoke.jl` 全通过；
+     - `tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl` 全通过。
+  5) 当前 B1 状态：**部分完成（FixedMu 主链化完成，其余模式待下一轮拆分迁移）**。
+- 2026-04-04：B1-2 尝试记录（FixedRho 单独迁移实验）：
+  1) 尝试将 `solve(model, FixedRho, ...)` / `solve_multi(model, FixedRho, ...)` 迁移到 models 主链；
+  2) 回归观察到 `fixedrho semantic equivalence` 口径偏移（legacy 与 models 数值误差超阈，且 legacy convergence 断言不稳定）；
+  3) 已回滚该迁移，恢复 FixedRho 走 `ImplicitSolver` 路径，确保当前门禁稳定全绿；
+  4) 仍保留已稳定项：
+     - `solve(model, FixedMu, ...)` 与 `solve_multi(model, FixedMu, ...)` 主链化；
+     - `constraint_solver` 中 FixedRho fallback 明确调用 `Main.Models.ImplicitSolver.solve(...)`，避免递归。

--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -491,3 +491,23 @@ Files:
      - `FixedRho` 已进入“joint 主链 + 无 legacy fallback”状态并保持回归稳定；
      - `FixedEntropy/FixedSigma` 已完成“懒触发 attempts + continuity-aware 默认方法”推广；
      - 下一步按计划进入 `FixedAsymmetricRho` 同策略迁移与收口。
+
+- 2026-04-05：FixedAsymmetricRho 策略推广（与 FixedRho/Entropy/Sigma 对齐）
+  1) 目标：将 `FixedAsymmetricRho` 统一到非 `FixedMu` 懒触发 attempts 框架，保持 “joint/约束构造与策略层解耦”。
+  2) 代码落地：
+     - `ProblemSpec._fixedasymrho_problem_spec_forward_solve(...)` 已改为 staged/lazy attempts：
+       - 先 primary 单次尝试；
+       - 失败后触发 method-rescue / seed-rescue；
+       - 命中 hard-constraints 后 early-stop；
+     - 默认方法改为 continuity-aware：
+       - `continuity_seed=true` 默认 `:newton`；
+       - 否则默认 `:trust_region`；
+     - `_solve_constraint_fixedasymrho(...)` 新增 `nlsolve_method` 参数并用于 outer nlsolve 方法选择。
+  3) 验证通过：
+     - `julia --project=. -e 'include("tests/unit/models/test_solver.jl")'`（25/25）
+     - `julia --project=. -e 'include("tests/unit/models/test_problem_spec_contract.jl")'`（121/121）
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
+     - `julia --project=. -e 'include("tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl")'`（fixedrho guard 全通过，防回归）。
+  4) 阶段状态：
+     - 非 `FixedMu` 三个模式（`FixedRho` / `FixedEntropy` / `FixedSigma` / `FixedAsymmetricRho`）已统一到“懒触发 attempts + continuity-aware 默认方法”的策略骨架；
+     - `FixedMu` 继续保持“强制多 attempts 选优”作为唯一多解主模式。

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -59,6 +59,7 @@ export solve_constraint
 export solve, solve_multi, SolverResult
 export ModelStateSchema, schema_for_model, flatten_state, unflatten_state
 export ConstraintModes
+export state_var_dim, mu_var_dim, solution_dim
 export ProblemSpec, build_problem_spec
 export AbstractConstraintComponent
 export constraint_name, constraint_dim, build_constraint_components, constraint_total_dim
@@ -68,6 +69,7 @@ export get_seed, update!, reset!, get_all_seeds, set_phase!
 export HADRON_SEED_5, QUARK_SEED_5, HADRON_SEED_8, QUARK_SEED_8
 export build_conditions, build_residual!, GapParams
 export explicit_residual, explicit_residual!
+export solve_weighted_block_fallback
 export solve_with_derivatives
 export is_physical_solution
 export RootProblemSpec, RootPolicy, ContinuationState, RootAttempt, RootDiagnostics, RootSolveResult
@@ -162,6 +164,7 @@ include(joinpath(@__DIR__, "solver", "CandidateGovernance.jl"))
 include(joinpath(@__DIR__, "solver", "SeedStrategies.jl"))
 include(joinpath(@__DIR__, "solver", "Conditions.jl"))
 include(joinpath(@__DIR__, "solver", "GenericRootEngine.jl"))
+include(joinpath(@__DIR__, "solver", "WeightedFallback.jl"))
 include(joinpath(@__DIR__, "solver", "ImplicitSolver.jl"))
 include(joinpath(@__DIR__, "solver", "Solver.jl"))
 include(joinpath(@__DIR__, "derivatives", "ThermoDerivatives.jl"))

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -60,7 +60,7 @@ export solve, solve_multi, SolverResult
 export ModelStateSchema, schema_for_model, flatten_state, unflatten_state
 export ConstraintModes
 export state_var_dim, mu_var_dim, solution_dim
-export ProblemSpec, build_problem_spec
+export ProblemSpec, build_problem_spec, ExtraConstraints, default_extra_constraints
 export AbstractConstraintComponent
 export constraint_name, constraint_dim, build_constraint_components, constraint_total_dim
 export HardRule, CandidateSelector, build_candidate_context

--- a/src/models/constraint_solver.jl
+++ b/src/models/constraint_solver.jl
@@ -1303,6 +1303,48 @@ function _solve_constraint_fixedasymrho(
         isfinite(residual_norm) && residual_norm <= max(Float64(residual_norm_max), 1e-3)
     end
 
+    if !converged && model isa AbstractPNJLModel
+        seed_legacy = if length(seed_guess) >= 8
+            Float64.(seed_guess[1:8])
+        else
+            Main.Models.extend_seed(Float64.(seed_guess), Main.Models.FixedAsymmetricRho(rho_target, ud_ratio_target, s_target))
+        end
+
+        legacy_result = try
+            Main.Models.ImplicitSolver.solve(
+                Main.Models.FixedAsymmetricRho(rho_target, ud_ratio_target, s_target),
+                T_fm;
+                xi=xi,
+                seed_strategy=Main.Models.DefaultSeed(seed_legacy, seed_legacy, :hadron),
+                p_num=p_num,
+                t_num=t_num,
+                model_kind=:PNJL,
+                trust_region_fallback=true,
+                residual_norm_max=residual_norm_max,
+                nlsolve_kwargs...,
+            )
+        catch
+            nothing
+        end
+
+        if legacy_result !== nothing && legacy_result.converged
+            return (
+                converged=true,
+                solution=Float64.(legacy_result.solution),
+                x_state=legacy_result.x_state,
+                mu_vec=legacy_result.mu_vec,
+                omega=legacy_result.omega,
+                pressure=legacy_result.pressure,
+                rho_norm=legacy_result.rho_norm,
+                entropy=legacy_result.entropy,
+                energy=legacy_result.energy,
+                masses=legacy_result.masses,
+                iterations=legacy_result.iterations,
+                residual_norm=legacy_result.residual_norm,
+            )
+        end
+    end
+
     return (
         converged=converged,
         solution=_pack_solution(x_state_ref[], mu_vec_ref[]),

--- a/src/models/constraint_solver.jl
+++ b/src/models/constraint_solver.jl
@@ -1154,6 +1154,7 @@ function _solve_constraint_fixedasymrho(
     p_num::Int=24,
     t_num::Int=8,
     residual_norm_max::Real=1e-6,
+    nlsolve_method::Symbol=:trust_region,
     rho0::Real,
     enforce_physicality::Bool=false,
     physicality_check::Function=((_, _) -> true),
@@ -1232,7 +1233,7 @@ function _solve_constraint_fixedasymrho(
         residual_fn!,
         Float64.(mu0);
         autodiff=:forward,
-        method=:trust_region,
+        method=nlsolve_method,
         xtol=1e-9,
         ftol=1e-9,
         nlsolve_kwargs...,

--- a/src/models/constraint_solver.jl
+++ b/src/models/constraint_solver.jl
@@ -794,7 +794,7 @@ function _solve_constraint_fixedrho(
         end
 
         legacy_result = try
-            Main.Models.solve(
+            Main.Models.ImplicitSolver.solve(
                 Main.Models.FixedRho(rho_target),
                 T_fm;
                 xi=xi,

--- a/src/models/constraint_solver.jl
+++ b/src/models/constraint_solver.jl
@@ -786,48 +786,6 @@ function _solve_constraint_fixedrho(
 
     best === nothing && throw(ArgumentError("FixedRho outer solve failed for all attempts"))
 
-    if !best.converged && model isa AbstractPNJLModel
-        seed_legacy = if length(seed_guess) >= 8
-            Float64.(seed_guess[1:8])
-        else
-            Main.Models.extend_seed(Float64.(seed_guess), Main.Models.FixedRho(rho_target))
-        end
-
-        legacy_result = try
-            Main.Models.ImplicitSolver.solve(
-                Main.Models.FixedRho(rho_target),
-                T_fm;
-                xi=xi,
-                seed_strategy=Main.Models.DefaultSeed(seed_legacy, seed_legacy, :hadron),
-                p_num=p_num,
-                t_num=t_num,
-                nlsolve_method=nlsolve_method,
-                trust_region_fallback=true,
-                residual_norm_max=residual_norm_max,
-                nlsolve_kwargs...,
-            )
-        catch
-            nothing
-        end
-
-        if legacy_result !== nothing && legacy_result.converged
-            return (
-                converged=true,
-                solution=Float64.(legacy_result.solution),
-                x_state=legacy_result.x_state,
-                mu_vec=legacy_result.mu_vec,
-                omega=legacy_result.omega,
-                pressure=legacy_result.pressure,
-                rho_norm=legacy_result.rho_norm,
-                entropy=legacy_result.entropy,
-                energy=legacy_result.energy,
-                masses=legacy_result.masses,
-                iterations=legacy_result.iterations,
-                residual_norm=legacy_result.residual_norm,
-            )
-        end
-    end
-
     return (
         converged=best.converged,
         solution=best.solution,
@@ -856,6 +814,7 @@ function _solve_constraint_fixedentropy(
     p_num::Int=24,
     t_num::Int=8,
     residual_norm_max::Real=1e-6,
+    nlsolve_method::Symbol=:trust_region,
     rho0::Real,
     physicality_check::Function=((_, _) -> true),
     mass_positive_constraint::Bool=true,
@@ -928,7 +887,7 @@ function _solve_constraint_fixedentropy(
         residual_fn!,
         [Float64(mu0)];
         autodiff=:forward,
-        method=:trust_region,
+        method=nlsolve_method,
         xtol=1e-9,
         ftol=1e-9,
         nlsolve_kwargs...,
@@ -1028,6 +987,7 @@ function _solve_constraint_fixedsigma(
     p_num::Int=24,
     t_num::Int=8,
     residual_norm_max::Real=1e-6,
+    nlsolve_method::Symbol=:trust_region,
     rho0::Real,
     physicality_check::Function=((_, _) -> true),
     nlsolve_kwargs...,
@@ -1100,7 +1060,7 @@ function _solve_constraint_fixedsigma(
         residual_fn!,
         [Float64(mu0)];
         autodiff=:forward,
-        method=:trust_region,
+        method=nlsolve_method,
         xtol=1e-9,
         ftol=1e-9,
         nlsolve_kwargs...,

--- a/src/models/constraint_solver.jl
+++ b/src/models/constraint_solver.jl
@@ -959,6 +959,47 @@ function _solve_constraint_fixedentropy(
         ((phys || soft_phys) && residual_norm <= near_accept_tol)
     )
 
+    if !converged && model isa AbstractPNJLModel
+        seed_legacy = if length(seed_guess) >= 8
+            Float64.(seed_guess[1:8])
+        else
+            Main.Models.extend_seed(Float64.(seed_guess), Main.Models.FixedEntropy(s_target))
+        end
+
+        legacy_result = try
+            Main.Models.ImplicitSolver.solve(
+                Main.Models.FixedEntropy(s_target),
+                T_fm;
+                xi=xi,
+                seed_strategy=Main.Models.DefaultSeed(seed_legacy, seed_legacy, :hadron),
+                p_num=p_num,
+                t_num=t_num,
+                trust_region_fallback=true,
+                residual_norm_max=residual_norm_max,
+                nlsolve_kwargs...,
+            )
+        catch
+            nothing
+        end
+
+        if legacy_result !== nothing && legacy_result.converged
+            return (
+                converged=true,
+                solution=Float64.(legacy_result.solution),
+                x_state=legacy_result.x_state,
+                mu_vec=legacy_result.mu_vec,
+                omega=legacy_result.omega,
+                pressure=legacy_result.pressure,
+                rho_norm=legacy_result.rho_norm,
+                entropy=legacy_result.entropy,
+                energy=legacy_result.energy,
+                masses=legacy_result.masses,
+                iterations=legacy_result.iterations,
+                residual_norm=legacy_result.residual_norm,
+            )
+        end
+    end
+
     return (
         converged=converged,
         solution=_pack_solution(x_state_ref[], mu_vec_ref[]),
@@ -1081,6 +1122,47 @@ function _solve_constraint_fixedsigma(
     thermo_finite = isfinite(omega_val) && isfinite(pressure_ref[]) && isfinite(rho_norm_ref[]) && isfinite(entropy_ref[]) && isfinite(energy_ref[])
     phys = physicality_check(x_state_ref[], masses_ref[]) && thermo_finite
     converged = res.f_converged && phys && isfinite(residual_norm) && residual_norm <= max(Float64(residual_norm_max), 1e-3)
+
+    if !converged && model isa AbstractPNJLModel
+        seed_legacy = if length(seed_guess) >= 8
+            Float64.(seed_guess[1:8])
+        else
+            Main.Models.extend_seed(Float64.(seed_guess), Main.Models.FixedSigma(sigma_target))
+        end
+
+        legacy_result = try
+            Main.Models.ImplicitSolver.solve(
+                Main.Models.FixedSigma(sigma_target),
+                T_fm;
+                xi=xi,
+                seed_strategy=Main.Models.DefaultSeed(seed_legacy, seed_legacy, :hadron),
+                p_num=p_num,
+                t_num=t_num,
+                trust_region_fallback=true,
+                residual_norm_max=residual_norm_max,
+                nlsolve_kwargs...,
+            )
+        catch
+            nothing
+        end
+
+        if legacy_result !== nothing && legacy_result.converged
+            return (
+                converged=true,
+                solution=Float64.(legacy_result.solution),
+                x_state=legacy_result.x_state,
+                mu_vec=legacy_result.mu_vec,
+                omega=legacy_result.omega,
+                pressure=legacy_result.pressure,
+                rho_norm=legacy_result.rho_norm,
+                entropy=legacy_result.entropy,
+                energy=legacy_result.energy,
+                masses=legacy_result.masses,
+                iterations=legacy_result.iterations,
+                residual_norm=legacy_result.residual_norm,
+            )
+        end
+    end
 
     return (
         converged=converged,

--- a/src/models/constraint_solver.jl
+++ b/src/models/constraint_solver.jl
@@ -815,6 +815,7 @@ function _solve_constraint_fixedentropy(
     t_num::Int=8,
     residual_norm_max::Real=1e-6,
     nlsolve_method::Symbol=:trust_region,
+    allow_legacy_fallback::Bool=true,
     rho0::Real,
     physicality_check::Function=((_, _) -> true),
     mass_positive_constraint::Bool=true,
@@ -918,7 +919,7 @@ function _solve_constraint_fixedentropy(
         ((phys || soft_phys) && residual_norm <= near_accept_tol)
     )
 
-    if !converged && model isa AbstractPNJLModel
+    if allow_legacy_fallback && !converged && model isa AbstractPNJLModel
         seed_legacy = if length(seed_guess) >= 8
             Float64.(seed_guess[1:8])
         else
@@ -955,6 +956,7 @@ function _solve_constraint_fixedentropy(
                 masses=legacy_result.masses,
                 iterations=legacy_result.iterations,
                 residual_norm=legacy_result.residual_norm,
+                legacy_fallback_used=true,
             )
         end
     end
@@ -972,6 +974,7 @@ function _solve_constraint_fixedentropy(
         masses=masses_ref[],
         iterations=res.iterations,
         residual_norm=residual_norm,
+        legacy_fallback_used=false,
     )
 end
 
@@ -988,6 +991,7 @@ function _solve_constraint_fixedsigma(
     t_num::Int=8,
     residual_norm_max::Real=1e-6,
     nlsolve_method::Symbol=:trust_region,
+    allow_legacy_fallback::Bool=true,
     rho0::Real,
     physicality_check::Function=((_, _) -> true),
     nlsolve_kwargs...,
@@ -1083,7 +1087,7 @@ function _solve_constraint_fixedsigma(
     phys = physicality_check(x_state_ref[], masses_ref[]) && thermo_finite
     converged = res.f_converged && phys && isfinite(residual_norm) && residual_norm <= max(Float64(residual_norm_max), 1e-3)
 
-    if !converged && model isa AbstractPNJLModel
+    if allow_legacy_fallback && !converged && model isa AbstractPNJLModel
         seed_legacy = if length(seed_guess) >= 8
             Float64.(seed_guess[1:8])
         else
@@ -1120,6 +1124,7 @@ function _solve_constraint_fixedsigma(
                 masses=legacy_result.masses,
                 iterations=legacy_result.iterations,
                 residual_norm=legacy_result.residual_norm,
+                legacy_fallback_used=true,
             )
         end
     end
@@ -1137,6 +1142,7 @@ function _solve_constraint_fixedsigma(
         masses=masses_ref[],
         iterations=res.iterations,
         residual_norm=residual_norm,
+        legacy_fallback_used=false,
     )
 end
 
@@ -1155,6 +1161,7 @@ function _solve_constraint_fixedasymrho(
     t_num::Int=8,
     residual_norm_max::Real=1e-6,
     nlsolve_method::Symbol=:trust_region,
+    allow_legacy_fallback::Bool=true,
     rho0::Real,
     enforce_physicality::Bool=false,
     physicality_check::Function=((_, _) -> true),
@@ -1264,7 +1271,7 @@ function _solve_constraint_fixedasymrho(
         isfinite(residual_norm) && residual_norm <= max(Float64(residual_norm_max), 1e-3)
     end
 
-    if !converged && model isa AbstractPNJLModel
+    if allow_legacy_fallback && !converged && model isa AbstractPNJLModel
         seed_legacy = if length(seed_guess) >= 8
             Float64.(seed_guess[1:8])
         else
@@ -1302,6 +1309,7 @@ function _solve_constraint_fixedasymrho(
                 masses=legacy_result.masses,
                 iterations=legacy_result.iterations,
                 residual_norm=legacy_result.residual_norm,
+                legacy_fallback_used=true,
             )
         end
     end
@@ -1319,5 +1327,6 @@ function _solve_constraint_fixedasymrho(
         masses=masses_ref[],
         iterations=res.iterations,
         residual_norm=residual_norm,
+        legacy_fallback_used=false,
     )
 end

--- a/src/models/constraint_solver.jl
+++ b/src/models/constraint_solver.jl
@@ -14,6 +14,48 @@ const rho0 = ρ0_inv_fm3
 
 const HardConstraintRule = Function
 
+@inline function _pack_solution(x_state::AbstractVector, mu_vec::AbstractVector)
+    return vcat(Float64.(x_state), Float64.(mu_vec))
+end
+
+@inline _to_state_svec(st) = SVector{5}(Tuple(state_vector(st)))
+@inline _to_mu_svec(mu_vec) = SVector{3}(Tuple(mu_vec))
+@inline _to_chiral_triplet(x_state) = SVector{3}(x_state[1], x_state[2], x_state[3])
+@inline _mass_from_state(model::AbstractQCDModel, x_state) = calculate_mass_vec(model, _to_chiral_triplet(x_state))
+
+@inline function _unpack_solution(solution::AbstractVector; state_n::Int=5, mu_n::Int=3)
+    return _unpack_solution(solution, Val(state_n), Val(mu_n))
+end
+
+@inline function _unpack_solution(solution::AbstractVector, ::Val{STATE_N}, ::Val{MU_N}) where {STATE_N, MU_N}
+    expected = STATE_N + MU_N
+    length(solution) == expected || throw(ArgumentError("solution length mismatch: expected $expected, got $(length(solution))"))
+    x_state = SVector{STATE_N}(Tuple(solution[1:STATE_N]))
+    mu_vec = SVector{MU_N}(Tuple(solution[(STATE_N + 1):expected]))
+    return x_state, mu_vec
+end
+
+@inline function _empty_candidate(; state_n::Int=5, mu_n::Int=3, residual_norm_max::Real)
+    solution_n = state_n + mu_n
+    return (
+        solution=fill(NaN, solution_n),
+        x_state=SVector{state_n}(fill(NaN, state_n)),
+        mu_vec=SVector{mu_n}(fill(NaN, mu_n)),
+        omega=NaN,
+        pressure=-Inf,
+        rho_norm=NaN,
+        entropy=NaN,
+        energy=NaN,
+        masses=SVector{3}(fill(NaN, 3)),
+        iterations=0,
+        residual_norm=Inf,
+        residual_norm_max=Float64(residual_norm_max),
+        hard_constraint_ok=false,
+        failed_constraints=Symbol[:solver_failed],
+        converged=false,
+    )
+end
+
 @inline function default_mu0_from_seed(seed)::Float64
     if length(seed) >= 8
         return mean(Float64.(seed[6:8]))
@@ -272,7 +314,7 @@ function _compute_fixedmu_candidate(
     p_num::Int,
     t_num::Int,
 )
-    x_state = SVector{5}(Tuple(state_vector(st)))
+    x_state = _to_state_svec(st)
     mu_vec = normalize_mu_vec(μ_fm)
 
     pressure = -omega(model, x_state, T_fm, mu_vec; p_num=p_num, t_num=t_num, xi=xi)
@@ -283,7 +325,7 @@ function _compute_fixedmu_candidate(
     entropy = ForwardDiff.derivative(pressure_T, T_fm)
     energy = -pressure + sum(mu_vec .* rho_vec) + T_fm * entropy
     omega_val = -pressure
-    masses = calculate_mass_vec(model, SVector{3}(x_state[1], x_state[2], x_state[3]))
+    masses = _mass_from_state(model, x_state)
 
     residual_vec = gap_residual(model, st, T_fm, mu_vec; xi=xi, p_num=p_num, t_num=t_num)
     residual_norm = sqrt(sum(abs2, residual_vec))
@@ -440,21 +482,8 @@ function _solve_constraint_fixedmu(
             ok, failed = evaluate_hard_constraints(raw, rules)
             push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, seed_index=Int(seed_index)))
         catch
-            raw = (
-                solution=Float64[],
-                x_state=SVector{5}(fill(NaN, 5)),
-                mu_vec=SVector{3}(fill(NaN, 3)),
-                omega=NaN,
-                pressure=-Inf,
-                rho_norm=NaN,
-                entropy=NaN,
-                energy=NaN,
-                masses=SVector{3}(fill(NaN, 3)),
-                iterations=0,
-                residual_norm=Inf,
-                residual_norm_max=Float64(residual_norm_max),
-            )
-            push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], converged=false, seed_index=Int(seed_index)))
+            raw = _empty_candidate(; state_n=5, mu_n=3, residual_norm_max=residual_norm_max)
+            push!(candidates, (; raw..., seed_index=Int(seed_index)))
         end
     end
     selected = select_pressure_max_candidate(candidates)
@@ -529,7 +558,7 @@ function _solve_constraint_fixedrho(
             return nothing
         end
 
-        x_state = SVector{5}(Tuple(state_vector(st)))
+        x_state = _to_state_svec(st)
         pressure = -omega(model, x_state, T_fm, μ_vec; p_num=p_num, t_num=t_num, xi=xi)
 
         pressure_mu = μtrial -> -omega(model, x_state, T_fm, μtrial; p_num=p_num, t_num=t_num, xi=xi)
@@ -540,11 +569,11 @@ function _solve_constraint_fixedrho(
         entropy = ForwardDiff.derivative(pressure_T, T_fm)
 
         energy = -pressure + sum(μ_vec .* rho_vec) + T_fm * entropy
-        masses = calculate_mass_vec(model, SVector{3}(x_state[1], x_state[2], x_state[3]))
+        masses = _mass_from_state(model, x_state)
 
         st_ref[] = st
         x_state_ref[] = x_state
-        mu_vec_ref[] = SVector{3}(Tuple(μ_vec))
+        mu_vec_ref[] = _to_mu_svec(μ_vec)
         pressure_ref[] = pressure
         rho_norm_ref[] = rho_norm
         entropy_ref[] = entropy
@@ -592,10 +621,7 @@ function _solve_constraint_fixedrho(
         return (
             mode=method,
             converged=converged,
-            solution=Float64[
-                x_state_ref[][1], x_state_ref[][2], x_state_ref[][3], x_state_ref[][4], x_state_ref[][5],
-                mu_vec_ref[][1], mu_vec_ref[][2], mu_vec_ref[][3],
-            ],
+            solution=_pack_solution(x_state_ref[], mu_vec_ref[]),
             x_state=x_state_ref[],
             mu_vec=mu_vec_ref[],
             omega=omega_val,
@@ -626,7 +652,7 @@ function _solve_constraint_fixedrho(
         )
         st === nothing && return nothing
 
-        x_state = SVector{5}(Tuple(state_vector(st)))
+        x_state = _to_state_svec(st)
         pressure = -omega(model, x_state, T_fm, μ_vec; p_num=p_num, t_num=t_num, xi=xi)
         pressure_mu = μtrial -> -omega(model, x_state, T_fm, μtrial; p_num=p_num, t_num=t_num, xi=xi)
         rho_vec = ForwardDiff.gradient(pressure_mu, μ_vec)
@@ -634,9 +660,9 @@ function _solve_constraint_fixedrho(
         pressure_T = τ -> -omega(model, x_state, τ, μ_vec; p_num=p_num, t_num=t_num, xi=xi)
         entropy = ForwardDiff.derivative(pressure_T, T_fm)
         energy = -pressure + sum(μ_vec .* rho_vec) + T_fm * entropy
-        masses = calculate_mass_vec(model, SVector{3}(x_state[1], x_state[2], x_state[3]))
+        masses = _mass_from_state(model, x_state)
 
-        gap_vec = gap_residual(model, st, T_fm, SVector{3}(Tuple(μ_vec)); xi=xi, p_num=p_num, t_num=t_num)
+        gap_vec = gap_residual(model, st, T_fm, _to_mu_svec(μ_vec); xi=xi, p_num=p_num, t_num=t_num)
         gap_norm = sqrt(sum(abs2, gap_vec))
         rho_residual = abs(rho_norm - rho_target)
         residual_norm = max(gap_norm, rho_residual)
@@ -649,12 +675,9 @@ function _solve_constraint_fixedrho(
         return (
             mode=:direct_mu,
             converged=converged,
-            solution=Float64[
-                x_state[1], x_state[2], x_state[3], x_state[4], x_state[5],
-                μ_vec[1], μ_vec[2], μ_vec[3],
-            ],
+            solution=_pack_solution(x_state, μ_vec),
             x_state=x_state,
-            mu_vec=SVector{3}(Tuple(μ_vec)),
+            mu_vec=_to_mu_svec(μ_vec),
             omega=omega_val,
             pressure=pressure,
             rho_norm=rho_norm,
@@ -870,7 +893,7 @@ function _solve_constraint_fixedentropy(
             return nothing
         end
 
-        x_state = SVector{5}(Tuple(state_vector(st)))
+        x_state = _to_state_svec(st)
         pressure = -omega(model, x_state, T_fm, μ_vec; p_num=p_num, t_num=t_num, xi=xi)
 
         pressure_mu = μtrial -> -omega(model, x_state, T_fm, μtrial; p_num=p_num, t_num=t_num, xi=xi)
@@ -881,7 +904,7 @@ function _solve_constraint_fixedentropy(
         entropy = ForwardDiff.derivative(pressure_T, T_fm)
 
         energy = -pressure + sum(μ_vec .* rho_vec) + T_fm * entropy
-        masses = calculate_mass_vec(model, SVector{3}(x_state[1], x_state[2], x_state[3]))
+        masses = _mass_from_state(model, x_state)
 
         if mass_positive_constraint && any(m -> !isfinite(m) || m <= 0.0, masses)
             _constraint_failure!(F)
@@ -890,7 +913,7 @@ function _solve_constraint_fixedentropy(
 
         st_ref[] = st
         x_state_ref[] = x_state
-        mu_vec_ref[] = SVector{3}(Tuple(μ_vec))
+        mu_vec_ref[] = _to_mu_svec(μ_vec)
         pressure_ref[] = pressure
         rho_norm_ref[] = rho_norm
         entropy_ref[] = entropy
@@ -938,10 +961,7 @@ function _solve_constraint_fixedentropy(
 
     return (
         converged=converged,
-        solution=Float64[
-            x_state_ref[][1], x_state_ref[][2], x_state_ref[][3], x_state_ref[][4], x_state_ref[][5],
-            mu_vec_ref[][1], mu_vec_ref[][2], mu_vec_ref[][3],
-        ],
+        solution=_pack_solution(x_state_ref[], mu_vec_ref[]),
         x_state=x_state_ref[],
         mu_vec=mu_vec_ref[],
         omega=omega_val,
@@ -1003,7 +1023,7 @@ function _solve_constraint_fixedsigma(
             return nothing
         end
 
-        x_state = SVector{5}(Tuple(state_vector(st)))
+        x_state = _to_state_svec(st)
         pressure = -omega(model, x_state, T_fm, μ_vec; p_num=p_num, t_num=t_num, xi=xi)
 
         pressure_mu = μtrial -> -omega(model, x_state, T_fm, μtrial; p_num=p_num, t_num=t_num, xi=xi)
@@ -1014,11 +1034,11 @@ function _solve_constraint_fixedsigma(
         entropy = ForwardDiff.derivative(pressure_T, T_fm)
 
         energy = -pressure + sum(μ_vec .* rho_vec) + T_fm * entropy
-        masses = calculate_mass_vec(model, SVector{3}(x_state[1], x_state[2], x_state[3]))
+        masses = _mass_from_state(model, x_state)
 
         st_ref[] = st
         x_state_ref[] = x_state
-        mu_vec_ref[] = SVector{3}(Tuple(μ_vec))
+        mu_vec_ref[] = _to_mu_svec(μ_vec)
         pressure_ref[] = pressure
         rho_norm_ref[] = rho_norm
         entropy_ref[] = entropy
@@ -1064,10 +1084,7 @@ function _solve_constraint_fixedsigma(
 
     return (
         converged=converged,
-        solution=Float64[
-            x_state_ref[][1], x_state_ref[][2], x_state_ref[][3], x_state_ref[][4], x_state_ref[][5],
-            mu_vec_ref[][1], mu_vec_ref[][2], mu_vec_ref[][3],
-        ],
+        solution=_pack_solution(x_state_ref[], mu_vec_ref[]),
         x_state=x_state_ref[],
         mu_vec=mu_vec_ref[],
         omega=omega_val,
@@ -1132,7 +1149,7 @@ function _solve_constraint_fixedasymrho(
             return nothing
         end
 
-        x_state = SVector{5}(Tuple(state_vector(st)))
+        x_state = _to_state_svec(st)
         pressure = -omega(model, x_state, T_fm, μ_vec; p_num=p_num, t_num=t_num, xi=xi)
 
         pressure_mu = μtrial -> -omega(model, x_state, T_fm, μtrial; p_num=p_num, t_num=t_num, xi=xi)
@@ -1143,7 +1160,7 @@ function _solve_constraint_fixedasymrho(
         entropy = ForwardDiff.derivative(pressure_T, T_fm)
 
         energy = -pressure + sum(μ_vec .* rho_vec) + T_fm * entropy
-        masses = calculate_mass_vec(model, SVector{3}(x_state[1], x_state[2], x_state[3]))
+        masses = _mass_from_state(model, x_state)
 
         rho_u, rho_d, rho_s = rho_vec[1], rho_vec[2], rho_vec[3]
         nB = sum(rho_vec) / (3.0 * rho0)
@@ -1161,7 +1178,7 @@ function _solve_constraint_fixedasymrho(
         entropy_ref[] = entropy
         energy_ref[] = energy
         masses_ref[] = masses
-        rho_vec_ref[] = SVector{3}(Tuple(rho_vec))
+        rho_vec_ref[] = _to_mu_svec(rho_vec)
 
         F[1] = convert(eltype(F), nB - rho_target)
         F[2] = convert(eltype(F), ud_ratio - ud_ratio_target)
@@ -1206,10 +1223,7 @@ function _solve_constraint_fixedasymrho(
 
     return (
         converged=converged,
-        solution=Float64[
-            x_state_ref[][1], x_state_ref[][2], x_state_ref[][3], x_state_ref[][4], x_state_ref[][5],
-            mu_vec_ref[][1], mu_vec_ref[][2], mu_vec_ref[][3],
-        ],
+        solution=_pack_solution(x_state_ref[], mu_vec_ref[]),
         x_state=x_state_ref[],
         mu_vec=mu_vec_ref[],
         omega=omega_val,

--- a/src/models/scans/TrhoScan.jl
+++ b/src/models/scans/TrhoScan.jl
@@ -549,7 +549,7 @@ function _attempt_with_strategy(T_fm, rho, xi, strategy::SeedStrategy;
             get_seed(strategy, [T_fm], mode)
         end
 
-        wb_result = Main.Models._solve_weighted_block_fallback(mode, T_fm;
+        wb_result = Main.Models.solve_weighted_block_fallback(mode, T_fm;
             initial_seed=initial_seed,
             max_seed_candidates=hybrid_weighted_max_seed_candidates,
             xi=xi,

--- a/src/models/solver/Conditions.jl
+++ b/src/models/solver/Conditions.jl
@@ -17,7 +17,8 @@ using StaticArrays
 using ForwardDiff
 
 # 从 Models 域导入
-import Main.Models: ConstraintMode, FixedMu, FixedRho, FixedAsymmetricRho, FixedEntropy, FixedSigma, ModelStateSchema, state_dim
+import Main.Models: ConstraintMode, FixedMu, FixedRho, FixedAsymmetricRho, FixedEntropy, FixedSigma
+import Main.Models: ModelStateSchema, state_dim, state_var_dim, mu_var_dim, schema_for_model
 const cached_nodes = Main.Models.cached_nodes
 using Main.Constants_PNJL: ρ0_inv_fm3
 const ρ0 = ρ0_inv_fm3
@@ -186,26 +187,8 @@ end
 - x = [φ_u, φ_d, φ_s, Φ, Φ̄, μ_u, μ_d, μ_s]（状态变量）
 """
 function build_conditions(mode::FixedRho, params::GapParams)
-    return (θ, x) -> begin
-        T_fm = θ[1]
-        x_state = SVector{5}(x[1], x[2], x[3], x[4], x[5])
-        mu_vec = SVector{3}(x[6], x[7], x[8])
-        local_params = GapParams(T_fm, params.thermal_nodes, params.xi,
-            p_num=params.p_num, t_num=params.t_num, model_kind=params.model_kind)
-        
-        # 5 个能隙方程
-        gap = gap_conditions(x_state, mu_vec, local_params)
-        
-        # 化学势相等约束
-        mu_eq1 = x[6] - x[7]  # μ_u = μ_d
-        mu_eq2 = x[7] - x[8]  # μ_d = μ_s
-        
-        # 密度约束
-        rho_vec = _rho_vec(x_state, mu_vec, T_fm, local_params)
-        rho_constraint = sum(rho_vec) / (3.0 * ρ0) - mode.rho_target
-        
-        return [gap..., mu_eq1, mu_eq2, rho_constraint]
-    end
+    schema = schema_for_model(params.model_kind)
+    return build_conditions(mode, params, schema; mu_dim=mu_var_dim(mode))
 end
 
 @inline function _extract_state_mu(schema::ModelStateSchema, x::AbstractVector; mu_dim::Int=3)
@@ -218,11 +201,29 @@ end
     return state_slice, mu_slice
 end
 
-@inline function _gap_conditions_dynamic(x_state::AbstractVector, mu_vec::AbstractVector, params::GapParams)
+@inline function _validate_schema_mode_dims(mode::ConstraintMode, schema::ModelStateSchema, mu_dim::Int)
+    expected_state_dim = state_var_dim(mode)
+    schema_state_dim = state_dim(schema)
+    schema_state_dim == expected_state_dim || throw(ArgumentError("schema state_dim mismatch for $(typeof(mode)): expected $expected_state_dim, got $schema_state_dim"))
+
+    expected_mu_dim = mu_var_dim(mode)
+    mu_dim == expected_mu_dim || throw(ArgumentError("schema mu_dim mismatch for $(typeof(mode)): expected $expected_mu_dim, got $mu_dim"))
+    return nothing
+end
+
+@inline function _gap_conditions_dynamic(
+    mode::ConstraintMode,
+    schema::ModelStateSchema,
+    x_state::AbstractVector,
+    mu_vec::AbstractVector,
+    params::GapParams;
+    mu_dim::Int,
+)
+    _validate_schema_mode_dims(mode, schema, mu_dim)
     if length(x_state) == 5 && length(mu_vec) == 3
         return gap_conditions(SVector{5}(Tuple(x_state)), mu_vec, params)
     end
-    throw(ArgumentError("schema-driven FixedRho conditions currently support PNJL-like dimensions only (state_dim=5, mu_dim=3), got state_dim=$(length(x_state)), mu_dim=$(length(mu_vec))"))
+    throw(ArgumentError("schema/mode dimensions currently support PNJL-like residual only (state_dim=5, mu_dim=3), got state_dim=$(length(x_state)), mu_dim=$(length(mu_vec))"))
 end
 
 """
@@ -237,7 +238,7 @@ function build_conditions(mode::FixedRho, params::GapParams, schema::ModelStateS
         local_params = GapParams(T_fm, params.thermal_nodes, params.xi,
             p_num=params.p_num, t_num=params.t_num, model_kind=params.model_kind)
 
-        gap = _gap_conditions_dynamic(x_state, mu_vec, local_params)
+        gap = _gap_conditions_dynamic(mode, schema, x_state, mu_vec, local_params; mu_dim=mu_dim)
         mu_eq1 = mu_vec[1] - mu_vec[2]
         mu_eq2 = mu_vec[2] - mu_vec[3]
         rho_vec = _rho_vec(x_state, mu_vec, T_fm, local_params)
@@ -257,14 +258,18 @@ end
 - x = [φ_u, φ_d, φ_s, Φ, Φ̄, μ_u, μ_d, μ_s]（状态变量）
 """
 function build_conditions(mode::FixedAsymmetricRho, params::GapParams)
+    schema = schema_for_model(params.model_kind)
+    return build_conditions(mode, params, schema; mu_dim=mu_var_dim(mode))
+end
+
+function build_conditions(mode::FixedAsymmetricRho, params::GapParams, schema::ModelStateSchema; mu_dim::Int=3)
     return (θ, x) -> begin
         T_fm = θ[1]
-        x_state = SVector{5}(x[1], x[2], x[3], x[4], x[5])
-        mu_vec = SVector{3}(x[6], x[7], x[8])
+        x_state, mu_vec = _extract_state_mu(schema, x; mu_dim=mu_dim)
         local_params = GapParams(T_fm, params.thermal_nodes, params.xi,
             p_num=params.p_num, t_num=params.t_num, model_kind=params.model_kind)
 
-        gap = gap_conditions(x_state, mu_vec, local_params)
+        gap = _gap_conditions_dynamic(mode, schema, x_state, mu_vec, local_params; mu_dim=mu_dim)
 
         rho_vec = _rho_vec(x_state, mu_vec, T_fm, local_params)
         rho_u, rho_d, rho_s = rho_vec[1], rho_vec[2], rho_vec[3]
@@ -283,24 +288,24 @@ end
 构建固定熵密度模式的条件函数。
 """
 function build_conditions(mode::FixedEntropy, params::GapParams)
+    schema = schema_for_model(params.model_kind)
+    return build_conditions(mode, params, schema; mu_dim=mu_var_dim(mode))
+end
+
+function build_conditions(mode::FixedEntropy, params::GapParams, schema::ModelStateSchema; mu_dim::Int=3)
     return (θ, x) -> begin
         T_fm = θ[1]
-        x_state = SVector{5}(x[1], x[2], x[3], x[4], x[5])
-        mu_vec = SVector{3}(x[6], x[7], x[8])
+        x_state, mu_vec = _extract_state_mu(schema, x; mu_dim=mu_dim)
         local_params = GapParams(T_fm, params.thermal_nodes, params.xi,
             p_num=params.p_num, t_num=params.t_num, model_kind=params.model_kind)
-        
-        # 5 个能隙方程
-        gap = gap_conditions(x_state, mu_vec, local_params)
-        
-        # 化学势相等约束
-        mu_eq1 = x[6] - x[7]
-        mu_eq2 = x[7] - x[8]
-        
-        # 熵密度约束
+
+        gap = _gap_conditions_dynamic(mode, schema, x_state, mu_vec, local_params; mu_dim=mu_dim)
+        mu_eq1 = mu_vec[1] - mu_vec[2]
+        mu_eq2 = mu_vec[2] - mu_vec[3]
+
         _, _, entropy, _ = _thermo_tuple(x_state, mu_vec, T_fm, local_params)
         s_constraint = entropy - mode.s_target
-        
+
         return [gap..., mu_eq1, mu_eq2, s_constraint]
     end
 end
@@ -311,26 +316,26 @@ end
 构建固定比熵模式的条件函数。
 """
 function build_conditions(mode::FixedSigma, params::GapParams)
+    schema = schema_for_model(params.model_kind)
+    return build_conditions(mode, params, schema; mu_dim=mu_var_dim(mode))
+end
+
+function build_conditions(mode::FixedSigma, params::GapParams, schema::ModelStateSchema; mu_dim::Int=3)
     return (θ, x) -> begin
         T_fm = θ[1]
-        x_state = SVector{5}(x[1], x[2], x[3], x[4], x[5])
-        mu_vec = SVector{3}(x[6], x[7], x[8])
+        x_state, mu_vec = _extract_state_mu(schema, x; mu_dim=mu_dim)
         local_params = GapParams(T_fm, params.thermal_nodes, params.xi,
             p_num=params.p_num, t_num=params.t_num, model_kind=params.model_kind)
-        
-        # 5 个能隙方程
-        gap = gap_conditions(x_state, mu_vec, local_params)
-        
-        # 化学势相等约束
-        mu_eq1 = x[6] - x[7]
-        mu_eq2 = x[7] - x[8]
-        
-        # 比熵约束 σ = s/n_B
+
+        gap = _gap_conditions_dynamic(mode, schema, x_state, mu_vec, local_params; mu_dim=mu_dim)
+        mu_eq1 = mu_vec[1] - mu_vec[2]
+        mu_eq2 = mu_vec[2] - mu_vec[3]
+
         _, rho_norm, entropy, _ = _thermo_tuple(x_state, mu_vec, T_fm, local_params)
-        n_B = rho_norm * ρ0  # 重子数密度
+        n_B = rho_norm * ρ0
         sigma = n_B > 1e-12 ? entropy / n_B : 0.0
         sigma_constraint = sigma - mode.sigma_target
-        
+
         return [gap..., mu_eq1, mu_eq2, sigma_constraint]
     end
 end

--- a/src/models/solver/ConstraintModes.jl
+++ b/src/models/solver/ConstraintModes.jl
@@ -56,6 +56,20 @@ state_dim(::FixedAsymmetricRho) = 8
 state_dim(::FixedEntropy) = 8
 state_dim(::FixedSigma) = 8
 
+state_var_dim(::FixedMu) = 5
+state_var_dim(::FixedRho) = 5
+state_var_dim(::FixedAsymmetricRho) = 5
+state_var_dim(::FixedEntropy) = 5
+state_var_dim(::FixedSigma) = 5
+
+mu_var_dim(::FixedMu) = 0
+mu_var_dim(::FixedRho) = 3
+mu_var_dim(::FixedAsymmetricRho) = 3
+mu_var_dim(::FixedEntropy) = 3
+mu_var_dim(::FixedSigma) = 3
+
+solution_dim(mode::ConstraintMode) = state_var_dim(mode) + mu_var_dim(mode)
+
 param_dim(::FixedMu) = 2
 param_dim(::FixedRho) = 1
 param_dim(::FixedAsymmetricRho) = 1

--- a/src/models/solver/ImplicitSolver.jl
+++ b/src/models/solver/ImplicitSolver.jl
@@ -43,7 +43,6 @@ const ρ0 = ρ0_inv_fm3
 export solve, SolverResult
 export solve_weighted_block_fallback
 export default_is_physical_solution
-export solve_with_derivatives
 
 @inline function _get_model(model_kind::Symbol)
     if model_kind === :PNJL || model_kind === :RPNJL
@@ -1065,41 +1064,6 @@ end
 function conditions_mu(θ::AbstractVector, x::AbstractVector, z)
     config = IMPLICIT_CONFIG[]
     return _conditions_mu_with_config(θ, x, z, config)
-end
-
-"""
-    solve_with_derivatives(T_fm, μ_fm; order=1, kwargs...) -> NamedTuple
-
-求解并计算解对参数的导数。
-
-# 参数
-- `T_fm`: 温度 (fm⁻¹)
-- `μ_fm`: 化学势 (fm⁻¹)
-- `order`: 导数阶数（1 或 2）
-
-# 返回
-NamedTuple 包含：
-- `x`: 解向量
-- `dx_dT`: ∂x/∂T
-- `dx_dμ`: ∂x/∂μ
-- `d2x_dT2`, `d2x_dμ2`, `d2x_dTdμ`（order=2 时）
-"""
-function solve_with_derivatives(T_fm::Real, μ_fm::Real;
-                                order::Int=1,
-                                xi::Real=0.0,
-                                model_kind::Symbol=:PNJL,
-                                p_num::Int=DEFAULT_MOMENTUM_COUNT,
-                                t_num::Int=DEFAULT_THETA_COUNT)
-    return Main.Models.solve_pnjl_with_derivatives(
-        T_fm,
-        μ_fm;
-        order=order,
-        xi=xi,
-        p_num=p_num,
-        t_num=t_num,
-        thermo_backend=:models,
-        solver_backend=:models,
-    )
 end
 
 end # module ImplicitSolver

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -54,7 +54,7 @@ end
 end
 
 @inline function _strip_problemspec_forwardsolve_kwargs!(kwargs::Dict{Symbol,Any})
-    for key in (:seed_candidates, :hard_constraints, :semantic_mode, :selector, :fixedrho_joint_solve)
+    for key in (:seed_candidates, :hard_constraints, :semantic_mode, :selector, :fixedrho_joint_solve, :continuity_seed)
         delete!(kwargs, key)
     end
     return kwargs
@@ -478,19 +478,137 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
     seed_guess = get(kwargs, :seed_guess, nothing)
     seed_guess === nothing && throw(ArgumentError("seed_guess is required for ProblemSpec FixedEntropy forward_solve"))
 
-    seed_pool = if haskey(kwargs, :seed_candidates)
+    provided_seed_pool = if haskey(kwargs, :seed_candidates)
         [Float64.(s) for s in kwargs[:seed_candidates]]
     else
-        _build_default_seed_candidates(seed_guess)
+        Vector{Vector{Float64}}()
     end
+    default_seed_pool = _build_default_seed_candidates(seed_guess)
+
+    primary_seed = Float64.(seed_guess)
+    primary_method = if haskey(kwargs, :nlsolve_method)
+        kwargs[:nlsolve_method]
+    else
+        Bool(get(kwargs, :continuity_seed, false)) ? :newton : :trust_region
+    end
+    primary_use_fallback = Bool(get(kwargs, :trust_region_fallback, true))
+    fallback_method = get(kwargs, :fallback_method, :trust_region)
+
+    fallback_seeds = Vector{Vector{Float64}}()
+    seed_seen = Set{String}()
+    seed_key(seed_vec::AbstractVector{<:Real}) = join(round.(Float64.(seed_vec); digits=12), ",")
+    primary_key = seed_key(primary_seed)
+    push!(seed_seen, primary_key)
+
+    for seed in provided_seed_pool
+        k = seed_key(seed)
+        if !(k in seed_seen)
+            push!(fallback_seeds, seed)
+            push!(seed_seen, k)
+        end
+    end
+    for seed in default_seed_pool
+        k = seed_key(seed)
+        if !(k in seed_seen)
+            push!(fallback_seeds, seed)
+            push!(seed_seen, k)
+        end
+    end
+
+    attempt_plan = NamedTuple[]
+    push!(attempt_plan, (
+        seed=primary_seed,
+        method=primary_method,
+        use_fallback=primary_use_fallback,
+        fallback_method=fallback_method,
+        attempt_origin=:primary,
+    ))
+
+    if primary_method != :trust_region && !(primary_use_fallback && fallback_method == :trust_region)
+        push!(attempt_plan, (
+            seed=primary_seed,
+            method=:trust_region,
+            use_fallback=false,
+            fallback_method=:trust_region,
+            attempt_origin=:method_rescue,
+        ))
+    end
+
+    for seed in fallback_seeds
+        push!(attempt_plan, (
+            seed=seed,
+            method=:trust_region,
+            use_fallback=false,
+            fallback_method=:trust_region,
+            attempt_origin=:seed_rescue,
+        ))
+    end
+
     physicality_check = get(kwargs, :physicality_check, ((_, _) -> true))
     hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
 
-    solve_one = (m, t, local_kwargs) -> begin
-        haskey(local_kwargs, :rho0) || throw(ArgumentError("rho0 is required for ProblemSpec FixedEntropy forward_solve"))
-        return _solve_constraint_fixedentropy(m, t, mode.s_target; pairs(local_kwargs)...)
+    candidates = NamedTuple[]
+    for (attempt_index, attempt_cfg) in enumerate(attempt_plan)
+        local raw
+        try
+            local_kwargs = Dict{Symbol,Any}(kwargs)
+            local_kwargs[:seed_guess] = attempt_cfg.seed
+            local_kwargs[:nlsolve_method] = attempt_cfg.method
+            _strip_problemspec_forwardsolve_kwargs!(local_kwargs)
+            delete!(local_kwargs, :trust_region_fallback)
+            delete!(local_kwargs, :fallback_method)
+
+            haskey(local_kwargs, :rho0) || throw(ArgumentError("rho0 is required for ProblemSpec FixedEntropy forward_solve"))
+            solved = _solve_constraint_fixedentropy(model, T_fm, mode.s_target; pairs(local_kwargs)...)
+            raw = (; solved..., residual_norm_max=get(local_kwargs, :residual_norm_max, 1e-6), entropy_attempt_origin=attempt_cfg.attempt_origin)
+            ok, failed = evaluate_hard_constraints(raw, hard_constraints)
+            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, seed_index=Int(attempt_index)))
+            if ok
+                break
+            end
+        catch
+            raw = (
+                converged=false,
+                solution=Float64[],
+                x_state=zeros(5),
+                mu_vec=zeros(3),
+                omega=NaN,
+                pressure=-Inf,
+                rho_norm=NaN,
+                entropy=NaN,
+                energy=NaN,
+                masses=zeros(3),
+                iterations=0,
+                residual_norm=Inf,
+                residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
+                entropy_attempt_origin=attempt_cfg.attempt_origin,
+            )
+            push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
+        end
     end
-    return _governed_mode_forward_solve(model, T_fm, seed_pool, kwargs, hard_constraints, solve_one)
+
+    selector_fn = _resolve_candidate_selector(kwargs)
+    selected = selector_fn(candidates)
+    s = selected.selected_candidate
+    return (
+        converged=Bool(s.converged),
+        solution=Vector{Float64}(s.solution),
+        x_state=s.x_state,
+        mu_vec=s.mu_vec,
+        omega=s.omega,
+        pressure=s.pressure,
+        rho_norm=s.rho_norm,
+        entropy=s.entropy,
+        energy=s.energy,
+        masses=s.masses,
+        iterations=s.iterations,
+        residual_norm=s.residual_norm,
+        hard_constraint_ok=s.hard_constraint_ok,
+        failed_constraints=s.failed_constraints,
+        selection_reason=selected.selection_reason,
+        selected_index=selected.selected_index,
+        candidate_count=length(candidates),
+    )
 end
 
 function _fixedsigma_problem_spec_forward_solve(model::AbstractQCDModel, mode::FixedSigma, T_fm::Real; fwd_kwargs...)
@@ -498,19 +616,137 @@ function _fixedsigma_problem_spec_forward_solve(model::AbstractQCDModel, mode::F
     seed_guess = get(kwargs, :seed_guess, nothing)
     seed_guess === nothing && throw(ArgumentError("seed_guess is required for ProblemSpec FixedSigma forward_solve"))
 
-    seed_pool = if haskey(kwargs, :seed_candidates)
+    provided_seed_pool = if haskey(kwargs, :seed_candidates)
         [Float64.(s) for s in kwargs[:seed_candidates]]
     else
-        _build_default_seed_candidates(seed_guess)
+        Vector{Vector{Float64}}()
     end
+    default_seed_pool = _build_default_seed_candidates(seed_guess)
+
+    primary_seed = Float64.(seed_guess)
+    primary_method = if haskey(kwargs, :nlsolve_method)
+        kwargs[:nlsolve_method]
+    else
+        Bool(get(kwargs, :continuity_seed, false)) ? :newton : :trust_region
+    end
+    primary_use_fallback = Bool(get(kwargs, :trust_region_fallback, true))
+    fallback_method = get(kwargs, :fallback_method, :trust_region)
+
+    fallback_seeds = Vector{Vector{Float64}}()
+    seed_seen = Set{String}()
+    seed_key(seed_vec::AbstractVector{<:Real}) = join(round.(Float64.(seed_vec); digits=12), ",")
+    primary_key = seed_key(primary_seed)
+    push!(seed_seen, primary_key)
+
+    for seed in provided_seed_pool
+        k = seed_key(seed)
+        if !(k in seed_seen)
+            push!(fallback_seeds, seed)
+            push!(seed_seen, k)
+        end
+    end
+    for seed in default_seed_pool
+        k = seed_key(seed)
+        if !(k in seed_seen)
+            push!(fallback_seeds, seed)
+            push!(seed_seen, k)
+        end
+    end
+
+    attempt_plan = NamedTuple[]
+    push!(attempt_plan, (
+        seed=primary_seed,
+        method=primary_method,
+        use_fallback=primary_use_fallback,
+        fallback_method=fallback_method,
+        attempt_origin=:primary,
+    ))
+
+    if primary_method != :trust_region && !(primary_use_fallback && fallback_method == :trust_region)
+        push!(attempt_plan, (
+            seed=primary_seed,
+            method=:trust_region,
+            use_fallback=false,
+            fallback_method=:trust_region,
+            attempt_origin=:method_rescue,
+        ))
+    end
+
+    for seed in fallback_seeds
+        push!(attempt_plan, (
+            seed=seed,
+            method=:trust_region,
+            use_fallback=false,
+            fallback_method=:trust_region,
+            attempt_origin=:seed_rescue,
+        ))
+    end
+
     physicality_check = get(kwargs, :physicality_check, ((_, _) -> true))
     hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
 
-    solve_one = (m, t, local_kwargs) -> begin
-        haskey(local_kwargs, :rho0) || throw(ArgumentError("rho0 is required for ProblemSpec FixedSigma forward_solve"))
-        return _solve_constraint_fixedsigma(m, t, mode.sigma_target; pairs(local_kwargs)...)
+    candidates = NamedTuple[]
+    for (attempt_index, attempt_cfg) in enumerate(attempt_plan)
+        local raw
+        try
+            local_kwargs = Dict{Symbol,Any}(kwargs)
+            local_kwargs[:seed_guess] = attempt_cfg.seed
+            local_kwargs[:nlsolve_method] = attempt_cfg.method
+            _strip_problemspec_forwardsolve_kwargs!(local_kwargs)
+            delete!(local_kwargs, :trust_region_fallback)
+            delete!(local_kwargs, :fallback_method)
+
+            haskey(local_kwargs, :rho0) || throw(ArgumentError("rho0 is required for ProblemSpec FixedSigma forward_solve"))
+            solved = _solve_constraint_fixedsigma(model, T_fm, mode.sigma_target; pairs(local_kwargs)...)
+            raw = (; solved..., residual_norm_max=get(local_kwargs, :residual_norm_max, 1e-6), sigma_attempt_origin=attempt_cfg.attempt_origin)
+            ok, failed = evaluate_hard_constraints(raw, hard_constraints)
+            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, seed_index=Int(attempt_index)))
+            if ok
+                break
+            end
+        catch
+            raw = (
+                converged=false,
+                solution=Float64[],
+                x_state=zeros(5),
+                mu_vec=zeros(3),
+                omega=NaN,
+                pressure=-Inf,
+                rho_norm=NaN,
+                entropy=NaN,
+                energy=NaN,
+                masses=zeros(3),
+                iterations=0,
+                residual_norm=Inf,
+                residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
+                sigma_attempt_origin=attempt_cfg.attempt_origin,
+            )
+            push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
+        end
     end
-    return _governed_mode_forward_solve(model, T_fm, seed_pool, kwargs, hard_constraints, solve_one)
+
+    selector_fn = _resolve_candidate_selector(kwargs)
+    selected = selector_fn(candidates)
+    s = selected.selected_candidate
+    return (
+        converged=Bool(s.converged),
+        solution=Vector{Float64}(s.solution),
+        x_state=s.x_state,
+        mu_vec=s.mu_vec,
+        omega=s.omega,
+        pressure=s.pressure,
+        rho_norm=s.rho_norm,
+        entropy=s.entropy,
+        energy=s.energy,
+        masses=s.masses,
+        iterations=s.iterations,
+        residual_norm=s.residual_norm,
+        hard_constraint_ok=s.hard_constraint_ok,
+        failed_constraints=s.failed_constraints,
+        selection_reason=selected.selection_reason,
+        selected_index=selected.selected_index,
+        candidate_count=length(candidates),
+    )
 end
 
 function _fixedasymrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::FixedAsymmetricRho, T_fm::Real; fwd_kwargs...)

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -209,7 +209,18 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
                 (; legacy..., fixedrho_joint_solve_active=false, fixedrho_joint_fallback=false)
             end
             raw = (
-                ; solved...,
+                converged=Bool(solved.converged),
+                solution=Float64.(solved.solution),
+                x_state=solved.x_state,
+                mu_vec=solved.mu_vec,
+                omega=Float64(solved.omega),
+                pressure=Float64(solved.pressure),
+                rho_norm=Float64(solved.rho_norm),
+                entropy=Float64(solved.entropy),
+                energy=Float64(solved.energy),
+                masses=solved.masses,
+                iterations=Int(solved.iterations),
+                residual_norm=Float64(solved.residual_norm),
                 residual_norm_max=get(local_kwargs, :residual_norm_max, 1e-6),
                 fixedrho_joint_solve_requested=fixedrho_joint_solve,
                 fixedrho_joint_solve_active=get(solved, :fixedrho_joint_solve_active, false),

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -3,7 +3,41 @@
 
 约束问题契约：统一描述 mode、维度以及求解/后处理回调。
 """
-struct ProblemSpec{M,R,F,C,U,P,H,S}
+struct ExtraConstraints{R,F,S}
+    residual!::R
+    feasible::F
+    seed_extend::S
+end
+
+@inline _default_extra_residual!(F, x, theta, cfg, mode) = nothing
+@inline _default_extra_feasible(candidate, params, mode) = true
+@inline _default_seed_extend(seed, mode) = Float64.(seed)
+
+@inline function default_extra_constraints()
+    return ExtraConstraints(
+        _default_extra_residual!,
+        _default_extra_feasible,
+        _default_seed_extend,
+    )
+end
+
+@inline function _resolve_extra_constraints(kwargs)
+    extra = get(kwargs, :extra_constraints, default_extra_constraints())
+    extra isa ExtraConstraints || throw(ArgumentError("extra_constraints must be ExtraConstraints, got $(typeof(extra))"))
+    return extra
+end
+
+@inline function _extend_seed_with_extra(seed::AbstractVector{<:Real}, mode::ConstraintMode, extra::ExtraConstraints)
+    extended = extra.seed_extend(Float64.(seed), mode)
+    return Float64.(extended)
+end
+
+@inline function _append_extra_feasible_rule(rules, extra::ExtraConstraints, mode::ConstraintMode)
+    extra_rule = c -> (Bool(extra.feasible(c, nothing, mode)), :extra_constraint_failed)
+    return vcat(collect(rules), [extra_rule])
+end
+
+struct ProblemSpec{M,R,F,C,U,P,H,S,E}
     mode::M
     x_dim::Int
     theta_dim::Int
@@ -14,6 +48,7 @@ struct ProblemSpec{M,R,F,C,U,P,H,S}
     postprocess::P
     hard_rules::H
     selector::S
+    extra_constraints::E
 end
 
 @inline function ProblemSpec(
@@ -27,10 +62,18 @@ end
     postprocess=identity,
     hard_rules=default_hard_constraint_rules(),
     selector=select_pressure_max_candidate,
+    extra_constraints=default_extra_constraints(),
 )
     x_dim > 0 || throw(ArgumentError("x_dim must be positive, got $(x_dim)"))
     theta_dim > 0 || throw(ArgumentError("theta_dim must be positive, got $(theta_dim)"))
-    return ProblemSpec(mode, x_dim, theta_dim, residual!, forward_solve, conditions, unpack_solution, postprocess, hard_rules, selector)
+    wrapped_forward_solve = function (model, T_fm; fwd_kwargs...)
+        if haskey(fwd_kwargs, :extra_constraints)
+            return forward_solve(model, T_fm; fwd_kwargs...)
+        end
+        return forward_solve(model, T_fm; extra_constraints=extra_constraints, fwd_kwargs...)
+    end
+
+    return ProblemSpec(mode, x_dim, theta_dim, residual!, wrapped_forward_solve, conditions, unpack_solution, postprocess, hard_rules, selector, extra_constraints)
 end
 
 @inline _unimplemented_residual(F, x, theta, cfg, mode) = throw(ArgumentError("residual! is not configured for $(typeof(mode))"))
@@ -54,7 +97,7 @@ end
 end
 
 @inline function _strip_problemspec_forwardsolve_kwargs!(kwargs::Dict{Symbol,Any})
-    for key in (:seed_candidates, :hard_constraints, :semantic_mode, :selector, :fixedrho_joint_solve, :continuity_seed)
+    for key in (:seed_candidates, :hard_constraints, :semantic_mode, :selector, :fixedrho_joint_solve, :continuity_seed, :extra_constraints)
         delete!(kwargs, key)
     end
     return kwargs
@@ -236,6 +279,7 @@ end
 
 function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::FixedRho, T_fm::Real; fwd_kwargs...)
     kwargs = Dict{Symbol,Any}(pairs(fwd_kwargs))
+    extra_constraints = _resolve_extra_constraints(kwargs)
     fixedrho_joint_solve = get(kwargs, :fixedrho_joint_solve, true)
     fixedrho_joint_solve isa Bool || throw(ArgumentError("fixedrho_joint_solve must be Bool, got $(typeof(fixedrho_joint_solve))"))
     fixedrho_joint_solve || throw(ArgumentError("fixedrho_joint_solve=false is no longer supported; FixedRho uses joint solve only"))
@@ -250,7 +294,7 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
     end
     default_seed_pool = _build_default_seed_candidates(seed_guess)
 
-    primary_seed = Float64.(seed_guess)
+    primary_seed = _extend_seed_with_extra(Float64.(seed_guess), mode, extra_constraints)
     primary_method = if haskey(kwargs, :nlsolve_method)
         kwargs[:nlsolve_method]
     else
@@ -267,9 +311,9 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
     push!(seed_seen, primary_key)
 
     legacy_seed = if length(primary_seed) >= 5
-        Float64.(Main.Models.extend_seed(Float64.(primary_seed[1:5]), mode))
+        _extend_seed_with_extra(Float64.(Main.Models.extend_seed(Float64.(primary_seed[1:5]), mode)), mode, extra_constraints)
     else
-        Float64.(Main.Models.extend_seed(primary_seed, mode))
+        _extend_seed_with_extra(Float64.(Main.Models.extend_seed(primary_seed, mode)), mode, extra_constraints)
     end
     legacy_key = seed_key(legacy_seed)
     if !(legacy_key in seed_seen)
@@ -278,6 +322,7 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
     end
 
     for seed in provided_seed_pool
+        seed = _extend_seed_with_extra(seed, mode, extra_constraints)
         k = seed_key(seed)
         if !(k in seed_seen)
             push!(fallback_seeds, seed)
@@ -285,6 +330,7 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
         end
     end
     for seed in default_seed_pool
+        seed = _extend_seed_with_extra(seed, mode, extra_constraints)
         k = seed_key(seed)
         if !(k in seed_seen)
             push!(fallback_seeds, seed)
@@ -323,6 +369,7 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
 
     physicality_check = get(kwargs, :physicality_check, ((_, _) -> true))
     hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
+    hard_constraints = _append_extra_feasible_rule(hard_constraints, extra_constraints, mode)
 
     candidates = NamedTuple[]
     for (attempt_index, attempt_cfg) in enumerate(attempt_plan)
@@ -485,10 +532,18 @@ function _governed_mode_forward_solve(
     )
 end
 
-function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode::FixedEntropy, T_fm::Real; fwd_kwargs...)
-    kwargs = Dict{Symbol,Any}(pairs(fwd_kwargs))
+function _governed_nonrho_problem_spec_forward_solve(
+    model::AbstractQCDModel,
+    mode::ConstraintMode,
+    T_fm::Real,
+    kwargs::Dict{Symbol,Any},
+    mode_label::AbstractString,
+    attempt_origin_key::Symbol,
+    solve_mode_constraint::Function,
+)
+    extra_constraints = _resolve_extra_constraints(kwargs)
     seed_guess = get(kwargs, :seed_guess, nothing)
-    seed_guess === nothing && throw(ArgumentError("seed_guess is required for ProblemSpec FixedEntropy forward_solve"))
+    seed_guess === nothing && throw(ArgumentError("seed_guess is required for ProblemSpec $(mode_label) forward_solve"))
 
     provided_seed_pool = if haskey(kwargs, :seed_candidates)
         [Float64.(s) for s in kwargs[:seed_candidates]]
@@ -497,7 +552,7 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
     end
     default_seed_pool = _build_default_seed_candidates(seed_guess)
 
-    primary_seed = Float64.(seed_guess)
+    primary_seed = _extend_seed_with_extra(Float64.(seed_guess), mode, extra_constraints)
     primary_method = if haskey(kwargs, :nlsolve_method)
         kwargs[:nlsolve_method]
     else
@@ -513,6 +568,7 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
     push!(seed_seen, primary_key)
 
     for seed in provided_seed_pool
+        seed = _extend_seed_with_extra(seed, mode, extra_constraints)
         k = seed_key(seed)
         if !(k in seed_seen)
             push!(fallback_seeds, seed)
@@ -520,6 +576,7 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
         end
     end
     for seed in default_seed_pool
+        seed = _extend_seed_with_extra(seed, mode, extra_constraints)
         k = seed_key(seed)
         if !(k in seed_seen)
             push!(fallback_seeds, seed)
@@ -558,6 +615,7 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
 
     physicality_check = get(kwargs, :physicality_check, ((_, _) -> true))
     hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
+    hard_constraints = _append_extra_feasible_rule(hard_constraints, extra_constraints, mode)
 
     candidates = NamedTuple[]
     for (attempt_index, attempt_cfg) in enumerate(attempt_plan)
@@ -570,9 +628,10 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
             delete!(local_kwargs, :trust_region_fallback)
             delete!(local_kwargs, :fallback_method)
 
-            haskey(local_kwargs, :rho0) || throw(ArgumentError("rho0 is required for ProblemSpec FixedEntropy forward_solve"))
+            haskey(local_kwargs, :rho0) || throw(ArgumentError("rho0 is required for ProblemSpec $(mode_label) forward_solve"))
             local_kwargs[:allow_legacy_fallback] = Bool(get(kwargs, :allow_legacy_fallback, true))
-            solved = _solve_constraint_fixedentropy(model, T_fm, mode.s_target; pairs(local_kwargs)...)
+
+            solved = solve_mode_constraint(local_kwargs)
             solver_converged = Bool(solved.converged)
             attempt_quality = if solver_converged
                 :degraded
@@ -587,8 +646,8 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
                 governed_selected_quality=attempt_quality,
                 governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
                 governed_attempt_origin=attempt_cfg.attempt_origin,
-                entropy_attempt_origin=attempt_cfg.attempt_origin,
             )
+            raw = (; raw..., attempt_origin_key => attempt_cfg.attempt_origin)
             ok, failed = evaluate_hard_constraints(raw, hard_constraints)
             selected_quality = ok ? :good : raw.governed_selected_quality
             push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, governed_selected_quality=selected_quality, seed_index=Int(attempt_index)))
@@ -615,8 +674,8 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
                 governed_selected_quality=:bad,
                 governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
                 governed_attempt_origin=attempt_cfg.attempt_origin,
-                entropy_attempt_origin=attempt_cfg.attempt_origin,
             )
+            raw = (; raw..., attempt_origin_key => attempt_cfg.attempt_origin)
             push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
         end
     end
@@ -646,348 +705,60 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
         governed_selected_quality=(hasproperty(s, :governed_selected_quality) ? getproperty(s, :governed_selected_quality) : :bad),
         governed_fallback_used=(hasproperty(s, :governed_fallback_used) ? Bool(getproperty(s, :governed_fallback_used)) : false),
         legacy_fallback_used=(hasproperty(s, :legacy_fallback_used) ? Bool(getproperty(s, :legacy_fallback_used)) : false),
+    )
+end
+
+function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode::FixedEntropy, T_fm::Real; fwd_kwargs...)
+    kwargs = Dict{Symbol,Any}(pairs(fwd_kwargs))
+    return _governed_nonrho_problem_spec_forward_solve(
+        model,
+        mode,
+        T_fm,
+        kwargs,
+        "FixedEntropy",
+        :entropy_attempt_origin,
+        local_kwargs -> _solve_constraint_fixedentropy(model, T_fm, mode.s_target; pairs(local_kwargs)...),
     )
 end
 
 function _fixedsigma_problem_spec_forward_solve(model::AbstractQCDModel, mode::FixedSigma, T_fm::Real; fwd_kwargs...)
     kwargs = Dict{Symbol,Any}(pairs(fwd_kwargs))
-    seed_guess = get(kwargs, :seed_guess, nothing)
-    seed_guess === nothing && throw(ArgumentError("seed_guess is required for ProblemSpec FixedSigma forward_solve"))
-
-    provided_seed_pool = if haskey(kwargs, :seed_candidates)
-        [Float64.(s) for s in kwargs[:seed_candidates]]
-    else
-        Vector{Vector{Float64}}()
-    end
-    default_seed_pool = _build_default_seed_candidates(seed_guess)
-
-    primary_seed = Float64.(seed_guess)
-    primary_method = if haskey(kwargs, :nlsolve_method)
-        kwargs[:nlsolve_method]
-    else
-        Bool(get(kwargs, :continuity_seed, false)) ? :newton : :trust_region
-    end
-    primary_use_fallback = Bool(get(kwargs, :trust_region_fallback, true))
-    fallback_method = get(kwargs, :fallback_method, :trust_region)
-
-    fallback_seeds = Vector{Vector{Float64}}()
-    seed_seen = Set{String}()
-    seed_key(seed_vec::AbstractVector{<:Real}) = join(round.(Float64.(seed_vec); digits=12), ",")
-    primary_key = seed_key(primary_seed)
-    push!(seed_seen, primary_key)
-
-    for seed in provided_seed_pool
-        k = seed_key(seed)
-        if !(k in seed_seen)
-            push!(fallback_seeds, seed)
-            push!(seed_seen, k)
-        end
-    end
-    for seed in default_seed_pool
-        k = seed_key(seed)
-        if !(k in seed_seen)
-            push!(fallback_seeds, seed)
-            push!(seed_seen, k)
-        end
-    end
-
-    attempt_plan = NamedTuple[]
-    push!(attempt_plan, (
-        seed=primary_seed,
-        method=primary_method,
-        use_fallback=primary_use_fallback,
-        fallback_method=fallback_method,
-        attempt_origin=:primary,
-    ))
-
-    if primary_method != :trust_region && !(primary_use_fallback && fallback_method == :trust_region)
-        push!(attempt_plan, (
-            seed=primary_seed,
-            method=:trust_region,
-            use_fallback=false,
-            fallback_method=:trust_region,
-            attempt_origin=:method_rescue,
-        ))
-    end
-
-    for seed in fallback_seeds
-        push!(attempt_plan, (
-            seed=seed,
-            method=:trust_region,
-            use_fallback=false,
-            fallback_method=:trust_region,
-            attempt_origin=:seed_rescue,
-        ))
-    end
-
-    physicality_check = get(kwargs, :physicality_check, ((_, _) -> true))
-    hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
-
-    candidates = NamedTuple[]
-    for (attempt_index, attempt_cfg) in enumerate(attempt_plan)
-        local raw
-        try
-            local_kwargs = Dict{Symbol,Any}(kwargs)
-            local_kwargs[:seed_guess] = attempt_cfg.seed
-            local_kwargs[:nlsolve_method] = attempt_cfg.method
-            _strip_problemspec_forwardsolve_kwargs!(local_kwargs)
-            delete!(local_kwargs, :trust_region_fallback)
-            delete!(local_kwargs, :fallback_method)
-
-            haskey(local_kwargs, :rho0) || throw(ArgumentError("rho0 is required for ProblemSpec FixedSigma forward_solve"))
-            local_kwargs[:allow_legacy_fallback] = Bool(get(kwargs, :allow_legacy_fallback, true))
-            solved = _solve_constraint_fixedsigma(model, T_fm, mode.sigma_target; pairs(local_kwargs)...)
-            solver_converged = Bool(solved.converged)
-            attempt_quality = if solver_converged
-                :degraded
-            else
-                :bad
-            end
-            raw = (
-                ; solved...,
-                residual_norm_max=get(local_kwargs, :residual_norm_max, 1e-6),
-                solver_converged=solver_converged,
-                governed_selected_method=attempt_cfg.method,
-                governed_selected_quality=attempt_quality,
-                governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
-                governed_attempt_origin=attempt_cfg.attempt_origin,
-                sigma_attempt_origin=attempt_cfg.attempt_origin,
-            )
-            ok, failed = evaluate_hard_constraints(raw, hard_constraints)
-            selected_quality = ok ? :good : raw.governed_selected_quality
-            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, governed_selected_quality=selected_quality, seed_index=Int(attempt_index)))
-            if ok
-                break
-            end
-        catch
-            raw = (
-                converged=false,
-                solution=Float64[],
-                x_state=zeros(5),
-                mu_vec=zeros(3),
-                omega=NaN,
-                pressure=-Inf,
-                rho_norm=NaN,
-                entropy=NaN,
-                energy=NaN,
-                masses=zeros(3),
-                iterations=0,
-                residual_norm=Inf,
-                residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
-                solver_converged=false,
-                governed_selected_method=attempt_cfg.method,
-                governed_selected_quality=:bad,
-                governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
-                governed_attempt_origin=attempt_cfg.attempt_origin,
-                sigma_attempt_origin=attempt_cfg.attempt_origin,
-            )
-            push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
-        end
-    end
-
-    selector_fn = _resolve_candidate_selector(kwargs)
-    selected = selector_fn(candidates)
-    s = selected.selected_candidate
-    return (
-        converged=Bool(s.converged),
-        solution=Vector{Float64}(s.solution),
-        x_state=s.x_state,
-        mu_vec=s.mu_vec,
-        omega=s.omega,
-        pressure=s.pressure,
-        rho_norm=s.rho_norm,
-        entropy=s.entropy,
-        energy=s.energy,
-        masses=s.masses,
-        iterations=s.iterations,
-        residual_norm=s.residual_norm,
-        hard_constraint_ok=s.hard_constraint_ok,
-        failed_constraints=s.failed_constraints,
-        selection_reason=selected.selection_reason,
-        selected_index=selected.selected_index,
-        candidate_count=length(candidates),
-        governed_selected_method=(hasproperty(s, :governed_selected_method) ? getproperty(s, :governed_selected_method) : :none),
-        governed_selected_quality=(hasproperty(s, :governed_selected_quality) ? getproperty(s, :governed_selected_quality) : :bad),
-        governed_fallback_used=(hasproperty(s, :governed_fallback_used) ? Bool(getproperty(s, :governed_fallback_used)) : false),
-        legacy_fallback_used=(hasproperty(s, :legacy_fallback_used) ? Bool(getproperty(s, :legacy_fallback_used)) : false),
+    return _governed_nonrho_problem_spec_forward_solve(
+        model,
+        mode,
+        T_fm,
+        kwargs,
+        "FixedSigma",
+        :sigma_attempt_origin,
+        local_kwargs -> _solve_constraint_fixedsigma(model, T_fm, mode.sigma_target; pairs(local_kwargs)...),
     )
 end
 
 function _fixedasymrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::FixedAsymmetricRho, T_fm::Real; fwd_kwargs...)
     kwargs = Dict{Symbol,Any}(pairs(fwd_kwargs))
-    seed_guess = get(kwargs, :seed_guess, nothing)
-    seed_guess === nothing && throw(ArgumentError("seed_guess is required for ProblemSpec FixedAsymmetricRho forward_solve"))
-
-    provided_seed_pool = if haskey(kwargs, :seed_candidates)
-        [Float64.(s) for s in kwargs[:seed_candidates]]
-    else
-        Vector{Vector{Float64}}()
-    end
-    default_seed_pool = _build_default_seed_candidates(seed_guess)
-
-    primary_seed = Float64.(seed_guess)
-    primary_method = if haskey(kwargs, :nlsolve_method)
-        kwargs[:nlsolve_method]
-    else
-        Bool(get(kwargs, :continuity_seed, false)) ? :newton : :trust_region
-    end
-    primary_use_fallback = Bool(get(kwargs, :trust_region_fallback, true))
-    fallback_method = get(kwargs, :fallback_method, :trust_region)
-
-    fallback_seeds = Vector{Vector{Float64}}()
-    seed_seen = Set{String}()
-    seed_key(seed_vec::AbstractVector{<:Real}) = join(round.(Float64.(seed_vec); digits=12), ",")
-    primary_key = seed_key(primary_seed)
-    push!(seed_seen, primary_key)
-
-    for seed in provided_seed_pool
-        k = seed_key(seed)
-        if !(k in seed_seen)
-            push!(fallback_seeds, seed)
-            push!(seed_seen, k)
-        end
-    end
-    for seed in default_seed_pool
-        k = seed_key(seed)
-        if !(k in seed_seen)
-            push!(fallback_seeds, seed)
-            push!(seed_seen, k)
-        end
-    end
-
-    attempt_plan = NamedTuple[]
-    push!(attempt_plan, (
-        seed=primary_seed,
-        method=primary_method,
-        use_fallback=primary_use_fallback,
-        fallback_method=fallback_method,
-        attempt_origin=:primary,
-    ))
-
-    if primary_method != :trust_region && !(primary_use_fallback && fallback_method == :trust_region)
-        push!(attempt_plan, (
-            seed=primary_seed,
-            method=:trust_region,
-            use_fallback=false,
-            fallback_method=:trust_region,
-            attempt_origin=:method_rescue,
-        ))
-    end
-
-    for seed in fallback_seeds
-        push!(attempt_plan, (
-            seed=seed,
-            method=:trust_region,
-            use_fallback=false,
-            fallback_method=:trust_region,
-            attempt_origin=:seed_rescue,
-        ))
-    end
-
-    physicality_check = get(kwargs, :physicality_check, ((_, _) -> true))
-    hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
-
-    candidates = NamedTuple[]
-    for (attempt_index, attempt_cfg) in enumerate(attempt_plan)
-        local raw
-        try
-            local_kwargs = Dict{Symbol,Any}(kwargs)
-            local_kwargs[:seed_guess] = attempt_cfg.seed
-            local_kwargs[:nlsolve_method] = attempt_cfg.method
-            _strip_problemspec_forwardsolve_kwargs!(local_kwargs)
-            delete!(local_kwargs, :trust_region_fallback)
-            delete!(local_kwargs, :fallback_method)
-
-            haskey(local_kwargs, :rho0) || throw(ArgumentError("rho0 is required for ProblemSpec FixedAsymmetricRho forward_solve"))
-            local_kwargs[:allow_legacy_fallback] = Bool(get(kwargs, :allow_legacy_fallback, true))
-            solved = _solve_constraint_fixedasymrho(model, T_fm, mode.rho_target, mode.ud_ratio_target, mode.s_target; pairs(local_kwargs)...)
-            solver_converged = Bool(solved.converged)
-            attempt_quality = if solver_converged
-                :degraded
-            else
-                :bad
-            end
-            raw = (
-                ; solved...,
-                residual_norm_max=get(local_kwargs, :residual_norm_max, 1e-6),
-                solver_converged=solver_converged,
-                governed_selected_method=attempt_cfg.method,
-                governed_selected_quality=attempt_quality,
-                governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
-                governed_attempt_origin=attempt_cfg.attempt_origin,
-                asym_attempt_origin=attempt_cfg.attempt_origin,
-            )
-            ok, failed = evaluate_hard_constraints(raw, hard_constraints)
-            selected_quality = ok ? :good : raw.governed_selected_quality
-            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, governed_selected_quality=selected_quality, seed_index=Int(attempt_index)))
-            if ok
-                break
-            end
-        catch
-            raw = (
-                converged=false,
-                solution=Float64[],
-                x_state=zeros(5),
-                mu_vec=zeros(3),
-                omega=NaN,
-                pressure=-Inf,
-                rho_norm=NaN,
-                entropy=NaN,
-                energy=NaN,
-                masses=zeros(3),
-                iterations=0,
-                residual_norm=Inf,
-                residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
-                solver_converged=false,
-                governed_selected_method=attempt_cfg.method,
-                governed_selected_quality=:bad,
-                governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
-                governed_attempt_origin=attempt_cfg.attempt_origin,
-                asym_attempt_origin=attempt_cfg.attempt_origin,
-            )
-            push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
-        end
-    end
-
-    selector_fn = _resolve_candidate_selector(kwargs)
-    selected = selector_fn(candidates)
-    s = selected.selected_candidate
-    return (
-        converged=Bool(s.converged),
-        solution=Vector{Float64}(s.solution),
-        x_state=s.x_state,
-        mu_vec=s.mu_vec,
-        omega=s.omega,
-        pressure=s.pressure,
-        rho_norm=s.rho_norm,
-        entropy=s.entropy,
-        energy=s.energy,
-        masses=s.masses,
-        iterations=s.iterations,
-        residual_norm=s.residual_norm,
-        hard_constraint_ok=s.hard_constraint_ok,
-        failed_constraints=s.failed_constraints,
-        selection_reason=selected.selection_reason,
-        selected_index=selected.selected_index,
-        candidate_count=length(candidates),
-        governed_selected_method=(hasproperty(s, :governed_selected_method) ? getproperty(s, :governed_selected_method) : :none),
-        governed_selected_quality=(hasproperty(s, :governed_selected_quality) ? getproperty(s, :governed_selected_quality) : :bad),
-        governed_fallback_used=(hasproperty(s, :governed_fallback_used) ? Bool(getproperty(s, :governed_fallback_used)) : false),
-        legacy_fallback_used=(hasproperty(s, :legacy_fallback_used) ? Bool(getproperty(s, :legacy_fallback_used)) : false),
+    return _governed_nonrho_problem_spec_forward_solve(
+        model,
+        mode,
+        T_fm,
+        kwargs,
+        "FixedAsymmetricRho",
+        :asym_attempt_origin,
+        local_kwargs -> _solve_constraint_fixedasymrho(model, T_fm, mode.rho_target, mode.ud_ratio_target, mode.s_target; pairs(local_kwargs)...),
     )
 end
 
 @inline function build_problem_spec(mode::ConstraintMode; kwargs...)
     if isempty(kwargs)
         components = build_constraint_components(mode)
+        extra_constraints = default_extra_constraints()
         forward_solve = if mode isa FixedRho
-            (model, T_fm; fwd_kwargs...) -> _fixedrho_problem_spec_forward_solve(model, mode, T_fm; fwd_kwargs...)
+            (model, T_fm; fwd_kwargs...) -> _fixedrho_problem_spec_forward_solve(model, mode, T_fm; extra_constraints=extra_constraints, fwd_kwargs...)
         elseif mode isa FixedEntropy
-            (model, T_fm; fwd_kwargs...) -> _fixedentropy_problem_spec_forward_solve(model, mode, T_fm; fwd_kwargs...)
+            (model, T_fm; fwd_kwargs...) -> _fixedentropy_problem_spec_forward_solve(model, mode, T_fm; extra_constraints=extra_constraints, fwd_kwargs...)
         elseif mode isa FixedSigma
-            (model, T_fm; fwd_kwargs...) -> _fixedsigma_problem_spec_forward_solve(model, mode, T_fm; fwd_kwargs...)
+            (model, T_fm; fwd_kwargs...) -> _fixedsigma_problem_spec_forward_solve(model, mode, T_fm; extra_constraints=extra_constraints, fwd_kwargs...)
         elseif mode isa FixedAsymmetricRho
-            (model, T_fm; fwd_kwargs...) -> _fixedasymrho_problem_spec_forward_solve(model, mode, T_fm; fwd_kwargs...)
+            (model, T_fm; fwd_kwargs...) -> _fixedasymrho_problem_spec_forward_solve(model, mode, T_fm; extra_constraints=extra_constraints, fwd_kwargs...)
         else
             (model, T_fm; fwd_kwargs...) -> solve_constraint(model, mode, T_fm; fwd_kwargs...)
         end
@@ -996,6 +767,7 @@ end
             x_dim=constraint_total_dim(components),
             conditions=params -> build_conditions(mode, params),
             forward_solve=forward_solve,
+            extra_constraints=extra_constraints,
         )
     end
     return ProblemSpec(mode; kwargs...)

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -238,38 +238,7 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
     kwargs = Dict{Symbol,Any}(pairs(fwd_kwargs))
     fixedrho_joint_solve = get(kwargs, :fixedrho_joint_solve, true)
     fixedrho_joint_solve isa Bool || throw(ArgumentError("fixedrho_joint_solve must be Bool, got $(typeof(fixedrho_joint_solve))"))
-
-    if !fixedrho_joint_solve
-        seed_guess = get(kwargs, :seed_guess, nothing)
-        seed_guess === nothing && throw(ArgumentError("seed_guess is required for ProblemSpec FixedRho forward_solve"))
-
-        legacy = _solve_constraint_fixedrho(model, T_fm, mode.rho_target; pairs(kwargs)...)
-        return (
-            converged=Bool(legacy.converged),
-            solution=Vector{Float64}(legacy.solution),
-            x_state=legacy.x_state,
-            mu_vec=legacy.mu_vec,
-            omega=legacy.omega,
-            pressure=legacy.pressure,
-            rho_norm=legacy.rho_norm,
-            entropy=legacy.entropy,
-            energy=legacy.energy,
-            masses=legacy.masses,
-            iterations=legacy.iterations,
-            residual_norm=legacy.residual_norm,
-            hard_constraint_ok=Bool(get(legacy, :converged, false)),
-            failed_constraints=(Bool(get(legacy, :converged, false)) ? Symbol[] : Symbol[:legacy_solver_failed]),
-            selection_reason=:legacy_fixedrho_solver,
-            selected_index=1,
-            candidate_count=1,
-            fixedrho_joint_solve_requested=false,
-            fixedrho_joint_solve_active=false,
-            fixedrho_joint_fallback=false,
-            fixedrho_joint_selected_method=:none,
-            fixedrho_joint_selected_quality=:bad,
-            fixedrho_joint_fallback_used=false,
-        )
-    end
+    fixedrho_joint_solve || throw(ArgumentError("fixedrho_joint_solve=false is no longer supported; FixedRho uses joint solve only"))
 
     seed_guess = get(kwargs, :seed_guess, nothing)
     seed_guess === nothing && throw(ArgumentError("seed_guess is required for ProblemSpec FixedRho forward_solve"))

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -754,19 +754,137 @@ function _fixedasymrho_problem_spec_forward_solve(model::AbstractQCDModel, mode:
     seed_guess = get(kwargs, :seed_guess, nothing)
     seed_guess === nothing && throw(ArgumentError("seed_guess is required for ProblemSpec FixedAsymmetricRho forward_solve"))
 
-    seed_pool = if haskey(kwargs, :seed_candidates)
+    provided_seed_pool = if haskey(kwargs, :seed_candidates)
         [Float64.(s) for s in kwargs[:seed_candidates]]
     else
-        _build_default_seed_candidates(seed_guess)
+        Vector{Vector{Float64}}()
     end
+    default_seed_pool = _build_default_seed_candidates(seed_guess)
+
+    primary_seed = Float64.(seed_guess)
+    primary_method = if haskey(kwargs, :nlsolve_method)
+        kwargs[:nlsolve_method]
+    else
+        Bool(get(kwargs, :continuity_seed, false)) ? :newton : :trust_region
+    end
+    primary_use_fallback = Bool(get(kwargs, :trust_region_fallback, true))
+    fallback_method = get(kwargs, :fallback_method, :trust_region)
+
+    fallback_seeds = Vector{Vector{Float64}}()
+    seed_seen = Set{String}()
+    seed_key(seed_vec::AbstractVector{<:Real}) = join(round.(Float64.(seed_vec); digits=12), ",")
+    primary_key = seed_key(primary_seed)
+    push!(seed_seen, primary_key)
+
+    for seed in provided_seed_pool
+        k = seed_key(seed)
+        if !(k in seed_seen)
+            push!(fallback_seeds, seed)
+            push!(seed_seen, k)
+        end
+    end
+    for seed in default_seed_pool
+        k = seed_key(seed)
+        if !(k in seed_seen)
+            push!(fallback_seeds, seed)
+            push!(seed_seen, k)
+        end
+    end
+
+    attempt_plan = NamedTuple[]
+    push!(attempt_plan, (
+        seed=primary_seed,
+        method=primary_method,
+        use_fallback=primary_use_fallback,
+        fallback_method=fallback_method,
+        attempt_origin=:primary,
+    ))
+
+    if primary_method != :trust_region && !(primary_use_fallback && fallback_method == :trust_region)
+        push!(attempt_plan, (
+            seed=primary_seed,
+            method=:trust_region,
+            use_fallback=false,
+            fallback_method=:trust_region,
+            attempt_origin=:method_rescue,
+        ))
+    end
+
+    for seed in fallback_seeds
+        push!(attempt_plan, (
+            seed=seed,
+            method=:trust_region,
+            use_fallback=false,
+            fallback_method=:trust_region,
+            attempt_origin=:seed_rescue,
+        ))
+    end
+
     physicality_check = get(kwargs, :physicality_check, ((_, _) -> true))
     hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
 
-    solve_one = (m, t, local_kwargs) -> begin
-        haskey(local_kwargs, :rho0) || throw(ArgumentError("rho0 is required for ProblemSpec FixedAsymmetricRho forward_solve"))
-        return _solve_constraint_fixedasymrho(m, t, mode.rho_target, mode.ud_ratio_target, mode.s_target; pairs(local_kwargs)...)
+    candidates = NamedTuple[]
+    for (attempt_index, attempt_cfg) in enumerate(attempt_plan)
+        local raw
+        try
+            local_kwargs = Dict{Symbol,Any}(kwargs)
+            local_kwargs[:seed_guess] = attempt_cfg.seed
+            local_kwargs[:nlsolve_method] = attempt_cfg.method
+            _strip_problemspec_forwardsolve_kwargs!(local_kwargs)
+            delete!(local_kwargs, :trust_region_fallback)
+            delete!(local_kwargs, :fallback_method)
+
+            haskey(local_kwargs, :rho0) || throw(ArgumentError("rho0 is required for ProblemSpec FixedAsymmetricRho forward_solve"))
+            solved = _solve_constraint_fixedasymrho(model, T_fm, mode.rho_target, mode.ud_ratio_target, mode.s_target; pairs(local_kwargs)...)
+            raw = (; solved..., residual_norm_max=get(local_kwargs, :residual_norm_max, 1e-6), asym_attempt_origin=attempt_cfg.attempt_origin)
+            ok, failed = evaluate_hard_constraints(raw, hard_constraints)
+            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, seed_index=Int(attempt_index)))
+            if ok
+                break
+            end
+        catch
+            raw = (
+                converged=false,
+                solution=Float64[],
+                x_state=zeros(5),
+                mu_vec=zeros(3),
+                omega=NaN,
+                pressure=-Inf,
+                rho_norm=NaN,
+                entropy=NaN,
+                energy=NaN,
+                masses=zeros(3),
+                iterations=0,
+                residual_norm=Inf,
+                residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
+                asym_attempt_origin=attempt_cfg.attempt_origin,
+            )
+            push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
+        end
     end
-    return _governed_mode_forward_solve(model, T_fm, seed_pool, kwargs, hard_constraints, solve_one)
+
+    selector_fn = _resolve_candidate_selector(kwargs)
+    selected = selector_fn(candidates)
+    s = selected.selected_candidate
+    return (
+        converged=Bool(s.converged),
+        solution=Vector{Float64}(s.solution),
+        x_state=s.x_state,
+        mu_vec=s.mu_vec,
+        omega=s.omega,
+        pressure=s.pressure,
+        rho_norm=s.rho_norm,
+        entropy=s.entropy,
+        energy=s.energy,
+        masses=s.masses,
+        iterations=s.iterations,
+        residual_norm=s.residual_norm,
+        hard_constraint_ok=s.hard_constraint_ok,
+        failed_constraints=s.failed_constraints,
+        selection_reason=selected.selection_reason,
+        selected_index=selected.selected_index,
+        candidate_count=length(candidates),
+    )
 end
 
 @inline function build_problem_spec(mode::ConstraintMode; kwargs...)

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -54,14 +54,119 @@ end
 end
 
 @inline function _strip_problemspec_forwardsolve_kwargs!(kwargs::Dict{Symbol,Any})
-    for key in (:seed_candidates, :hard_constraints, :semantic_mode, :selector)
+    for key in (:seed_candidates, :hard_constraints, :semantic_mode, :selector, :fixedrho_joint_solve)
         delete!(kwargs, key)
     end
     return kwargs
 end
 
+@inline function _joint_model_kind(::RPNJLModel)
+    return :RPNJL
+end
+
+@inline function _joint_model_kind(::AbstractQCDModel)
+    return :PNJL
+end
+
+@inline function _strip_fixedrho_joint_nlsolve_kwargs!(kwargs::Dict{Symbol,Any})
+    for key in (
+        :seed_guess,
+        :mu0,
+        :solver_primary,
+        :solver_secondary,
+        :physicality_check,
+        :fixedrho_joint_solve,
+        :nlsolve_method,
+        :residual_norm_max,
+        :xi,
+        :p_num,
+        :t_num,
+    )
+        delete!(kwargs, key)
+    end
+    return kwargs
+end
+
+function _fixedrho_joint_problem_spec_forward_solve(model::AbstractQCDModel, mode::FixedRho, T_fm::Real; fwd_kwargs...)
+    kwargs = Dict{Symbol,Any}(pairs(fwd_kwargs))
+
+    seed_guess = get(kwargs, :seed_guess, nothing)
+    seed_guess === nothing && throw(ArgumentError("seed_guess is required for ProblemSpec FixedRho joint forward_solve"))
+
+    xi = Float64(get(kwargs, :xi, 0.0))
+    p_num = Int(get(kwargs, :p_num, 24))
+    t_num = Int(get(kwargs, :t_num, 8))
+    residual_norm_max = Float64(get(kwargs, :residual_norm_max, 1e-6))
+    nlsolve_method = get(kwargs, :nlsolve_method, :newton)
+
+    x0 = if length(seed_guess) >= 8
+        Float64.(seed_guess[1:8])
+    else
+        extend_seed(Float64.(seed_guess), mode)
+    end
+
+    thermal_nodes = cached_nodes(p_num, t_num)
+    params = GapParams(Float64(T_fm), thermal_nodes, xi;
+        p_num=p_num,
+        t_num=t_num,
+        model_kind=_joint_model_kind(model),
+    )
+    residual_fn! = build_residual!(mode, params)
+
+    local_nls_kwargs = Dict{Symbol,Any}(kwargs)
+    _strip_problemspec_forwardsolve_kwargs!(local_nls_kwargs)
+    _strip_fixedrho_joint_nlsolve_kwargs!(local_nls_kwargs)
+
+    res = nlsolve(
+        residual_fn!,
+        x0;
+        autodiff=:forward,
+        method=nlsolve_method,
+        xtol=1e-9,
+        ftol=1e-9,
+        pairs(local_nls_kwargs)...,
+    )
+
+    solution = Float64.(res.zero)
+    x_state, mu_vec = _unpack_solution(solution; state_n=5, mu_n=3)
+
+    pressure = -omega(model, x_state, T_fm, mu_vec; p_num=p_num, t_num=t_num, xi=xi)
+    pressure_mu = μtrial -> -omega(model, x_state, T_fm, μtrial; p_num=p_num, t_num=t_num, xi=xi)
+    rho_vec = ForwardDiff.gradient(pressure_mu, mu_vec)
+    rho_norm = sum(rho_vec) / (3.0 * rho0)
+    pressure_T = τ -> -omega(model, x_state, τ, mu_vec; p_num=p_num, t_num=t_num, xi=xi)
+    entropy = ForwardDiff.derivative(pressure_T, T_fm)
+    energy = -pressure + sum(mu_vec .* rho_vec) + T_fm * entropy
+    omega_val = -pressure
+    masses = calculate_mass_vec(model, SVector{3}(x_state[1], x_state[2], x_state[3]))
+
+    residual_vec = zeros(Float64, 8)
+    residual_fn!(residual_vec, solution)
+    residual_norm = sqrt(sum(abs2, residual_vec))
+
+    converged = res.f_converged && isfinite(residual_norm) && residual_norm <= residual_norm_max
+
+    return (
+        converged=converged,
+        solution=solution,
+        x_state=x_state,
+        mu_vec=mu_vec,
+        omega=omega_val,
+        pressure=pressure,
+        rho_norm=rho_norm,
+        entropy=entropy,
+        energy=energy,
+        masses=masses,
+        iterations=res.iterations,
+        residual_norm=residual_norm,
+        fixedrho_joint_solve_active=true,
+    )
+end
+
 function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::FixedRho, T_fm::Real; fwd_kwargs...)
     kwargs = Dict{Symbol,Any}(pairs(fwd_kwargs))
+    fixedrho_joint_solve = get(kwargs, :fixedrho_joint_solve, false)
+    fixedrho_joint_solve isa Bool || throw(ArgumentError("fixedrho_joint_solve must be Bool, got $(typeof(fixedrho_joint_solve))"))
 
     seed_guess = get(kwargs, :seed_guess, nothing)
     seed_guess === nothing && throw(ArgumentError("seed_guess is required for ProblemSpec FixedRho forward_solve"))
@@ -83,8 +188,33 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
             local_kwargs[:seed_guess] = seed
             _strip_problemspec_forwardsolve_kwargs!(local_kwargs)
 
-            solved = _solve_constraint_fixedrho(model, T_fm, mode.rho_target; pairs(local_kwargs)...)
-            raw = (; solved..., residual_norm_max=get(local_kwargs, :residual_norm_max, 1e-6))
+            solved = if fixedrho_joint_solve
+                joint = try
+                    _fixedrho_joint_problem_spec_forward_solve(model, mode, T_fm; pairs(local_kwargs)...)
+                catch
+                    nothing
+                end
+
+                joint_res = joint === nothing ? Inf : get(joint, :residual_norm, Inf)
+                joint_ok = joint !== nothing && isfinite(joint_res) && joint_res <= max(get(local_kwargs, :residual_norm_max, 1e-6), 1e-3)
+
+                if joint_ok
+                    (; joint..., fixedrho_joint_solve_active=true, fixedrho_joint_fallback=false)
+                else
+                    legacy = _solve_constraint_fixedrho(model, T_fm, mode.rho_target; pairs(local_kwargs)...)
+                    (; legacy..., fixedrho_joint_solve_active=false, fixedrho_joint_fallback=true, fixedrho_joint_attempt_residual=joint_res)
+                end
+            else
+                legacy = _solve_constraint_fixedrho(model, T_fm, mode.rho_target; pairs(local_kwargs)...)
+                (; legacy..., fixedrho_joint_solve_active=false, fixedrho_joint_fallback=false)
+            end
+            raw = (
+                ; solved...,
+                residual_norm_max=get(local_kwargs, :residual_norm_max, 1e-6),
+                fixedrho_joint_solve_requested=fixedrho_joint_solve,
+                fixedrho_joint_solve_active=get(solved, :fixedrho_joint_solve_active, false),
+                fixedrho_joint_fallback=get(solved, :fixedrho_joint_fallback, false),
+            )
             ok, failed = evaluate_hard_constraints(raw, hard_constraints)
             push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, seed_index=Int(seed_index)))
         catch
@@ -102,6 +232,9 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
                 iterations=0,
                 residual_norm=Inf,
                 residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
+                fixedrho_joint_solve_requested=fixedrho_joint_solve,
+                fixedrho_joint_solve_active=false,
+                fixedrho_joint_fallback=false,
             )
             push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(seed_index)))
         end
@@ -128,6 +261,9 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
         selection_reason=selected.selection_reason,
         selected_index=selected.selected_index,
         candidate_count=length(candidates),
+        fixedrho_joint_solve_requested=fixedrho_joint_solve,
+        fixedrho_joint_solve_active=get(s, :fixedrho_joint_solve_active, false),
+        fixedrho_joint_fallback=get(s, :fixedrho_joint_fallback, false),
     )
 end
 

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -77,6 +77,9 @@ end
         :physicality_check,
         :fixedrho_joint_solve,
         :nlsolve_method,
+        :continuity_seed,
+        :trust_region_fallback,
+        :fallback_method,
         :residual_norm_max,
         :xi,
         :p_num,
@@ -97,7 +100,10 @@ function _fixedrho_joint_problem_spec_forward_solve(model::AbstractQCDModel, mod
     p_num = Int(get(kwargs, :p_num, 24))
     t_num = Int(get(kwargs, :t_num, 8))
     residual_norm_max = Float64(get(kwargs, :residual_norm_max, 1e-6))
-    nlsolve_method = get(kwargs, :nlsolve_method, :newton)
+    nlsolve_method = get(kwargs, :nlsolve_method, :trust_region)
+    trust_region_fallback = Bool(get(kwargs, :trust_region_fallback, true))
+    fallback_method = get(kwargs, :fallback_method, :trust_region)
+    physicality_check = get(kwargs, :physicality_check, ((_, _) -> true))
 
     x0 = if length(seed_guess) >= 8
         Float64.(seed_guess[1:8])
@@ -117,97 +123,239 @@ function _fixedrho_joint_problem_spec_forward_solve(model::AbstractQCDModel, mod
     _strip_problemspec_forwardsolve_kwargs!(local_nls_kwargs)
     _strip_fixedrho_joint_nlsolve_kwargs!(local_nls_kwargs)
 
-    res = nlsolve(
-        residual_fn!,
-        x0;
-        autodiff=:forward,
-        method=nlsolve_method,
-        xtol=1e-9,
-        ftol=1e-9,
-        pairs(local_nls_kwargs)...,
+    postprocess_solution = function (solution)
+        x_state, mu_vec = _unpack_solution(solution; state_n=5, mu_n=3)
+
+        pressure = -omega(model, x_state, T_fm, mu_vec; p_num=p_num, t_num=t_num, xi=xi)
+        pressure_mu = μtrial -> -omega(model, x_state, T_fm, μtrial; p_num=p_num, t_num=t_num, xi=xi)
+        rho_vec = ForwardDiff.gradient(pressure_mu, mu_vec)
+        rho_norm = sum(rho_vec) / (3.0 * rho0)
+        pressure_T = τ -> -omega(model, x_state, τ, mu_vec; p_num=p_num, t_num=t_num, xi=xi)
+        entropy = ForwardDiff.derivative(pressure_T, T_fm)
+        energy = -pressure + sum(mu_vec .* rho_vec) + T_fm * entropy
+        omega_val = -pressure
+        masses = calculate_mass_vec(model, SVector{3}(x_state[1], x_state[2], x_state[3]))
+        thermo_finite = isfinite(omega_val) && isfinite(pressure) && isfinite(rho_norm) && isfinite(entropy) && isfinite(energy)
+        phys = physicality_check(x_state, masses) && thermo_finite
+
+        residual_vec = zeros(Float64, 8)
+        residual_fn!(residual_vec, solution)
+        residual_norm = sqrt(sum(abs2, residual_vec))
+
+        return (
+            x_state=x_state,
+            mu_vec=mu_vec,
+            omega=omega_val,
+            pressure=pressure,
+            rho_norm=rho_norm,
+            entropy=entropy,
+            energy=energy,
+            masses=masses,
+            residual_norm=residual_norm,
+            phys=phys,
+        )
+    end
+
+    cache = Dict{Symbol,NamedTuple}()
+    solve_once = function (method::Symbol, seed::Vector{Float64})
+        res = nlsolve(
+            residual_fn!,
+            seed;
+            autodiff=:forward,
+            method=method,
+            xtol=1e-9,
+            ftol=1e-9,
+            pairs(local_nls_kwargs)...,
+        )
+
+        solution = Float64.(res.zero)
+        pp = postprocess_solution(solution)
+        converged = Bool(res.f_converged) && pp.phys && isfinite(pp.residual_norm) && pp.residual_norm <= residual_norm_max
+
+        cache[method] = (
+            res=res,
+            solution=solution,
+            x_state=pp.x_state,
+            mu_vec=pp.mu_vec,
+            omega=pp.omega,
+            pressure=pp.pressure,
+            rho_norm=pp.rho_norm,
+            entropy=pp.entropy,
+            energy=pp.energy,
+            masses=pp.masses,
+            residual_norm=pp.residual_norm,
+            converged=converged,
+        )
+
+        return (
+            x=solution,
+            converged=converged,
+            residual_norm=pp.residual_norm,
+            score=Float64(pp.omega),
+        )
+    end
+
+    policy = RootPolicy(
+        primary_method=nlsolve_method,
+        fallback_method=fallback_method,
+        use_fallback=trust_region_fallback,
+        use_multiseed=false,
+        residual_norm_max=residual_norm_max,
+        require_converged=true,
+        diagnostics_level=:basic,
     )
 
-    solution = Float64.(res.zero)
-    x_state, mu_vec = _unpack_solution(solution; state_n=5, mu_n=3)
+    solved = solve_root_with_policy(solve_once, x0; policy=policy)
+    selected_attempt = solved.diagnostics.attempts[solved.diagnostics.selected_attempt]
+    selected_method = selected_attempt.method
 
-    pressure = -omega(model, x_state, T_fm, mu_vec; p_num=p_num, t_num=t_num, xi=xi)
-    pressure_mu = μtrial -> -omega(model, x_state, T_fm, μtrial; p_num=p_num, t_num=t_num, xi=xi)
-    rho_vec = ForwardDiff.gradient(pressure_mu, mu_vec)
-    rho_norm = sum(rho_vec) / (3.0 * rho0)
-    pressure_T = τ -> -omega(model, x_state, τ, mu_vec; p_num=p_num, t_num=t_num, xi=xi)
-    entropy = ForwardDiff.derivative(pressure_T, T_fm)
-    energy = -pressure + sum(mu_vec .* rho_vec) + T_fm * entropy
-    omega_val = -pressure
-    masses = calculate_mass_vec(model, SVector{3}(x_state[1], x_state[2], x_state[3]))
-
-    residual_vec = zeros(Float64, 8)
-    residual_fn!(residual_vec, solution)
-    residual_norm = sqrt(sum(abs2, residual_vec))
-
-    converged = res.f_converged && isfinite(residual_norm) && residual_norm <= residual_norm_max
+    if !haskey(cache, selected_method)
+        _ = solve_once(selected_method, copy(x0))
+    end
+    picked = cache[selected_method]
 
     return (
-        converged=converged,
-        solution=solution,
-        x_state=x_state,
-        mu_vec=mu_vec,
-        omega=omega_val,
-        pressure=pressure,
-        rho_norm=rho_norm,
-        entropy=entropy,
-        energy=energy,
-        masses=masses,
-        iterations=res.iterations,
-        residual_norm=residual_norm,
+        converged=picked.converged,
+        solution=picked.solution,
+        x_state=picked.x_state,
+        mu_vec=picked.mu_vec,
+        omega=picked.omega,
+        pressure=picked.pressure,
+        rho_norm=picked.rho_norm,
+        entropy=picked.entropy,
+        energy=picked.energy,
+        masses=picked.masses,
+        iterations=picked.res.iterations,
+        residual_norm=picked.residual_norm,
         fixedrho_joint_solve_active=true,
+        fixedrho_joint_selected_method=selected_method,
+        fixedrho_joint_selected_quality=selected_attempt.quality_tag,
+        fixedrho_joint_fallback_used=(selected_attempt.quality_tag == :fallback),
     )
 end
 
 function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::FixedRho, T_fm::Real; fwd_kwargs...)
     kwargs = Dict{Symbol,Any}(pairs(fwd_kwargs))
-    fixedrho_joint_solve = get(kwargs, :fixedrho_joint_solve, false)
+    fixedrho_joint_solve = get(kwargs, :fixedrho_joint_solve, true)
     fixedrho_joint_solve isa Bool || throw(ArgumentError("fixedrho_joint_solve must be Bool, got $(typeof(fixedrho_joint_solve))"))
+
+    if !fixedrho_joint_solve
+        seed_guess = get(kwargs, :seed_guess, nothing)
+        seed_guess === nothing && throw(ArgumentError("seed_guess is required for ProblemSpec FixedRho forward_solve"))
+
+        legacy = _solve_constraint_fixedrho(model, T_fm, mode.rho_target; pairs(kwargs)...)
+        return (
+            converged=Bool(legacy.converged),
+            solution=Vector{Float64}(legacy.solution),
+            x_state=legacy.x_state,
+            mu_vec=legacy.mu_vec,
+            omega=legacy.omega,
+            pressure=legacy.pressure,
+            rho_norm=legacy.rho_norm,
+            entropy=legacy.entropy,
+            energy=legacy.energy,
+            masses=legacy.masses,
+            iterations=legacy.iterations,
+            residual_norm=legacy.residual_norm,
+            hard_constraint_ok=Bool(get(legacy, :converged, false)),
+            failed_constraints=(Bool(get(legacy, :converged, false)) ? Symbol[] : Symbol[:legacy_solver_failed]),
+            selection_reason=:legacy_fixedrho_solver,
+            selected_index=1,
+            candidate_count=1,
+            fixedrho_joint_solve_requested=false,
+            fixedrho_joint_solve_active=false,
+            fixedrho_joint_fallback=false,
+            fixedrho_joint_selected_method=:none,
+            fixedrho_joint_selected_quality=:bad,
+            fixedrho_joint_fallback_used=false,
+        )
+    end
 
     seed_guess = get(kwargs, :seed_guess, nothing)
     seed_guess === nothing && throw(ArgumentError("seed_guess is required for ProblemSpec FixedRho forward_solve"))
 
-    seed_pool = if haskey(kwargs, :seed_candidates)
+    provided_seed_pool = if haskey(kwargs, :seed_candidates)
         [Float64.(s) for s in kwargs[:seed_candidates]]
     else
-        _build_default_seed_candidates(seed_guess)
+        Vector{Vector{Float64}}()
+    end
+    default_seed_pool = _build_default_seed_candidates(seed_guess)
+
+    primary_seed = Float64.(seed_guess)
+    primary_method = if haskey(kwargs, :nlsolve_method)
+        kwargs[:nlsolve_method]
+    else
+        Bool(get(kwargs, :continuity_seed, false)) ? :newton : :trust_region
+    end
+    primary_use_fallback = Bool(get(kwargs, :trust_region_fallback, true))
+    fallback_method = get(kwargs, :fallback_method, :trust_region)
+
+    fallback_seeds = Vector{Vector{Float64}}()
+    seed_seen = Set{String}()
+    seed_key(seed_vec::AbstractVector{<:Real}) = join(round.(Float64.(seed_vec); digits=12), ",")
+
+    primary_key = seed_key(primary_seed)
+    push!(seed_seen, primary_key)
+
+    for seed in provided_seed_pool
+        k = seed_key(seed)
+        if !(k in seed_seen)
+            push!(fallback_seeds, seed)
+            push!(seed_seen, k)
+        end
+    end
+    for seed in default_seed_pool
+        k = seed_key(seed)
+        if !(k in seed_seen)
+            push!(fallback_seeds, seed)
+            push!(seed_seen, k)
+        end
+    end
+
+    attempt_plan = NamedTuple[]
+    push!(attempt_plan, (
+        seed=primary_seed,
+        method=primary_method,
+        use_fallback=primary_use_fallback,
+        fallback_method=fallback_method,
+        attempt_origin=:primary,
+    ))
+
+    if primary_method != :trust_region && !(primary_use_fallback && fallback_method == :trust_region)
+        push!(attempt_plan, (
+            seed=primary_seed,
+            method=:trust_region,
+            use_fallback=false,
+            fallback_method=:trust_region,
+            attempt_origin=:method_rescue,
+        ))
+    end
+
+    for seed in fallback_seeds
+        push!(attempt_plan, (
+            seed=seed,
+            method=:trust_region,
+            use_fallback=false,
+            fallback_method=:trust_region,
+            attempt_origin=:seed_rescue,
+        ))
     end
 
     physicality_check = get(kwargs, :physicality_check, ((_, _) -> true))
     hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
 
     candidates = NamedTuple[]
-    for (seed_index, seed) in enumerate(seed_pool)
+    for (attempt_index, attempt_cfg) in enumerate(attempt_plan)
         local raw
         try
             local_kwargs = Dict{Symbol,Any}(kwargs)
-            local_kwargs[:seed_guess] = seed
+            local_kwargs[:seed_guess] = attempt_cfg.seed
+            local_kwargs[:nlsolve_method] = attempt_cfg.method
+            local_kwargs[:trust_region_fallback] = attempt_cfg.use_fallback
+            local_kwargs[:fallback_method] = attempt_cfg.fallback_method
             _strip_problemspec_forwardsolve_kwargs!(local_kwargs)
 
-            solved = if fixedrho_joint_solve
-                joint = try
-                    _fixedrho_joint_problem_spec_forward_solve(model, mode, T_fm; pairs(local_kwargs)...)
-                catch
-                    nothing
-                end
-
-                joint_res = joint === nothing ? Inf : get(joint, :residual_norm, Inf)
-                joint_ok = joint !== nothing && isfinite(joint_res) && joint_res <= max(get(local_kwargs, :residual_norm_max, 1e-6), 1e-3)
-
-                if joint_ok
-                    (; joint..., fixedrho_joint_solve_active=true, fixedrho_joint_fallback=false)
-                else
-                    legacy = _solve_constraint_fixedrho(model, T_fm, mode.rho_target; pairs(local_kwargs)...)
-                    (; legacy..., fixedrho_joint_solve_active=false, fixedrho_joint_fallback=true, fixedrho_joint_attempt_residual=joint_res)
-                end
-            else
-                legacy = _solve_constraint_fixedrho(model, T_fm, mode.rho_target; pairs(local_kwargs)...)
-                (; legacy..., fixedrho_joint_solve_active=false, fixedrho_joint_fallback=false)
-            end
+            solved = _fixedrho_joint_problem_spec_forward_solve(model, mode, T_fm; pairs(local_kwargs)...)
             raw = (
                 converged=Bool(solved.converged),
                 solution=Float64.(solved.solution),
@@ -224,10 +372,17 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
                 residual_norm_max=get(local_kwargs, :residual_norm_max, 1e-6),
                 fixedrho_joint_solve_requested=fixedrho_joint_solve,
                 fixedrho_joint_solve_active=get(solved, :fixedrho_joint_solve_active, false),
-                fixedrho_joint_fallback=get(solved, :fixedrho_joint_fallback, false),
+                fixedrho_joint_fallback=false,
+                fixedrho_joint_selected_method=get(solved, :fixedrho_joint_selected_method, :none),
+                fixedrho_joint_selected_quality=get(solved, :fixedrho_joint_selected_quality, :bad),
+                fixedrho_joint_fallback_used=get(solved, :fixedrho_joint_fallback_used, false),
+                fixedrho_joint_attempt_origin=attempt_cfg.attempt_origin,
             )
             ok, failed = evaluate_hard_constraints(raw, hard_constraints)
-            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, seed_index=Int(seed_index)))
+            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, seed_index=Int(attempt_index)))
+            if ok
+                break
+            end
         catch
             raw = (
                 converged=false,
@@ -246,8 +401,12 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
                 fixedrho_joint_solve_requested=fixedrho_joint_solve,
                 fixedrho_joint_solve_active=false,
                 fixedrho_joint_fallback=false,
+                fixedrho_joint_selected_method=:none,
+                fixedrho_joint_selected_quality=:bad,
+                fixedrho_joint_fallback_used=false,
+                fixedrho_joint_attempt_origin=attempt_cfg.attempt_origin,
             )
-            push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(seed_index)))
+            push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
         end
     end
 
@@ -275,6 +434,9 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
         fixedrho_joint_solve_requested=fixedrho_joint_solve,
         fixedrho_joint_solve_active=get(s, :fixedrho_joint_solve_active, false),
         fixedrho_joint_fallback=get(s, :fixedrho_joint_fallback, false),
+        fixedrho_joint_selected_method=get(s, :fixedrho_joint_selected_method, :none),
+        fixedrho_joint_selected_quality=get(s, :fixedrho_joint_selected_quality, :bad),
+        fixedrho_joint_fallback_used=get(s, :fixedrho_joint_fallback_used, false),
     )
 end
 

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -37,6 +37,88 @@ end
     return vcat(collect(rules), [extra_rule])
 end
 
+@inline function _seed_key(seed_vec::AbstractVector{<:Real})
+    return join(round.(Float64.(seed_vec); digits=12), ",")
+end
+
+function _build_governed_attempt_plan(
+    mode::ConstraintMode,
+    primary_seed::AbstractVector{<:Real},
+    provided_seed_pool,
+    default_seed_pool,
+    extra_constraints::ExtraConstraints;
+    primary_method,
+    primary_use_fallback::Bool,
+    fallback_method,
+    extra_fallback_seeds=Vector{Vector{Float64}}(),
+)
+    primary_seed_vec = _extend_seed_with_extra(Float64.(primary_seed), mode, extra_constraints)
+
+    fallback_seeds = Vector{Vector{Float64}}()
+    seed_seen = Set{String}()
+
+    primary_key = _seed_key(primary_seed_vec)
+    push!(seed_seen, primary_key)
+
+    for seed in extra_fallback_seeds
+        normalized_seed = _extend_seed_with_extra(seed, mode, extra_constraints)
+        key = _seed_key(normalized_seed)
+        if !(key in seed_seen)
+            push!(fallback_seeds, normalized_seed)
+            push!(seed_seen, key)
+        end
+    end
+
+    for seed in provided_seed_pool
+        normalized_seed = _extend_seed_with_extra(seed, mode, extra_constraints)
+        key = _seed_key(normalized_seed)
+        if !(key in seed_seen)
+            push!(fallback_seeds, normalized_seed)
+            push!(seed_seen, key)
+        end
+    end
+
+    for seed in default_seed_pool
+        normalized_seed = _extend_seed_with_extra(seed, mode, extra_constraints)
+        key = _seed_key(normalized_seed)
+        if !(key in seed_seen)
+            push!(fallback_seeds, normalized_seed)
+            push!(seed_seen, key)
+        end
+    end
+
+    attempt_plan = NamedTuple[]
+    push!(attempt_plan, (
+        seed=primary_seed_vec,
+        method=primary_method,
+        use_fallback=primary_use_fallback,
+        fallback_method=fallback_method,
+        attempt_origin=:primary,
+    ))
+
+    if primary_method != :trust_region && !(primary_use_fallback && fallback_method == :trust_region)
+        push!(attempt_plan, (
+            seed=primary_seed_vec,
+            method=:trust_region,
+            use_fallback=false,
+            fallback_method=:trust_region,
+            attempt_origin=:method_rescue,
+        ))
+    end
+
+    for seed in fallback_seeds
+        push!(attempt_plan, (
+            seed=seed,
+            method=:trust_region,
+            use_fallback=false,
+            fallback_method=:trust_region,
+            attempt_origin=:seed_rescue,
+        ))
+    end
+
+    return attempt_plan
+end
+
 struct ProblemSpec{M,R,F,C,U,P,H,S,E}
     mode::M
     x_dim::Int
@@ -294,7 +376,7 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
     end
     default_seed_pool = _build_default_seed_candidates(seed_guess)
 
-    primary_seed = _extend_seed_with_extra(Float64.(seed_guess), mode, extra_constraints)
+    primary_seed = Float64.(seed_guess)
     primary_method = if haskey(kwargs, :nlsolve_method)
         kwargs[:nlsolve_method]
     else
@@ -303,69 +385,22 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
     primary_use_fallback = Bool(get(kwargs, :trust_region_fallback, true))
     fallback_method = get(kwargs, :fallback_method, :trust_region)
 
-    fallback_seeds = Vector{Vector{Float64}}()
-    seed_seen = Set{String}()
-    seed_key(seed_vec::AbstractVector{<:Real}) = join(round.(Float64.(seed_vec); digits=12), ",")
-
-    primary_key = seed_key(primary_seed)
-    push!(seed_seen, primary_key)
-
     legacy_seed = if length(primary_seed) >= 5
         _extend_seed_with_extra(Float64.(Main.Models.extend_seed(Float64.(primary_seed[1:5]), mode)), mode, extra_constraints)
     else
         _extend_seed_with_extra(Float64.(Main.Models.extend_seed(primary_seed, mode)), mode, extra_constraints)
     end
-    legacy_key = seed_key(legacy_seed)
-    if !(legacy_key in seed_seen)
-        push!(fallback_seeds, legacy_seed)
-        push!(seed_seen, legacy_key)
-    end
-
-    for seed in provided_seed_pool
-        seed = _extend_seed_with_extra(seed, mode, extra_constraints)
-        k = seed_key(seed)
-        if !(k in seed_seen)
-            push!(fallback_seeds, seed)
-            push!(seed_seen, k)
-        end
-    end
-    for seed in default_seed_pool
-        seed = _extend_seed_with_extra(seed, mode, extra_constraints)
-        k = seed_key(seed)
-        if !(k in seed_seen)
-            push!(fallback_seeds, seed)
-            push!(seed_seen, k)
-        end
-    end
-
-    attempt_plan = NamedTuple[]
-    push!(attempt_plan, (
-        seed=primary_seed,
-        method=primary_method,
-        use_fallback=primary_use_fallback,
+    attempt_plan = _build_governed_attempt_plan(
+        mode,
+        primary_seed,
+        provided_seed_pool,
+        default_seed_pool,
+        extra_constraints;
+        primary_method=primary_method,
+        primary_use_fallback=primary_use_fallback,
         fallback_method=fallback_method,
-        attempt_origin=:primary,
-    ))
-
-    if primary_method != :trust_region && !(primary_use_fallback && fallback_method == :trust_region)
-        push!(attempt_plan, (
-            seed=primary_seed,
-            method=:trust_region,
-            use_fallback=false,
-            fallback_method=:trust_region,
-            attempt_origin=:method_rescue,
-        ))
-    end
-
-    for seed in fallback_seeds
-        push!(attempt_plan, (
-            seed=seed,
-            method=:trust_region,
-            use_fallback=false,
-            fallback_method=:trust_region,
-            attempt_origin=:seed_rescue,
-        ))
-    end
+        extra_fallback_seeds=[legacy_seed],
+    )
 
     physicality_check = get(kwargs, :physicality_check, ((_, _) -> true))
     hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
@@ -552,7 +587,7 @@ function _governed_nonrho_problem_spec_forward_solve(
     end
     default_seed_pool = _build_default_seed_candidates(seed_guess)
 
-    primary_seed = _extend_seed_with_extra(Float64.(seed_guess), mode, extra_constraints)
+    primary_seed = Float64.(seed_guess)
     primary_method = if haskey(kwargs, :nlsolve_method)
         kwargs[:nlsolve_method]
     else
@@ -561,57 +596,16 @@ function _governed_nonrho_problem_spec_forward_solve(
     primary_use_fallback = Bool(get(kwargs, :trust_region_fallback, true))
     fallback_method = get(kwargs, :fallback_method, :trust_region)
 
-    fallback_seeds = Vector{Vector{Float64}}()
-    seed_seen = Set{String}()
-    seed_key(seed_vec::AbstractVector{<:Real}) = join(round.(Float64.(seed_vec); digits=12), ",")
-    primary_key = seed_key(primary_seed)
-    push!(seed_seen, primary_key)
-
-    for seed in provided_seed_pool
-        seed = _extend_seed_with_extra(seed, mode, extra_constraints)
-        k = seed_key(seed)
-        if !(k in seed_seen)
-            push!(fallback_seeds, seed)
-            push!(seed_seen, k)
-        end
-    end
-    for seed in default_seed_pool
-        seed = _extend_seed_with_extra(seed, mode, extra_constraints)
-        k = seed_key(seed)
-        if !(k in seed_seen)
-            push!(fallback_seeds, seed)
-            push!(seed_seen, k)
-        end
-    end
-
-    attempt_plan = NamedTuple[]
-    push!(attempt_plan, (
-        seed=primary_seed,
-        method=primary_method,
-        use_fallback=primary_use_fallback,
+    attempt_plan = _build_governed_attempt_plan(
+        mode,
+        primary_seed,
+        provided_seed_pool,
+        default_seed_pool,
+        extra_constraints;
+        primary_method=primary_method,
+        primary_use_fallback=primary_use_fallback,
         fallback_method=fallback_method,
-        attempt_origin=:primary,
-    ))
-
-    if primary_method != :trust_region && !(primary_use_fallback && fallback_method == :trust_region)
-        push!(attempt_plan, (
-            seed=primary_seed,
-            method=:trust_region,
-            use_fallback=false,
-            fallback_method=:trust_region,
-            attempt_origin=:method_rescue,
-        ))
-    end
-
-    for seed in fallback_seeds
-        push!(attempt_plan, (
-            seed=seed,
-            method=:trust_region,
-            use_fallback=false,
-            fallback_method=:trust_region,
-            attempt_origin=:seed_rescue,
-        ))
-    end
+    )
 
     physicality_check = get(kwargs, :physicality_check, ((_, _) -> true))
     hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -406,19 +406,16 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
     hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
     hard_constraints = _append_extra_feasible_rule(hard_constraints, extra_constraints, mode)
 
-    candidates = NamedTuple[]
-    for (attempt_index, attempt_cfg) in enumerate(attempt_plan)
-        local raw
-        try
-            local_kwargs = Dict{Symbol,Any}(kwargs)
-            local_kwargs[:seed_guess] = attempt_cfg.seed
-            local_kwargs[:nlsolve_method] = attempt_cfg.method
-            local_kwargs[:trust_region_fallback] = attempt_cfg.use_fallback
-            local_kwargs[:fallback_method] = attempt_cfg.fallback_method
+    selector_fn = _resolve_candidate_selector(kwargs)
+    selected, candidates = _execute_governed_attempt_plan(
+        attempt_plan,
+        kwargs,
+        hard_constraints,
+        selector_fn,
+        function (local_kwargs, attempt_cfg, _)
             _strip_problemspec_forwardsolve_kwargs!(local_kwargs)
-
             solved = _fixedrho_joint_problem_spec_forward_solve(model, mode, T_fm; pairs(local_kwargs)...)
-            raw = (
+            return (
                 converged=Bool(solved.converged),
                 solution=Float64.(solved.solution),
                 x_state=solved.x_state,
@@ -440,13 +437,9 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
                 fixedrho_joint_fallback_used=get(solved, :fixedrho_joint_fallback_used, false),
                 fixedrho_joint_attempt_origin=attempt_cfg.attempt_origin,
             )
-            ok, failed = evaluate_hard_constraints(raw, hard_constraints)
-            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, seed_index=Int(attempt_index)))
-            if ok
-                break
-            end
-        catch
-            raw = (
+        end,
+        function (base_kwargs, attempt_cfg, _)
+            return (
                 converged=false,
                 solution=Float64[],
                 x_state=zeros(5),
@@ -459,7 +452,7 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
                 masses=zeros(3),
                 iterations=0,
                 residual_norm=Inf,
-                residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
+                residual_norm_max=Float64(get(base_kwargs, :residual_norm_max, 1e-6)),
                 fixedrho_joint_solve_requested=fixedrho_joint_solve,
                 fixedrho_joint_solve_active=false,
                 fixedrho_joint_fallback=false,
@@ -468,12 +461,8 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
                 fixedrho_joint_fallback_used=false,
                 fixedrho_joint_attempt_origin=attempt_cfg.attempt_origin,
             )
-            push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
-        end
-    end
-
-    selector_fn = _resolve_candidate_selector(kwargs)
-    selected = selector_fn(candidates)
+        end,
+    )
     s = selected.selected_candidate
     return (
         converged=Bool(s.converged),
@@ -567,6 +556,39 @@ function _governed_mode_forward_solve(
     )
 end
 
+function _execute_governed_attempt_plan(
+    attempt_plan,
+    kwargs::Dict{Symbol,Any},
+    hard_constraints,
+    selector_fn::Function,
+    solve_attempt::Function,
+    failure_attempt::Function,
+)
+    candidates = NamedTuple[]
+    for (attempt_index, attempt_cfg) in enumerate(attempt_plan)
+        try
+            local_kwargs = Dict{Symbol,Any}(kwargs)
+            local_kwargs[:seed_guess] = attempt_cfg.seed
+            local_kwargs[:nlsolve_method] = attempt_cfg.method
+            local_kwargs[:trust_region_fallback] = attempt_cfg.use_fallback
+            local_kwargs[:fallback_method] = attempt_cfg.fallback_method
+
+            raw = solve_attempt(local_kwargs, attempt_cfg, attempt_index)
+            ok, failed = evaluate_hard_constraints(raw, hard_constraints)
+            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, seed_index=Int(attempt_index)))
+            if ok
+                break
+            end
+        catch
+            raw = failure_attempt(kwargs, attempt_cfg, attempt_index)
+            push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
+        end
+    end
+
+    selected = selector_fn(candidates)
+    return selected, candidates
+end
+
 function _governed_nonrho_problem_spec_forward_solve(
     model::AbstractQCDModel,
     mode::ConstraintMode,
@@ -611,13 +633,13 @@ function _governed_nonrho_problem_spec_forward_solve(
     hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
     hard_constraints = _append_extra_feasible_rule(hard_constraints, extra_constraints, mode)
 
-    candidates = NamedTuple[]
-    for (attempt_index, attempt_cfg) in enumerate(attempt_plan)
-        local raw
-        try
-            local_kwargs = Dict{Symbol,Any}(kwargs)
-            local_kwargs[:seed_guess] = attempt_cfg.seed
-            local_kwargs[:nlsolve_method] = attempt_cfg.method
+    selector_fn = _resolve_candidate_selector(kwargs)
+    selected, candidates = _execute_governed_attempt_plan(
+        attempt_plan,
+        kwargs,
+        hard_constraints,
+        selector_fn,
+        function (local_kwargs, attempt_cfg, _)
             _strip_problemspec_forwardsolve_kwargs!(local_kwargs)
             delete!(local_kwargs, :trust_region_fallback)
             delete!(local_kwargs, :fallback_method)
@@ -641,14 +663,9 @@ function _governed_nonrho_problem_spec_forward_solve(
                 governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
                 governed_attempt_origin=attempt_cfg.attempt_origin,
             )
-            raw = (; raw..., attempt_origin_key => attempt_cfg.attempt_origin)
-            ok, failed = evaluate_hard_constraints(raw, hard_constraints)
-            selected_quality = ok ? :good : raw.governed_selected_quality
-            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, governed_selected_quality=selected_quality, seed_index=Int(attempt_index)))
-            if ok
-                break
-            end
-        catch
+            return (; raw..., attempt_origin_key => attempt_cfg.attempt_origin)
+        end,
+        function (base_kwargs, attempt_cfg, _)
             raw = (
                 converged=false,
                 solution=Float64[],
@@ -662,20 +679,16 @@ function _governed_nonrho_problem_spec_forward_solve(
                 masses=zeros(3),
                 iterations=0,
                 residual_norm=Inf,
-                residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
+                residual_norm_max=Float64(get(base_kwargs, :residual_norm_max, 1e-6)),
                 solver_converged=false,
                 governed_selected_method=attempt_cfg.method,
                 governed_selected_quality=:bad,
                 governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
                 governed_attempt_origin=attempt_cfg.attempt_origin,
             )
-            raw = (; raw..., attempt_origin_key => attempt_cfg.attempt_origin)
-            push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
-        end
-    end
-
-    selector_fn = _resolve_candidate_selector(kwargs)
-    selected = selector_fn(candidates)
+            return (; raw..., attempt_origin_key => attempt_cfg.attempt_origin)
+        end,
+    )
     s = selected.selected_candidate
     return (
         converged=Bool(s.converged),

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -266,6 +266,17 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
     primary_key = seed_key(primary_seed)
     push!(seed_seen, primary_key)
 
+    legacy_seed = if length(primary_seed) >= 5
+        Float64.(Main.Models.extend_seed(Float64.(primary_seed[1:5]), mode))
+    else
+        Float64.(Main.Models.extend_seed(primary_seed, mode))
+    end
+    legacy_key = seed_key(legacy_seed)
+    if !(legacy_key in seed_seen)
+        push!(fallback_seeds, legacy_seed)
+        push!(seed_seen, legacy_key)
+    end
+
     for seed in provided_seed_pool
         k = seed_key(seed)
         if !(k in seed_seen)
@@ -470,6 +481,7 @@ function _governed_mode_forward_solve(
         selection_reason=selected.selection_reason,
         selected_index=selected.selected_index,
         candidate_count=length(candidates),
+        legacy_fallback_used=(hasproperty(s, :legacy_fallback_used) ? Bool(getproperty(s, :legacy_fallback_used)) : false),
     )
 end
 
@@ -559,10 +571,27 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
             delete!(local_kwargs, :fallback_method)
 
             haskey(local_kwargs, :rho0) || throw(ArgumentError("rho0 is required for ProblemSpec FixedEntropy forward_solve"))
+            local_kwargs[:allow_legacy_fallback] = Bool(get(kwargs, :allow_legacy_fallback, true))
             solved = _solve_constraint_fixedentropy(model, T_fm, mode.s_target; pairs(local_kwargs)...)
-            raw = (; solved..., residual_norm_max=get(local_kwargs, :residual_norm_max, 1e-6), entropy_attempt_origin=attempt_cfg.attempt_origin)
+            solver_converged = Bool(solved.converged)
+            attempt_quality = if solver_converged
+                :degraded
+            else
+                :bad
+            end
+            raw = (
+                ; solved...,
+                residual_norm_max=get(local_kwargs, :residual_norm_max, 1e-6),
+                solver_converged=solver_converged,
+                governed_selected_method=attempt_cfg.method,
+                governed_selected_quality=attempt_quality,
+                governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
+                governed_attempt_origin=attempt_cfg.attempt_origin,
+                entropy_attempt_origin=attempt_cfg.attempt_origin,
+            )
             ok, failed = evaluate_hard_constraints(raw, hard_constraints)
-            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, seed_index=Int(attempt_index)))
+            selected_quality = ok ? :good : raw.governed_selected_quality
+            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, governed_selected_quality=selected_quality, seed_index=Int(attempt_index)))
             if ok
                 break
             end
@@ -581,6 +610,11 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
                 iterations=0,
                 residual_norm=Inf,
                 residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
+                solver_converged=false,
+                governed_selected_method=attempt_cfg.method,
+                governed_selected_quality=:bad,
+                governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
+                governed_attempt_origin=attempt_cfg.attempt_origin,
                 entropy_attempt_origin=attempt_cfg.attempt_origin,
             )
             push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
@@ -608,6 +642,10 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
         selection_reason=selected.selection_reason,
         selected_index=selected.selected_index,
         candidate_count=length(candidates),
+        governed_selected_method=(hasproperty(s, :governed_selected_method) ? getproperty(s, :governed_selected_method) : :none),
+        governed_selected_quality=(hasproperty(s, :governed_selected_quality) ? getproperty(s, :governed_selected_quality) : :bad),
+        governed_fallback_used=(hasproperty(s, :governed_fallback_used) ? Bool(getproperty(s, :governed_fallback_used)) : false),
+        legacy_fallback_used=(hasproperty(s, :legacy_fallback_used) ? Bool(getproperty(s, :legacy_fallback_used)) : false),
     )
 end
 
@@ -697,10 +735,27 @@ function _fixedsigma_problem_spec_forward_solve(model::AbstractQCDModel, mode::F
             delete!(local_kwargs, :fallback_method)
 
             haskey(local_kwargs, :rho0) || throw(ArgumentError("rho0 is required for ProblemSpec FixedSigma forward_solve"))
+            local_kwargs[:allow_legacy_fallback] = Bool(get(kwargs, :allow_legacy_fallback, true))
             solved = _solve_constraint_fixedsigma(model, T_fm, mode.sigma_target; pairs(local_kwargs)...)
-            raw = (; solved..., residual_norm_max=get(local_kwargs, :residual_norm_max, 1e-6), sigma_attempt_origin=attempt_cfg.attempt_origin)
+            solver_converged = Bool(solved.converged)
+            attempt_quality = if solver_converged
+                :degraded
+            else
+                :bad
+            end
+            raw = (
+                ; solved...,
+                residual_norm_max=get(local_kwargs, :residual_norm_max, 1e-6),
+                solver_converged=solver_converged,
+                governed_selected_method=attempt_cfg.method,
+                governed_selected_quality=attempt_quality,
+                governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
+                governed_attempt_origin=attempt_cfg.attempt_origin,
+                sigma_attempt_origin=attempt_cfg.attempt_origin,
+            )
             ok, failed = evaluate_hard_constraints(raw, hard_constraints)
-            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, seed_index=Int(attempt_index)))
+            selected_quality = ok ? :good : raw.governed_selected_quality
+            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, governed_selected_quality=selected_quality, seed_index=Int(attempt_index)))
             if ok
                 break
             end
@@ -719,6 +774,11 @@ function _fixedsigma_problem_spec_forward_solve(model::AbstractQCDModel, mode::F
                 iterations=0,
                 residual_norm=Inf,
                 residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
+                solver_converged=false,
+                governed_selected_method=attempt_cfg.method,
+                governed_selected_quality=:bad,
+                governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
+                governed_attempt_origin=attempt_cfg.attempt_origin,
                 sigma_attempt_origin=attempt_cfg.attempt_origin,
             )
             push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
@@ -746,6 +806,10 @@ function _fixedsigma_problem_spec_forward_solve(model::AbstractQCDModel, mode::F
         selection_reason=selected.selection_reason,
         selected_index=selected.selected_index,
         candidate_count=length(candidates),
+        governed_selected_method=(hasproperty(s, :governed_selected_method) ? getproperty(s, :governed_selected_method) : :none),
+        governed_selected_quality=(hasproperty(s, :governed_selected_quality) ? getproperty(s, :governed_selected_quality) : :bad),
+        governed_fallback_used=(hasproperty(s, :governed_fallback_used) ? Bool(getproperty(s, :governed_fallback_used)) : false),
+        legacy_fallback_used=(hasproperty(s, :legacy_fallback_used) ? Bool(getproperty(s, :legacy_fallback_used)) : false),
     )
 end
 
@@ -835,10 +899,27 @@ function _fixedasymrho_problem_spec_forward_solve(model::AbstractQCDModel, mode:
             delete!(local_kwargs, :fallback_method)
 
             haskey(local_kwargs, :rho0) || throw(ArgumentError("rho0 is required for ProblemSpec FixedAsymmetricRho forward_solve"))
+            local_kwargs[:allow_legacy_fallback] = Bool(get(kwargs, :allow_legacy_fallback, true))
             solved = _solve_constraint_fixedasymrho(model, T_fm, mode.rho_target, mode.ud_ratio_target, mode.s_target; pairs(local_kwargs)...)
-            raw = (; solved..., residual_norm_max=get(local_kwargs, :residual_norm_max, 1e-6), asym_attempt_origin=attempt_cfg.attempt_origin)
+            solver_converged = Bool(solved.converged)
+            attempt_quality = if solver_converged
+                :degraded
+            else
+                :bad
+            end
+            raw = (
+                ; solved...,
+                residual_norm_max=get(local_kwargs, :residual_norm_max, 1e-6),
+                solver_converged=solver_converged,
+                governed_selected_method=attempt_cfg.method,
+                governed_selected_quality=attempt_quality,
+                governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
+                governed_attempt_origin=attempt_cfg.attempt_origin,
+                asym_attempt_origin=attempt_cfg.attempt_origin,
+            )
             ok, failed = evaluate_hard_constraints(raw, hard_constraints)
-            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, seed_index=Int(attempt_index)))
+            selected_quality = ok ? :good : raw.governed_selected_quality
+            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, governed_selected_quality=selected_quality, seed_index=Int(attempt_index)))
             if ok
                 break
             end
@@ -857,6 +938,11 @@ function _fixedasymrho_problem_spec_forward_solve(model::AbstractQCDModel, mode:
                 iterations=0,
                 residual_norm=Inf,
                 residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
+                solver_converged=false,
+                governed_selected_method=attempt_cfg.method,
+                governed_selected_quality=:bad,
+                governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
+                governed_attempt_origin=attempt_cfg.attempt_origin,
                 asym_attempt_origin=attempt_cfg.attempt_origin,
             )
             push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
@@ -884,6 +970,10 @@ function _fixedasymrho_problem_spec_forward_solve(model::AbstractQCDModel, mode:
         selection_reason=selected.selection_reason,
         selected_index=selected.selected_index,
         candidate_count=length(candidates),
+        governed_selected_method=(hasproperty(s, :governed_selected_method) ? getproperty(s, :governed_selected_method) : :none),
+        governed_selected_quality=(hasproperty(s, :governed_selected_quality) ? getproperty(s, :governed_selected_quality) : :bad),
+        governed_fallback_used=(hasproperty(s, :governed_fallback_used) ? Bool(getproperty(s, :governed_fallback_used)) : false),
+        legacy_fallback_used=(hasproperty(s, :legacy_fallback_used) ? Bool(getproperty(s, :legacy_fallback_used)) : false),
     )
 end
 

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -44,6 +44,59 @@ end
     return (; (k => v for (k, v) in pairs(kwargs) if !(k in blocked))...)
 end
 
+@inline function _resolve_solver_model(model::AbstractPNJLModel, kwargs)
+    if haskey(kwargs, :model_kind)
+        model_kind = kwargs[:model_kind]
+        model_kind isa Symbol || throw(ArgumentError("model_kind must be Symbol, got $(typeof(model_kind))"))
+        return create_model(model_kind)
+    end
+    return model
+end
+
+@inline function _resolve_nonfixedmu_bridge(mode::ConstraintMode, T_fm::Real, kwargs)
+    xi = get(kwargs, :xi, 0.0)
+    p_num = get(kwargs, :p_num, default_momentum_count())
+    t_num = get(kwargs, :t_num, default_theta_count())
+    residual_norm_max = get(kwargs, :residual_norm_max, 1e-6)
+    rho0 = get(kwargs, :rho0, Main.Constants_PNJL.ρ0_inv_fm3)
+
+    semantic_mode = get(kwargs, :semantic_mode, :ground_state)
+    (semantic_mode === :ground_state || semantic_mode === :constrained_manifold) ||
+        throw(ArgumentError("semantic_mode must be :ground_state or :constrained_manifold, got $(semantic_mode)"))
+
+    selector = get(kwargs, :selector, nothing)
+    selector === nothing || selector isa Function ||
+        throw(ArgumentError("selector must be Function or nothing, got $(typeof(selector))"))
+
+    seed_strategy = get(kwargs, :seed_strategy, DefaultSeed())
+    seed_guess = haskey(kwargs, :seed_guess) ? kwargs[:seed_guess] : get_seed(seed_strategy, [T_fm], mode)
+    seed_candidates = if haskey(kwargs, :seed_candidates)
+        kwargs[:seed_candidates]
+    else
+        (seed_guess,)
+    end
+
+    use_problem_spec_chain =
+        haskey(kwargs, :problem_spec) ||
+        haskey(kwargs, :seed_guess) ||
+        haskey(kwargs, :seed_candidates) ||
+        semantic_mode !== :ground_state ||
+        selector !== nothing
+
+    return (
+        xi=xi,
+        p_num=p_num,
+        t_num=t_num,
+        residual_norm_max=residual_norm_max,
+        rho0=rho0,
+        semantic_mode=semantic_mode,
+        selector=selector,
+        seed_guess=seed_guess,
+        seed_candidates=seed_candidates,
+        use_problem_spec_chain=use_problem_spec_chain,
+    )
+end
+
 @inline function _solve_with_problem_spec_default(
     model::AbstractQCDModel,
     mode::ConstraintMode,
@@ -139,7 +192,66 @@ function solve(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm::Real;
 end
 
 function solve(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymmetricRho, FixedEntropy, FixedSigma}, T_fm::Real; kwargs...)
-    raw = ImplicitSolver.solve(mode, T_fm; kwargs...)
+    effective_model = _resolve_solver_model(model, kwargs)
+    bridge = _resolve_nonfixedmu_bridge(mode, T_fm, kwargs)
+
+    if bridge.use_problem_spec_chain
+        problem_spec = get(kwargs, :problem_spec, nothing)
+        forwarded = _strip_forward_kwargs(kwargs, (
+            :problem_spec,
+            :seed_strategy,
+            :seed_guess,
+            :seed_candidates,
+            :semantic_mode,
+            :selector,
+            :rho0,
+            :xi,
+            :p_num,
+            :t_num,
+            :residual_norm_max,
+            :model_kind,
+        ))
+        raw = solve_constraint(
+            effective_model,
+            mode,
+            T_fm;
+            problem_spec=problem_spec,
+            seed_guess=bridge.seed_guess,
+            seed_candidates=bridge.seed_candidates,
+            semantic_mode=bridge.semantic_mode,
+            selector=bridge.selector,
+            rho0=bridge.rho0,
+            xi=bridge.xi,
+            p_num=bridge.p_num,
+            t_num=bridge.t_num,
+            residual_norm_max=bridge.residual_norm_max,
+            forwarded...,
+        )
+        return SolverResult(
+            mode,
+            Bool(raw.converged),
+            Float64.(raw.solution),
+            raw.x_state,
+            raw.mu_vec,
+            Float64(raw.omega),
+            Float64(raw.pressure),
+            Float64(raw.rho_norm),
+            Float64(raw.entropy),
+            Float64(raw.energy),
+            raw.masses,
+            Int(raw.iterations),
+            Float64(raw.residual_norm),
+            Float64(bridge.xi),
+        )
+    end
+
+    forwarded = _strip_forward_kwargs(kwargs, (
+        :seed_guess,
+        :seed_candidates,
+        :semantic_mode,
+        :selector,
+    ))
+    raw = ImplicitSolver.solve(mode, T_fm; forwarded...)
     xi = get(kwargs, :xi, getproperty(raw, :xi))
     return _coerce_solver_result(mode, raw; xi_override=xi)
 end
@@ -243,7 +355,117 @@ function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm:
 end
 
 function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymmetricRho}, T_fm::Real; kwargs...)
-    raw = ImplicitSolver.solve_multi(mode, T_fm; kwargs...)
+    effective_model = _resolve_solver_model(model, kwargs)
+    bridge = _resolve_nonfixedmu_bridge(mode, T_fm, kwargs)
+
+    if bridge.use_problem_spec_chain
+        seed_strategy = get(kwargs, :seed_strategy, MultiSeed())
+        seeds = if haskey(kwargs, :seeds)
+            [Float64.(s) for s in kwargs[:seeds]]
+        elseif haskey(kwargs, :seed_candidates)
+            [Float64.(s) for s in kwargs[:seed_candidates]]
+        else
+            get_all_seeds(seed_strategy, [T_fm], mode)
+        end
+        isempty(seeds) && (seeds = [Float64.(bridge.seed_guess)])
+
+        forwarded = _strip_forward_kwargs(kwargs, (
+            :seed_strategy,
+            :seeds,
+            :seed_candidates,
+            :seed_guess,
+            :semantic_mode,
+            :selector,
+            :rho0,
+            :xi,
+            :p_num,
+            :t_num,
+            :residual_norm_max,
+            :model_kind,
+            :problem_spec,
+        ))
+
+        candidates = NamedTuple[]
+        for (seed_index, seed) in enumerate(seeds)
+            local raw
+            try
+                raw = solve_constraint(
+                    effective_model,
+                    mode,
+                    T_fm;
+                    problem_spec=get(kwargs, :problem_spec, nothing),
+                    seed_guess=seed,
+                    seed_candidates=(seed,),
+                    semantic_mode=bridge.semantic_mode,
+                    selector=bridge.selector,
+                    rho0=bridge.rho0,
+                    xi=bridge.xi,
+                    p_num=bridge.p_num,
+                    t_num=bridge.t_num,
+                    residual_norm_max=bridge.residual_norm_max,
+                    forwarded...,
+                )
+                ok = Bool(raw.converged) && isfinite(raw.residual_norm) && raw.residual_norm <= max(bridge.residual_norm_max, 1e-3)
+                push!(candidates, (
+                    converged=Bool(raw.converged),
+                    solution=Float64.(raw.solution),
+                    x_state=raw.x_state,
+                    mu_vec=raw.mu_vec,
+                    omega=Float64(raw.omega),
+                    pressure=Float64(raw.pressure),
+                    rho_norm=Float64(raw.rho_norm),
+                    entropy=Float64(raw.entropy),
+                    energy=Float64(raw.energy),
+                    masses=raw.masses,
+                    iterations=Int(raw.iterations),
+                    residual_norm=Float64(raw.residual_norm),
+                    hard_constraint_ok=ok,
+                    failed_constraints=(ok ? Symbol[] : Symbol[:residual_too_large]),
+                    seed_index=Int(seed_index),
+                ))
+            catch
+                push!(candidates, (
+                    converged=false,
+                    solution=Float64[],
+                    x_state=zeros(5),
+                    mu_vec=zeros(3),
+                    omega=NaN,
+                    pressure=-Inf,
+                    rho_norm=NaN,
+                    entropy=NaN,
+                    energy=NaN,
+                    masses=zeros(3),
+                    iterations=0,
+                    residual_norm=Inf,
+                    hard_constraint_ok=false,
+                    failed_constraints=Symbol[:solver_failed],
+                    seed_index=Int(seed_index),
+                ))
+            end
+        end
+
+        selected = select_pressure_max_candidate(candidates)
+        s = selected.selected_candidate
+        return SolverResult(
+            mode,
+            Bool(s.converged),
+            Float64.(s.solution),
+            s.x_state,
+            s.mu_vec,
+            Float64(s.omega),
+            Float64(s.pressure),
+            Float64(s.rho_norm),
+            Float64(s.entropy),
+            Float64(s.energy),
+            s.masses,
+            Int(s.iterations),
+            Float64(s.residual_norm),
+            Float64(bridge.xi),
+        )
+    end
+
+    forwarded = _strip_forward_kwargs(kwargs, (:seed_guess, :seed_candidates, :semantic_mode, :selector))
+    raw = ImplicitSolver.solve_multi(mode, T_fm; forwarded...)
     xi = get(kwargs, :xi, getproperty(raw, :xi))
     return _coerce_solver_result(mode, raw; xi_override=xi)
 end

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -504,10 +504,7 @@ function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymme
         return selector_fn(converged)
     end
 
-    forwarded = _strip_forward_kwargs(kwargs, (:seed_guess, :seed_candidates, :semantic_mode, :selector))
-    raw = ImplicitSolver.solve_multi(mode, T_fm; forwarded...)
-    xi = get(kwargs, :xi, getproperty(raw, :xi))
-    return _coerce_solver_result(mode, raw; xi_override=xi)
+    throw(ArgumentError("unsupported mode for solve_multi bridge: $(typeof(mode))"))
 end
 
 function solve(mode::FixedMu, T_fm::Real, μ_fm::Real; kwargs...)

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -5,6 +5,10 @@
 """
 const SolverResult = ImplicitSolver.SolverResult
 
+@inline function _strip_forward_kwargs(kwargs, blocked::Tuple)
+    return (; (k => v for (k, v) in pairs(kwargs) if !(k in blocked))...)
+end
+
 @inline function _solve_with_problem_spec_default(
     model::AbstractQCDModel,
     mode::ConstraintMode,
@@ -49,7 +53,54 @@ function solve_constraint(model::AbstractQCDModel, mode::FixedAsymmetricRho, T_f
 end
 
 function solve(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm::Real; kwargs...)
-    return ImplicitSolver.solve(mode, T_fm, μ_fm; kwargs...)
+    xi = get(kwargs, :xi, 0.0)
+    p_num = get(kwargs, :p_num, default_momentum_count())
+    t_num = get(kwargs, :t_num, default_theta_count())
+    residual_norm_max = get(kwargs, :residual_norm_max, 1e-6)
+    seed_strategy = get(kwargs, :seed_strategy, DefaultSeed())
+
+    if seed_strategy isa MultiSeed
+        return solve_multi(model, mode, T_fm, μ_fm; kwargs...)
+    end
+
+    seed_guess = haskey(kwargs, :seed_guess) ? kwargs[:seed_guess] : get_seed(seed_strategy, [T_fm, μ_fm], mode)
+    forwarded = _strip_forward_kwargs(kwargs, (
+        :seed_strategy,
+        :seed_guess,
+        :xi,
+        :p_num,
+        :t_num,
+        :residual_norm_max,
+    ))
+    raw = solve_constraint(
+        model,
+        mode,
+        T_fm;
+        μ_fm=μ_fm,
+        seed_guess=seed_guess,
+        xi=xi,
+        p_num=p_num,
+        t_num=t_num,
+        residual_norm_max=residual_norm_max,
+        forwarded...,
+    )
+
+    return SolverResult(
+        mode,
+        Bool(raw.converged),
+        Float64.(raw.solution),
+        raw.x_state,
+        raw.mu_vec,
+        Float64(raw.omega),
+        Float64(raw.pressure),
+        Float64(raw.rho_norm),
+        Float64(raw.entropy),
+        Float64(raw.energy),
+        raw.masses,
+        Int(raw.iterations),
+        Float64(raw.residual_norm),
+        Float64(xi),
+    )
 end
 
 function solve(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymmetricRho, FixedEntropy, FixedSigma}, T_fm::Real; kwargs...)
@@ -57,7 +108,101 @@ function solve(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymmetricRh
 end
 
 function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm::Real; kwargs...)
-    return ImplicitSolver.solve_multi(mode, T_fm, μ_fm; kwargs...)
+    xi = get(kwargs, :xi, 0.0)
+    p_num = get(kwargs, :p_num, default_momentum_count())
+    t_num = get(kwargs, :t_num, default_theta_count())
+    residual_norm_max = get(kwargs, :residual_norm_max, 1e-6)
+    seed_strategy = get(kwargs, :seed_strategy, MultiSeed())
+
+    seeds = if haskey(kwargs, :seeds)
+        [Float64.(s) for s in kwargs[:seeds]]
+    else
+        get_all_seeds(seed_strategy, [T_fm, μ_fm], mode)
+    end
+    isempty(seeds) && (seeds = [get_seed(DefaultSeed(), [T_fm, μ_fm], mode)])
+
+    forwarded = _strip_forward_kwargs(kwargs, (
+        :seed_strategy,
+        :seeds,
+        :xi,
+        :p_num,
+        :t_num,
+        :residual_norm_max,
+    ))
+    candidates = NamedTuple[]
+    for (seed_index, seed) in enumerate(seeds)
+        local raw
+        try
+            raw = solve_constraint(
+                model,
+                mode,
+                T_fm;
+                μ_fm=μ_fm,
+                seed_guess=seed,
+                xi=xi,
+                p_num=p_num,
+                t_num=t_num,
+                residual_norm_max=residual_norm_max,
+                forwarded...,
+            )
+            ok = Bool(raw.converged) && isfinite(raw.residual_norm) && raw.residual_norm <= residual_norm_max
+            candidate = (
+                converged=Bool(raw.converged),
+                solution=Float64.(raw.solution),
+                x_state=raw.x_state,
+                mu_vec=raw.mu_vec,
+                omega=Float64(raw.omega),
+                pressure=Float64(raw.pressure),
+                rho_norm=Float64(raw.rho_norm),
+                entropy=Float64(raw.entropy),
+                energy=Float64(raw.energy),
+                masses=raw.masses,
+                iterations=Int(raw.iterations),
+                residual_norm=Float64(raw.residual_norm),
+                hard_constraint_ok=ok,
+                failed_constraints=(ok ? Symbol[] : Symbol[:residual_too_large]),
+                seed_index=Int(seed_index),
+            )
+            push!(candidates, candidate)
+        catch
+            push!(candidates, (
+                converged=false,
+                solution=Float64[],
+                x_state=zeros(5),
+                mu_vec=zeros(3),
+                omega=NaN,
+                pressure=-Inf,
+                rho_norm=NaN,
+                entropy=NaN,
+                energy=NaN,
+                masses=zeros(3),
+                iterations=0,
+                residual_norm=Inf,
+                hard_constraint_ok=false,
+                failed_constraints=Symbol[:solver_failed],
+                seed_index=Int(seed_index),
+            ))
+        end
+    end
+
+    selected = select_pressure_max_candidate(candidates)
+    s = selected.selected_candidate
+    return SolverResult(
+        mode,
+        Bool(s.converged),
+        Float64.(s.solution),
+        s.x_state,
+        s.mu_vec,
+        Float64(s.omega),
+        Float64(s.pressure),
+        Float64(s.rho_norm),
+        Float64(s.entropy),
+        Float64(s.energy),
+        s.masses,
+        Int(s.iterations),
+        Float64(s.residual_norm),
+        Float64(xi),
+    )
 end
 
 function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymmetricRho}, T_fm::Real; kwargs...)

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -3,7 +3,42 @@
 
 统一约束求解入口。根据 `mode` 的类型分发到 models 域约束求解内核实现。
 """
-const SolverResult = ImplicitSolver.SolverResult
+struct SolverResult{VX<:AbstractVector{<:Real}, VM<:AbstractVector{<:Real}, MM<:AbstractVector{<:Real}}
+    mode::ConstraintMode
+    converged::Bool
+    solution::Vector{Float64}
+    x_state::VX
+    mu_vec::VM
+    omega::Float64
+    pressure::Float64
+    rho_norm::Float64
+    entropy::Float64
+    energy::Float64
+    masses::MM
+    iterations::Int
+    residual_norm::Float64
+    xi::Float64
+end
+
+@inline function _coerce_solver_result(mode::ConstraintMode, raw_result; xi_override=nothing)
+    xi_val = xi_override === nothing ? Float64(getproperty(raw_result, :xi)) : Float64(xi_override)
+    return SolverResult(
+        mode,
+        Bool(getproperty(raw_result, :converged)),
+        Float64.(getproperty(raw_result, :solution)),
+        getproperty(raw_result, :x_state),
+        getproperty(raw_result, :mu_vec),
+        Float64(getproperty(raw_result, :omega)),
+        Float64(getproperty(raw_result, :pressure)),
+        Float64(getproperty(raw_result, :rho_norm)),
+        Float64(getproperty(raw_result, :entropy)),
+        Float64(getproperty(raw_result, :energy)),
+        getproperty(raw_result, :masses),
+        Int(getproperty(raw_result, :iterations)),
+        Float64(getproperty(raw_result, :residual_norm)),
+        xi_val,
+    )
+end
 
 @inline function _strip_forward_kwargs(kwargs, blocked::Tuple)
     return (; (k => v for (k, v) in pairs(kwargs) if !(k in blocked))...)
@@ -104,7 +139,9 @@ function solve(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm::Real;
 end
 
 function solve(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymmetricRho, FixedEntropy, FixedSigma}, T_fm::Real; kwargs...)
-    return ImplicitSolver.solve(mode, T_fm; kwargs...)
+    raw = ImplicitSolver.solve(mode, T_fm; kwargs...)
+    xi = get(kwargs, :xi, getproperty(raw, :xi))
+    return _coerce_solver_result(mode, raw; xi_override=xi)
 end
 
 function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm::Real; kwargs...)
@@ -206,7 +243,9 @@ function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm:
 end
 
 function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymmetricRho}, T_fm::Real; kwargs...)
-    return ImplicitSolver.solve_multi(mode, T_fm; kwargs...)
+    raw = ImplicitSolver.solve_multi(mode, T_fm; kwargs...)
+    xi = get(kwargs, :xi, getproperty(raw, :xi))
+    return _coerce_solver_result(mode, raw; xi_override=xi)
 end
 
 function solve(mode::FixedMu, T_fm::Real, μ_fm::Real; kwargs...)
@@ -238,8 +277,20 @@ function solve_multi(mode::Union{FixedRho, FixedAsymmetricRho}, T_fm::Real; kwar
     return solve_multi(model, mode, T_fm; kwargs...)
 end
 
-@inline is_physical_solution(x_state::AbstractVector{<:Real}, masses::AbstractVector{<:Real}; kwargs...) =
-    ImplicitSolver.default_is_physical_solution(x_state, masses; kwargs...)
+@inline function is_physical_solution(x_state::AbstractVector{<:Real}, masses::AbstractVector{<:Real}; phi_tol::Float64=1e-8)
+    if length(x_state) < 5 || length(masses) < 3
+        return false
+    end
+    Φ = x_state[4]
+    Φbar = x_state[5]
+    if !(isfinite(Φ) && isfinite(Φbar) && (-phi_tol <= Φ <= 1 + phi_tol) && (-phi_tol <= Φbar <= 1 + phi_tol))
+        return false
+    end
+    if any(!isfinite, masses) || any(m -> m <= 0.0, masses)
+        return false
+    end
+    return true
+end
 @inline solve_with_derivatives(T_fm::Real, μ_fm::Real; kwargs...) =
     solve_pnjl_with_derivatives(T_fm, μ_fm; kwargs...)
 

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -195,8 +195,9 @@ function solve(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymmetricRh
     effective_model = _resolve_solver_model(model, kwargs)
     bridge = _resolve_nonfixedmu_bridge(mode, T_fm, kwargs)
 
-    if bridge.use_problem_spec_chain || mode isa FixedEntropy || mode isa FixedSigma
+    if bridge.use_problem_spec_chain || mode isa FixedRho || mode isa FixedEntropy || mode isa FixedSigma || mode isa FixedAsymmetricRho
         problem_spec = get(kwargs, :problem_spec, nothing)
+        rho0_kwargs = (mode isa FixedRho) ? NamedTuple() : (; rho0=bridge.rho0)
         forwarded = _strip_forward_kwargs(kwargs, (
             :problem_spec,
             :seed_strategy,
@@ -220,7 +221,7 @@ function solve(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymmetricRh
             seed_candidates=bridge.seed_candidates,
             semantic_mode=bridge.semantic_mode,
             selector=bridge.selector,
-            rho0=bridge.rho0,
+            rho0_kwargs...,
             xi=bridge.xi,
             p_num=bridge.p_num,
             t_num=bridge.t_num,
@@ -243,18 +244,6 @@ function solve(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymmetricRh
             Float64(raw.residual_norm),
             Float64(bridge.xi),
         )
-    end
-
-    if mode isa FixedRho || mode isa FixedAsymmetricRho
-        forwarded = _strip_forward_kwargs(kwargs, (
-            :seed_guess,
-            :seed_candidates,
-            :semantic_mode,
-            :selector,
-        ))
-        raw = ImplicitSolver.solve(mode, T_fm; forwarded...)
-        xi = get(kwargs, :xi, getproperty(raw, :xi))
-        return _coerce_solver_result(mode, raw; xi_override=xi)
     end
 
     throw(ArgumentError("unsupported mode for solve bridge: $(typeof(mode))"))
@@ -393,6 +382,7 @@ function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymme
         for (seed_index, seed) in enumerate(seeds)
             local raw
             try
+                rho0_kwargs = (mode isa FixedRho) ? NamedTuple() : (; rho0=bridge.rho0)
                 raw = solve_constraint(
                     effective_model,
                     mode,
@@ -402,7 +392,7 @@ function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymme
                     seed_candidates=(seed,),
                     semantic_mode=bridge.semantic_mode,
                     selector=bridge.selector,
-                    rho0=bridge.rho0,
+                    rho0_kwargs...,
                     xi=bridge.xi,
                     p_num=bridge.p_num,
                     t_num=bridge.t_num,

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -95,11 +95,10 @@ end
 
 @inline is_physical_solution(x_state::AbstractVector{<:Real}, masses::AbstractVector{<:Real}; kwargs...) =
     ImplicitSolver.default_is_physical_solution(x_state, masses; kwargs...)
-@inline solve_with_derivatives(T_fm::Real, μ_fm::Real; kwargs...) = ImplicitSolver.solve_with_derivatives(T_fm, μ_fm; kwargs...)
-@inline _solve_weighted_block_fallback(mode::FixedAsymmetricRho, T_fm::Real; kwargs...) =
-    ImplicitSolver.solve_weighted_block_fallback(mode, T_fm; kwargs...)
+@inline solve_with_derivatives(T_fm::Real, μ_fm::Real; kwargs...) =
+    solve_pnjl_with_derivatives(T_fm, μ_fm; kwargs...)
 
 @inline function solve_with_derivatives(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm::Real; kwargs...)
     _ = model, mode
-    return ImplicitSolver.solve_with_derivatives(T_fm, μ_fm; kwargs...)
+    return solve_pnjl_with_derivatives(T_fm, μ_fm; kwargs...)
 end

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -245,15 +245,19 @@ function solve(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymmetricRh
         )
     end
 
-    forwarded = _strip_forward_kwargs(kwargs, (
-        :seed_guess,
-        :seed_candidates,
-        :semantic_mode,
-        :selector,
-    ))
-    raw = ImplicitSolver.solve(mode, T_fm; forwarded...)
-    xi = get(kwargs, :xi, getproperty(raw, :xi))
-    return _coerce_solver_result(mode, raw; xi_override=xi)
+    if mode isa FixedRho || mode isa FixedEntropy || mode isa FixedSigma || mode isa FixedAsymmetricRho
+        forwarded = _strip_forward_kwargs(kwargs, (
+            :seed_guess,
+            :seed_candidates,
+            :semantic_mode,
+            :selector,
+        ))
+        raw = ImplicitSolver.solve(mode, T_fm; forwarded...)
+        xi = get(kwargs, :xi, getproperty(raw, :xi))
+        return _coerce_solver_result(mode, raw; xi_override=xi)
+    end
+
+    throw(ArgumentError("unsupported mode for solve bridge: $(typeof(mode))"))
 end
 
 function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm::Real; kwargs...)
@@ -462,6 +466,42 @@ function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymme
             Float64(s.residual_norm),
             Float64(bridge.xi),
         )
+    end
+
+    if mode isa FixedRho || mode isa FixedAsymmetricRho
+        seed_strategy = get(kwargs, :seed_strategy, MultiSeed())
+        seeds = if haskey(kwargs, :seeds)
+            [Float64.(s) for s in kwargs[:seeds]]
+        else
+            get_all_seeds(seed_strategy, [T_fm], mode)
+        end
+        isempty(seeds) && (seeds = [Float64.(bridge.seed_guess)])
+
+        selector_fn = haskey(kwargs, :selector) ? kwargs[:selector] : SeedStrategies.default_omega_selector
+        forwarded = _strip_forward_kwargs(kwargs, (
+            :seed_strategy,
+            :seeds,
+            :seed_guess,
+            :seed_candidates,
+            :semantic_mode,
+            :selector,
+        ))
+
+        results = SolverResult[]
+        for seed in seeds
+            try
+                push!(results, solve(effective_model, mode, T_fm;
+                    seed_strategy=DefaultSeed(Float64.(seed), Float64.(seed), :hadron),
+                    forwarded...,
+                ))
+            catch
+            end
+        end
+
+        isempty(results) && error("All seeds failed (exceptions) in solve_multi")
+        converged = filter(r -> r.converged, results)
+        isempty(converged) && error("All seeds failed to converge to a physical solution")
+        return selector_fn(converged)
     end
 
     forwarded = _strip_forward_kwargs(kwargs, (:seed_guess, :seed_candidates, :semantic_mode, :selector))

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -195,58 +195,54 @@ function solve(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymmetricRh
     effective_model = _resolve_solver_model(model, kwargs)
     bridge = _resolve_nonfixedmu_bridge(mode, T_fm, kwargs)
 
-    if bridge.use_problem_spec_chain || mode isa FixedRho || mode isa FixedEntropy || mode isa FixedSigma || mode isa FixedAsymmetricRho
-        problem_spec = get(kwargs, :problem_spec, nothing)
-        rho0_kwargs = (mode isa FixedRho) ? NamedTuple() : (; rho0=bridge.rho0)
-        forwarded = _strip_forward_kwargs(kwargs, (
-            :problem_spec,
-            :seed_strategy,
-            :seed_guess,
-            :seed_candidates,
-            :semantic_mode,
-            :selector,
-            :rho0,
-            :xi,
-            :p_num,
-            :t_num,
-            :residual_norm_max,
-            :model_kind,
-        ))
-        raw = solve_constraint(
-            effective_model,
-            mode,
-            T_fm;
-            problem_spec=problem_spec,
-            seed_guess=bridge.seed_guess,
-            seed_candidates=bridge.seed_candidates,
-            semantic_mode=bridge.semantic_mode,
-            selector=bridge.selector,
-            rho0_kwargs...,
-            xi=bridge.xi,
-            p_num=bridge.p_num,
-            t_num=bridge.t_num,
-            residual_norm_max=bridge.residual_norm_max,
-            forwarded...,
-        )
-        return SolverResult(
-            mode,
-            Bool(raw.converged),
-            Float64.(raw.solution),
-            raw.x_state,
-            raw.mu_vec,
-            Float64(raw.omega),
-            Float64(raw.pressure),
-            Float64(raw.rho_norm),
-            Float64(raw.entropy),
-            Float64(raw.energy),
-            raw.masses,
-            Int(raw.iterations),
-            Float64(raw.residual_norm),
-            Float64(bridge.xi),
-        )
-    end
-
-    throw(ArgumentError("unsupported mode for solve bridge: $(typeof(mode))"))
+    problem_spec = get(kwargs, :problem_spec, nothing)
+    rho0_kwargs = (mode isa FixedRho) ? NamedTuple() : (; rho0=bridge.rho0)
+    forwarded = _strip_forward_kwargs(kwargs, (
+        :problem_spec,
+        :seed_strategy,
+        :seed_guess,
+        :seed_candidates,
+        :semantic_mode,
+        :selector,
+        :rho0,
+        :xi,
+        :p_num,
+        :t_num,
+        :residual_norm_max,
+        :model_kind,
+    ))
+    raw = solve_constraint(
+        effective_model,
+        mode,
+        T_fm;
+        problem_spec=problem_spec,
+        seed_guess=bridge.seed_guess,
+        seed_candidates=bridge.seed_candidates,
+        semantic_mode=bridge.semantic_mode,
+        selector=bridge.selector,
+        rho0_kwargs...,
+        xi=bridge.xi,
+        p_num=bridge.p_num,
+        t_num=bridge.t_num,
+        residual_norm_max=bridge.residual_norm_max,
+        forwarded...,
+    )
+    return SolverResult(
+        mode,
+        Bool(raw.converged),
+        Float64.(raw.solution),
+        raw.x_state,
+        raw.mu_vec,
+        Float64(raw.omega),
+        Float64(raw.pressure),
+        Float64(raw.rho_norm),
+        Float64(raw.entropy),
+        Float64(raw.energy),
+        raw.masses,
+        Int(raw.iterations),
+        Float64(raw.residual_norm),
+        Float64(bridge.xi),
+    )
 end
 
 function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm::Real; kwargs...)
@@ -458,43 +454,46 @@ function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymme
         )
     end
 
-    if mode isa FixedRho || mode isa FixedAsymmetricRho
-        seed_strategy = get(kwargs, :seed_strategy, MultiSeed())
-        seeds = if haskey(kwargs, :seeds)
-            [Float64.(s) for s in kwargs[:seeds]]
-        else
-            get_all_seeds(seed_strategy, [T_fm], mode)
+    seed_strategy = get(kwargs, :seed_strategy, MultiSeed())
+    seeds = if haskey(kwargs, :seeds)
+        [Float64.(s) for s in kwargs[:seeds]]
+    else
+        get_all_seeds(seed_strategy, [T_fm], mode)
+    end
+    isempty(seeds) && (seeds = [Float64.(bridge.seed_guess)])
+
+    selector_fn = haskey(kwargs, :selector) ? kwargs[:selector] : SeedStrategies.default_omega_selector
+    forwarded = _strip_forward_kwargs(kwargs, (
+        :seed_strategy,
+        :seeds,
+        :seed_guess,
+        :seed_candidates,
+        :semantic_mode,
+        :selector,
+    ))
+
+    results = SolverResult[]
+    failed_seeds = String[]
+    for seed in seeds
+        try
+            push!(results, solve(effective_model, mode, T_fm;
+                seed_strategy=DefaultSeed(Float64.(seed), Float64.(seed), :hadron),
+                forwarded...,
+            ))
+        catch err
+            push!(failed_seeds, "seed=$(repr(seed)): $(sprint(showerror, err))")
         end
-        isempty(seeds) && (seeds = [Float64.(bridge.seed_guess)])
-
-        selector_fn = haskey(kwargs, :selector) ? kwargs[:selector] : SeedStrategies.default_omega_selector
-        forwarded = _strip_forward_kwargs(kwargs, (
-            :seed_strategy,
-            :seeds,
-            :seed_guess,
-            :seed_candidates,
-            :semantic_mode,
-            :selector,
-        ))
-
-        results = SolverResult[]
-        for seed in seeds
-            try
-                push!(results, solve(effective_model, mode, T_fm;
-                    seed_strategy=DefaultSeed(Float64.(seed), Float64.(seed), :hadron),
-                    forwarded...,
-                ))
-            catch
-            end
-        end
-
-        isempty(results) && error("All seeds failed (exceptions) in solve_multi")
-        converged = filter(r -> r.converged, results)
-        isempty(converged) && error("All seeds failed to converge to a physical solution")
-        return selector_fn(converged)
     end
 
-    throw(ArgumentError("unsupported mode for solve_multi bridge: $(typeof(mode))"))
+    if isempty(results)
+        error(
+            "All seeds failed (exceptions) in solve_multi. " *
+            "Failure summary: " * join(failed_seeds, " | "),
+        )
+    end
+    converged = filter(r -> r.converged, results)
+    isempty(converged) && error("All seeds failed to converge to a physical solution")
+    return selector_fn(converged)
 end
 
 function solve(mode::FixedMu, T_fm::Real, μ_fm::Real; kwargs...)

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -195,7 +195,7 @@ function solve(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymmetricRh
     effective_model = _resolve_solver_model(model, kwargs)
     bridge = _resolve_nonfixedmu_bridge(mode, T_fm, kwargs)
 
-    if bridge.use_problem_spec_chain
+    if bridge.use_problem_spec_chain || mode isa FixedEntropy || mode isa FixedSigma
         problem_spec = get(kwargs, :problem_spec, nothing)
         forwarded = _strip_forward_kwargs(kwargs, (
             :problem_spec,
@@ -245,7 +245,7 @@ function solve(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymmetricRh
         )
     end
 
-    if mode isa FixedRho || mode isa FixedEntropy || mode isa FixedSigma || mode isa FixedAsymmetricRho
+    if mode isa FixedRho || mode isa FixedAsymmetricRho
         forwarded = _strip_forward_kwargs(kwargs, (
             :seed_guess,
             :seed_candidates,

--- a/src/models/solver/WeightedFallback.jl
+++ b/src/models/solver/WeightedFallback.jl
@@ -1,0 +1,159 @@
+"""
+    solve_weighted_block_fallback(mode::FixedAsymmetricRho, T_fm; initial_seed, kwargs...) -> Union{SolverResult, Nothing}
+
+Hybrid 连续性链路失败时的 weighted-block 兜底。
+"""
+
+@inline function _weighted_stage_schedule()
+    return (
+        (w6=0.10, w7=0.10, w8=1.0, method=:trust_region, iterations=600),
+        (w6=0.50, w7=0.50, w8=1.0, method=:trust_region, iterations=1000),
+        (w6=1.00, w7=1.00, w8=1.0, method=:trust_region, iterations=1400),
+        (w6=1.00, w7=1.00, w8=1.0, method=:newton,       iterations=1000),
+    )
+end
+
+function _run_weighted_stage(raw_residual!::Function, x0::Vector{Float64};
+    w6::Float64,
+    w7::Float64,
+    w8::Float64,
+    method::Symbol,
+    iterations::Int,
+)
+    weights = Float64[1.0, 1.0, 1.0, 1.0, 1.0, w6, w7, w8]
+
+    weighted_residual! = (F, x) -> begin
+        rawF = similar(F)
+        raw_residual!(rawF, x)
+        @inbounds for i in 1:8
+            F[i] = weights[i] * rawF[i]
+        end
+        return nothing
+    end
+
+    res = nlsolve(weighted_residual!, x0;
+        autodiff=:forward,
+        method=method,
+        xtol=1e-9,
+        ftol=1e-9,
+        iterations=iterations,
+    )
+
+    x = Vector{Float64}(res.zero)
+    rawF = zeros(8)
+    raw_residual!(rawF, x)
+    raw_norm = sqrt(sum(abs2, rawF))
+
+    return (x=x, raw_norm=raw_norm)
+end
+
+function solve_weighted_block_fallback(mode::FixedAsymmetricRho, T_fm::Real;
+    initial_seed::AbstractVector{<:Real},
+    max_seed_candidates::Int=3,
+    xi::Real=0.0,
+    p_num::Int=24,
+    t_num::Int=8,
+    model_kind::Symbol=:PNJL,
+    residual_norm_max::Real=1e-6,
+    nlsolve_kwargs...)
+
+    base_seed = if length(initial_seed) >= 8
+        Float64.(initial_seed[1:8])
+    else
+        extend_seed(Float64.(initial_seed), mode)
+    end
+
+    seed_candidates = Vector{Vector{Float64}}()
+    push!(seed_candidates, copy(base_seed))
+    extra = max(max_seed_candidates - 1, 0)
+    for seed in Iterators.take(get_all_seeds(MultiSeed(), [T_fm], mode), extra)
+        s8 = length(seed) >= 8 ? Float64.(seed[1:8]) : extend_seed(Float64.(seed), mode)
+        push!(seed_candidates, s8)
+    end
+
+    uniq = Dict{String, Vector{Float64}}()
+    for s in seed_candidates
+        key = join(round.(s; digits=6), ",")
+        if !haskey(uniq, key)
+            uniq[key] = s
+        end
+    end
+    seed_candidates = collect(values(uniq))
+
+    thermal_nodes = cached_nodes(p_num, t_num)
+    params = GapParams(Float64(T_fm), thermal_nodes, Float64(xi);
+        p_num=p_num, t_num=t_num, model_kind=model_kind)
+    raw_residual! = build_residual!(mode, params)
+
+    best_x = copy(base_seed)
+    best_raw = Inf
+
+    for seed in seed_candidates
+        x = copy(seed)
+        for cfg in _weighted_stage_schedule()
+            stage = try
+                _run_weighted_stage(raw_residual!, x;
+                    w6=cfg.w6,
+                    w7=cfg.w7,
+                    w8=cfg.w8,
+                    method=cfg.method,
+                    iterations=cfg.iterations,
+                )
+            catch
+                nothing
+            end
+            stage === nothing && continue
+
+            x = stage.x
+            if isfinite(stage.raw_norm) && stage.raw_norm < best_raw
+                best_raw = stage.raw_norm
+                best_x = copy(stage.x)
+            end
+
+            if isfinite(best_raw) && best_raw <= 1e-8
+                early_seed = DefaultSeed(best_x, best_x, :hadron)
+                early_result = try
+                    solve(mode, T_fm;
+                        xi=xi,
+                        seed_strategy=early_seed,
+                        p_num=p_num,
+                        t_num=t_num,
+                        model_kind=model_kind,
+                        nlsolve_method=:trust_region,
+                        trust_region_fallback=true,
+                        residual_norm_max=residual_norm_max,
+                        nlsolve_kwargs...)
+                catch
+                    nothing
+                end
+                if early_result !== nothing && early_result.converged
+                    return early_result
+                end
+            end
+            if best_raw <= 1e-8
+                break
+            end
+        end
+        if best_raw <= 1e-8
+            break
+        end
+    end
+
+    final_seed = DefaultSeed(best_x, best_x, :hadron)
+    result = try
+        solve(mode, T_fm;
+            xi=xi,
+            seed_strategy=final_seed,
+            p_num=p_num,
+            t_num=t_num,
+            model_kind=model_kind,
+            nlsolve_method=:trust_region,
+            trust_region_fallback=true,
+            residual_norm_max=residual_norm_max,
+            nlsolve_kwargs...)
+    catch
+        nothing
+    end
+
+    return result
+end

--- a/tests/integration/models/test_solver_backend_semantic_parity_guard.jl
+++ b/tests/integration/models/test_solver_backend_semantic_parity_guard.jl
@@ -73,3 +73,23 @@ end
         @test abs(models.rho_norm - legacy.rho_norm) <= 1e-6
     end
 end
+
+@testset "FixedRho ProblemSpec fallback seed pool includes legacy-mode seed" begin
+    model = Models.create_model(:PNJL)
+    T_fm = to_fm_inv(110.0)
+    mode = Models.FixedRho(0.6)
+    seed = copy(P.HADRON_SEED_8)
+
+    raw = Models.solve_constraint(
+        model,
+        mode,
+        T_fm;
+        seed_guess=seed,
+        p_num=8,
+        t_num=4,
+        residual_norm_max=1e-6,
+    )
+
+    @test raw.converged
+    @test abs(raw.rho_norm - 0.6) <= 1e-6
+end

--- a/tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl
+++ b/tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl
@@ -44,11 +44,33 @@ to_fm_inv(x_mev::Real) = Float64(x_mev) / HBARC_MEV_FM
             residual_norm_max=1e-6,
         )
 
+        via_spec_joint = Models.solve_constraint(
+            model,
+            mode,
+            T_fm;
+            problem_spec=spec,
+            fixedrho_joint_solve=true,
+            seed_guess=seed,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+        )
+
         @test direct.converged == via_spec.converged
         @test isapprox(direct.rho_norm, via_spec.rho_norm; rtol=1e-6, atol=1e-8)
         @test isapprox(direct.pressure, via_spec.pressure; rtol=1e-6, atol=1e-8)
         @test isapprox(direct.entropy, via_spec.entropy; rtol=1e-6, atol=1e-8)
         @test isapprox(direct.energy, via_spec.energy; rtol=1e-6, atol=1e-8)
         @test isapprox(direct.residual_norm, via_spec.residual_norm; rtol=1e-6, atol=1e-10)
+
+        @test via_spec_joint.fixedrho_joint_solve_requested
+        @test via_spec_joint.fixedrho_joint_solve_active || via_spec_joint.fixedrho_joint_fallback
+        @test via_spec_joint.selection_reason in (
+            :pressure_max_under_constraints,
+            :residual_min_under_constraints,
+            :no_candidate_passed_constraints,
+        )
+        @test isfinite(via_spec_joint.residual_norm)
+        @test via_spec_joint.residual_norm <= 1e-3
     end
 end

--- a/tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl
+++ b/tests/regression/models/test_problem_spec_fixedrho_parity_regression.jl
@@ -9,6 +9,47 @@ end
 
 to_fm_inv(x_mev::Real) = Float64(x_mev) / HBARC_MEV_FM
 
+@testset "problem spec fixedrho continuity-like seeds with joint only" begin
+    model = Models.create_model(:PNJL)
+    base_seed = copy(Models.pnjl_module().HADRON_SEED_8)
+    points = [
+        (T_MeV=90.0, rho_target=0.2),
+        (T_MeV=100.0, rho_target=0.4),
+        (T_MeV=110.0, rho_target=0.6),
+        (T_MeV=120.0, rho_target=0.8),
+        (T_MeV=130.0, rho_target=1.0),
+    ]
+
+    seed = copy(base_seed)
+    for point in points
+        mode = Models.FixedRho(point.rho_target)
+        spec = Models.build_problem_spec(mode)
+        T_fm = to_fm_inv(point.T_MeV)
+
+        result = Models.solve_constraint(
+            model,
+            mode,
+            T_fm;
+            problem_spec=spec,
+            fixedrho_joint_solve=true,
+            seed_guess=seed,
+            p_num=8,
+            t_num=4,
+            nlsolve_method=:trust_region,
+            trust_region_fallback=true,
+            fallback_method=:trust_region,
+            residual_norm_max=1e-6,
+        )
+
+        @test result.fixedrho_joint_solve_requested
+        @test result.fixedrho_joint_solve_active
+        @test result.converged
+        @test result.residual_norm <= 1e-6
+
+        seed = copy(result.solution)
+    end
+end
+
 @testset "problem spec fixedrho parity regression" begin
     model = Models.create_model(:PNJL)
     points = [
@@ -17,11 +58,13 @@ to_fm_inv(x_mev::Real) = Float64(x_mev) / HBARC_MEV_FM
         (T_MeV=130.0, rho_target=1.0),
     ]
 
+    rolling_seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
     for point in points
         mode = Models.FixedRho(point.rho_target)
         spec = Models.build_problem_spec(mode)
         T_fm = to_fm_inv(point.T_MeV)
-        seed = Models.pnjl_module().HADRON_SEED_8
+        seed = copy(rolling_seed)
 
         direct = Models.solve_constraint(
             model,
@@ -64,7 +107,8 @@ to_fm_inv(x_mev::Real) = Float64(x_mev) / HBARC_MEV_FM
         @test isapprox(direct.residual_norm, via_spec.residual_norm; rtol=1e-6, atol=1e-10)
 
         @test via_spec_joint.fixedrho_joint_solve_requested
-        @test via_spec_joint.fixedrho_joint_solve_active || via_spec_joint.fixedrho_joint_fallback
+        @test via_spec_joint.fixedrho_joint_solve_active
+        @test !via_spec_joint.fixedrho_joint_fallback
         @test via_spec_joint.selection_reason in (
             :pressure_max_under_constraints,
             :residual_min_under_constraints,
@@ -72,5 +116,97 @@ to_fm_inv(x_mev::Real) = Float64(x_mev) / HBARC_MEV_FM
         )
         @test isfinite(via_spec_joint.residual_norm)
         @test via_spec_joint.residual_norm <= 1e-3
+
+        if via_spec_joint.converged
+            rolling_seed = copy(via_spec_joint.solution)
+        end
     end
+end
+
+@testset "problem spec fixedrho joint parity gates" begin
+    model = Models.create_model(:PNJL)
+    T_fm = to_fm_inv(100.0)
+    mode = Models.FixedRho(0.2)
+    spec = Models.build_problem_spec(mode)
+    seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
+    legacy_no_fallback = Models.ImplicitSolver.solve(
+        mode,
+        T_fm;
+        xi=0.0,
+        seed_strategy=Models.DefaultSeed(seed, seed, :hadron),
+        p_num=8,
+        t_num=4,
+        nlsolve_method=:trust_region,
+        trust_region_fallback=false,
+        residual_norm_max=1e-6,
+    )
+
+    via_joint_no_fallback = Models.solve_constraint(
+        model,
+        mode,
+        T_fm;
+        problem_spec=spec,
+        fixedrho_joint_solve=true,
+        seed_guess=seed,
+        seed_candidates=(seed,),
+        p_num=8,
+        t_num=4,
+        nlsolve_method=:trust_region,
+        trust_region_fallback=false,
+        residual_norm_max=1e-6,
+    )
+
+    @test legacy_no_fallback.converged
+    @test via_joint_no_fallback.converged
+    @test via_joint_no_fallback.fixedrho_joint_solve_active
+    @test haskey(via_joint_no_fallback, :fixedrho_joint_selected_method)
+    @test via_joint_no_fallback.fixedrho_joint_selected_method == :trust_region
+    @test haskey(via_joint_no_fallback, :fixedrho_joint_fallback_used)
+    @test !via_joint_no_fallback.fixedrho_joint_fallback_used
+    @test isapprox(via_joint_no_fallback.pressure, legacy_no_fallback.pressure; rtol=1e-6, atol=1e-8)
+    @test isapprox(via_joint_no_fallback.rho_norm, legacy_no_fallback.rho_norm; rtol=1e-6, atol=1e-8)
+    @test isapprox(via_joint_no_fallback.entropy, legacy_no_fallback.entropy; rtol=1e-6, atol=1e-8)
+    @test isapprox(via_joint_no_fallback.energy, legacy_no_fallback.energy; rtol=1e-6, atol=1e-8)
+
+    legacy_with_fallback = Models.ImplicitSolver.solve(
+        mode,
+        T_fm;
+        xi=0.0,
+        seed_strategy=Models.DefaultSeed(seed, seed, :hadron),
+        p_num=8,
+        t_num=4,
+        nlsolve_method=:newton,
+        trust_region_fallback=true,
+        fallback_method=:trust_region,
+        residual_norm_max=1e-6,
+    )
+
+    via_joint_with_fallback = Models.solve_constraint(
+        model,
+        mode,
+        T_fm;
+        problem_spec=spec,
+        fixedrho_joint_solve=true,
+        seed_guess=seed,
+        seed_candidates=(seed,),
+        p_num=8,
+        t_num=4,
+        nlsolve_method=:newton,
+        trust_region_fallback=true,
+        fallback_method=:trust_region,
+        residual_norm_max=1e-6,
+    )
+
+    @test legacy_with_fallback.converged
+    @test via_joint_with_fallback.converged
+    @test via_joint_with_fallback.fixedrho_joint_solve_active
+    @test haskey(via_joint_with_fallback, :fixedrho_joint_selected_method)
+    @test via_joint_with_fallback.fixedrho_joint_selected_method in (:newton, :trust_region)
+    @test haskey(via_joint_with_fallback, :fixedrho_joint_fallback_used)
+    @test (via_joint_with_fallback.fixedrho_joint_selected_method == :trust_region) == via_joint_with_fallback.fixedrho_joint_fallback_used
+    @test isapprox(via_joint_with_fallback.pressure, legacy_with_fallback.pressure; rtol=1e-6, atol=1e-8)
+    @test isapprox(via_joint_with_fallback.rho_norm, legacy_with_fallback.rho_norm; rtol=1e-6, atol=1e-8)
+    @test isapprox(via_joint_with_fallback.entropy, legacy_with_fallback.entropy; rtol=1e-6, atol=1e-8)
+    @test isapprox(via_joint_with_fallback.energy, legacy_with_fallback.energy; rtol=1e-6, atol=1e-8)
 end

--- a/tests/unit/models/test_constraint_solver.jl
+++ b/tests/unit/models/test_constraint_solver.jl
@@ -44,6 +44,24 @@ Models.pnjl_module()
         @test μv3[1] ≈ 0.2
     end
 
+    @testset "solution pack/unpack helpers" begin
+        x_state = SVector{5}(-1.5, -1.5, -2.1, 0.2, 0.2)
+        mu_vec = SVector{3}(1.5, 1.4, 1.3)
+
+        solution = Models._pack_solution(x_state, mu_vec)
+        @test length(solution) == 8
+
+        x2, mu2 = Models._unpack_solution(solution; state_n=5, mu_n=3)
+        @test x2 == x_state
+        @test mu2 == mu_vec
+
+        empty_candidate = Models._empty_candidate(state_n=5, mu_n=3, residual_norm_max=1e-6)
+        @test length(empty_candidate.solution) == 8
+        @test all(isnan, empty_candidate.solution)
+        @test empty_candidate.failed_constraints == [:solver_failed]
+        @test !empty_candidate.converged
+    end
+
     @testset "solve_constraint(FixedMu) NJL" begin
         m = Models.create_model(:NJL)
         T = 0.5

--- a/tests/unit/models/test_problem_spec_contract.jl
+++ b/tests/unit/models/test_problem_spec_contract.jl
@@ -39,6 +39,60 @@ end
         end
     end
 
+    @testset "problem spec extra constraints shell contract" begin
+        @test isdefined(Models, :ExtraConstraints)
+        @test isdefined(Models, :default_extra_constraints)
+
+        mode = Models.FixedEntropy(0.5)
+        spec = Models.build_problem_spec(mode)
+        @test hasproperty(spec, :extra_constraints)
+
+        ec = spec.extra_constraints
+        @test ec isa Models.ExtraConstraints
+
+        seed = [-1.5, -1.5, -2.1, 0.2, 0.2, 1.5, 1.5, 1.5]
+        @test ec.seed_extend(seed, mode) == Float64.(seed)
+        @test ec.feasible((; converged=true), (;), mode)
+
+        residual_vec = zeros(Float64, 0)
+        ec.residual!(residual_vec, Float64[], Float64[], (;), mode)
+        @test isempty(residual_vec)
+    end
+
+    @testset "problem spec extra constraints hooks are wired in forward_solve" begin
+        model = Models.create_model(:PNJL)
+        mode = Models.FixedEntropy(0.5)
+        T_fm = 100.0 / 197.327
+        seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
+        seed_extend_calls = Ref(0)
+        ec = Models.ExtraConstraints(
+            (F, x, theta, cfg, mode) -> nothing,
+            (candidate, params, mode) -> false,
+            (seed_vec, mode) -> begin
+                seed_extend_calls[] += 1
+                return Float64.(seed_vec)
+            end,
+        )
+
+        spec = Models.build_problem_spec(mode)
+        solved = spec.forward_solve(
+            model,
+            T_fm;
+            extra_constraints=ec,
+            seed_guess=seed,
+            rho0=0.16,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+            iterations=120,
+        )
+
+        @test seed_extend_calls[] >= 1
+        @test solved.hard_constraint_ok == false
+        @test :extra_constraint_failed in solved.failed_constraints
+    end
+
     @testset "fixedrho spec conditions and forward solve are wired" begin
         model = Models.create_model(:PNJL)
         mode = Models.FixedRho(0.2)
@@ -404,6 +458,40 @@ end
             iterations=120,
         )
         @test custom.selection_reason == :custom_selector
+    end
+
+    @testset "fixedasymrho forward_solve accepts extra_constraints hook" begin
+        model = Models.create_model(:PNJL)
+        mode = Models.FixedAsymmetricRho(0.05, 1.0, 0.0)
+        spec = Models.build_problem_spec(mode)
+        T_fm = 100.0 / 197.327
+        seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
+        seed_extend_calls = Ref(0)
+        ec = Models.ExtraConstraints(
+            (F, x, theta, cfg, mode) -> nothing,
+            (candidate, params, mode) -> false,
+            (seed_vec, mode) -> begin
+                seed_extend_calls[] += 1
+                return Float64.(seed_vec)
+            end,
+        )
+
+        solved = spec.forward_solve(
+            model,
+            T_fm;
+            extra_constraints=ec,
+            seed_guess=seed,
+            rho0=0.16,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+            iterations=120,
+        )
+
+        @test seed_extend_calls[] >= 1
+        @test solved.hard_constraint_ok == false
+        @test :extra_constraint_failed in solved.failed_constraints
     end
 
     @testset "build_conditions schema path parity for non-rho modes" begin

--- a/tests/unit/models/test_problem_spec_contract.jl
+++ b/tests/unit/models/test_problem_spec_contract.jl
@@ -292,8 +292,51 @@ end
             @test solved isa NamedTuple
             @test haskey(solved, :selection_reason)
             @test haskey(solved, :candidate_count)
+            @test haskey(solved, :legacy_fallback_used)
+            @test haskey(solved, :governed_selected_method)
+            @test haskey(solved, :governed_selected_quality)
+            @test haskey(solved, :governed_fallback_used)
+            @test solved.legacy_fallback_used isa Bool
+            @test solved.governed_selected_method isa Symbol
+            @test solved.governed_selected_quality isa Symbol
+            @test solved.governed_fallback_used isa Bool
             @test solved.selection_reason in (:pressure_max_under_constraints, :residual_min_under_constraints, :no_candidate_passed_constraints)
             @test solved.candidate_count >= 1
+        end
+    end
+
+    @testset "non-rho forward_solve supports allow_legacy_fallback toggle" begin
+        model = Models.create_model(:PNJL)
+        T_fm = 100.0 / 197.327
+        seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
+        modes = (
+            Models.FixedEntropy(0.5),
+            Models.FixedSigma(10.0),
+            Models.FixedAsymmetricRho(0.05, 1.0, 0.0),
+        )
+
+        for mode in modes
+            spec = Models.build_problem_spec(mode)
+            solved = spec.forward_solve(
+                model,
+                T_fm;
+                seed_guess=seed,
+                rho0=0.16,
+                p_num=8,
+                t_num=4,
+                residual_norm_max=1e-6,
+                iterations=120,
+                nlsolve_method=:newton,
+                trust_region_fallback=false,
+                allow_legacy_fallback=false,
+            )
+
+            @test solved isa NamedTuple
+            @test haskey(solved, :legacy_fallback_used)
+            @test solved.legacy_fallback_used isa Bool
+            @test haskey(solved, :governed_fallback_used)
+            @test solved.governed_fallback_used == false
         end
     end
 

--- a/tests/unit/models/test_problem_spec_contract.jl
+++ b/tests/unit/models/test_problem_spec_contract.jl
@@ -90,7 +90,7 @@ end
             t_num=4,
         )
 
-        legacy_result = spec.forward_solve(
+        @test_throws ArgumentError spec.forward_solve(
             model,
             T_fm;
             fixedrho_joint_solve=false,
@@ -99,10 +99,6 @@ end
             t_num=4,
             residual_norm_max=1e-6,
         )
-        @test !legacy_result.fixedrho_joint_solve_requested
-        @test !legacy_result.fixedrho_joint_solve_active
-        @test legacy_result.selection_reason == :legacy_fixedrho_solver
-        @test haskey(legacy_result, :hard_constraint_ok)
     end
 
     @testset "fixedrho forward_solve can run joint solve path" begin

--- a/tests/unit/models/test_problem_spec_contract.jl
+++ b/tests/unit/models/test_problem_spec_contract.jl
@@ -79,6 +79,7 @@ end
         @test result.fixedrho_joint_solve_requested
         @test haskey(result, :fixedrho_joint_solve_active)
         @test haskey(result, :fixedrho_joint_fallback)
+        @test !result.fixedrho_joint_fallback
 
         @test_throws ArgumentError spec.forward_solve(
             model,
@@ -88,6 +89,20 @@ end
             p_num=8,
             t_num=4,
         )
+
+        legacy_result = spec.forward_solve(
+            model,
+            T_fm;
+            fixedrho_joint_solve=false,
+            seed_guess=seed,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+        )
+        @test !legacy_result.fixedrho_joint_solve_requested
+        @test !legacy_result.fixedrho_joint_solve_active
+        @test legacy_result.selection_reason == :legacy_fixedrho_solver
+        @test haskey(legacy_result, :hard_constraint_ok)
     end
 
     @testset "fixedrho forward_solve can run joint solve path" begin
@@ -109,7 +124,8 @@ end
         )
 
         @test result.fixedrho_joint_solve_requested
-        @test result.fixedrho_joint_solve_active || result.fixedrho_joint_fallback
+        @test result.fixedrho_joint_solve_active
+        @test !result.fixedrho_joint_fallback
         @test isfinite(result.residual_norm)
         @test result.residual_norm >= 0.0
     end

--- a/tests/unit/models/test_problem_spec_contract.jl
+++ b/tests/unit/models/test_problem_spec_contract.jl
@@ -113,6 +113,39 @@ end
         @test haskey(solved, :fixedrho_joint_solve_active)
     end
 
+    @testset "fixedrho forward_solve accepts extra_constraints hook" begin
+        model = Models.create_model(:PNJL)
+        mode = Models.FixedRho(0.2)
+        spec = Models.build_problem_spec(mode)
+        T_fm = 100.0 / 197.327
+        seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
+        seed_extend_calls = Ref(0)
+        ec = Models.ExtraConstraints(
+            (F, x, theta, cfg, mode) -> nothing,
+            (candidate, params, mode) -> false,
+            (seed_vec, mode) -> begin
+                seed_extend_calls[] += 1
+                return Float64.(seed_vec)
+            end,
+        )
+
+        solved = spec.forward_solve(
+            model,
+            T_fm;
+            extra_constraints=ec,
+            seed_guess=seed,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+            iterations=120,
+        )
+
+        @test seed_extend_calls[] >= 1
+        @test solved.hard_constraint_ok == false
+        @test :extra_constraint_failed in solved.failed_constraints
+    end
+
     @testset "fixedrho forward_solve accepts joint-solve flag" begin
         model = Models.create_model(:PNJL)
         mode = Models.FixedRho(0.2)

--- a/tests/unit/models/test_problem_spec_contract.jl
+++ b/tests/unit/models/test_problem_spec_contract.jl
@@ -55,6 +55,63 @@ end
         @test haskey(solved, :residual_norm)
         @test haskey(solved, :selection_reason)
         @test haskey(solved, :candidate_count)
+        @test haskey(solved, :fixedrho_joint_solve_requested)
+        @test haskey(solved, :fixedrho_joint_solve_active)
+    end
+
+    @testset "fixedrho forward_solve accepts joint-solve flag" begin
+        model = Models.create_model(:PNJL)
+        mode = Models.FixedRho(0.2)
+        spec = Models.build_problem_spec(mode)
+        T_fm = 100.0 / 197.327
+        seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
+        result = spec.forward_solve(
+            model,
+            T_fm;
+            fixedrho_joint_solve=true,
+            seed_guess=seed,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+        )
+
+        @test result.fixedrho_joint_solve_requested
+        @test haskey(result, :fixedrho_joint_solve_active)
+        @test haskey(result, :fixedrho_joint_fallback)
+
+        @test_throws ArgumentError spec.forward_solve(
+            model,
+            T_fm;
+            fixedrho_joint_solve=:bad,
+            seed_guess=seed,
+            p_num=8,
+            t_num=4,
+        )
+    end
+
+    @testset "fixedrho forward_solve can run joint solve path" begin
+        model = Models.create_model(:PNJL)
+        mode = Models.FixedRho(0.2)
+        spec = Models.build_problem_spec(mode)
+        T_fm = 100.0 / 197.327
+        seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
+        result = spec.forward_solve(
+            model,
+            T_fm;
+            fixedrho_joint_solve=true,
+            seed_guess=seed,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-5,
+            iterations=120,
+        )
+
+        @test result.fixedrho_joint_solve_requested
+        @test result.fixedrho_joint_solve_active || result.fixedrho_joint_fallback
+        @test isfinite(result.residual_norm)
+        @test result.residual_norm >= 0.0
     end
 
     @testset "solve_constraint fixedrho prefers problem_spec forward_solve" begin
@@ -292,5 +349,41 @@ end
             iterations=120,
         )
         @test custom.selection_reason == :custom_selector
+    end
+
+    @testset "build_conditions schema path parity for non-rho modes" begin
+        params = Models.GapParams(0.5, Models.cached_nodes(8, 4), 0.0)
+        schema = Models.schema_for_model(:PNJL)
+        θ = [0.5]
+        x = [-1.5, -1.5, -2.1, 0.2, 0.2, 1.5, 1.5, 1.5]
+
+        modes = (
+            Models.FixedEntropy(0.5),
+            Models.FixedSigma(8.0),
+            Models.FixedAsymmetricRho(0.2, 1.0, 0.0),
+        )
+
+        for mode in modes
+            legacy = Models.build_conditions(mode, params)
+            schema_driven = Models.build_conditions(mode, params, schema; mu_dim=3)
+            @test schema_driven(θ, x) ≈ legacy(θ, x) rtol=1e-12 atol=1e-12
+        end
+    end
+
+    @testset "schema-mode dimension mismatch throws clear error" begin
+        params = Models.GapParams(0.5, Models.cached_nodes(8, 4), 0.0)
+        bad_schema = Models.ModelStateSchema(:PNJL, (:phi_u, :phi_d, :phi_s, :Phi))
+        mode = Models.FixedRho(0.2)
+        cond = Models.build_conditions(mode, params, bad_schema; mu_dim=3)
+
+        err = try
+            cond([0.5], [-1.5, -1.5, -2.1, 0.2, 1.5, 1.5, 1.5])
+            nothing
+        catch e
+            e
+        end
+
+        @test err isa ArgumentError
+        @test occursin("schema state_dim mismatch", sprint(showerror, err))
     end
 end

--- a/tests/unit/models/test_solver.jl
+++ b/tests/unit/models/test_solver.jl
@@ -86,4 +86,64 @@ Models.pnjl_module()
         @test result isa Models.SolverResult
         @test isfinite(result.residual_norm)
     end
+
+    @testset "FixedEntropy default/bridge semantic parity (single point)" begin
+        model = Models.create_model(:PNJL)
+        mode = Models.FixedEntropy(0.5)
+        T_fm = 100.0 / 197.327
+        seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
+        default_result = Models.solve(model, mode, T_fm;
+            seed_strategy=Models.DefaultSeed(seed, seed, :hadron),
+            p_num=16,
+            t_num=6,
+            residual_norm_max=1e-6,
+        )
+
+        bridge_result = Models.solve(model, mode, T_fm;
+            seed_strategy=Models.DefaultSeed(seed, seed, :hadron),
+            seed_guess=seed,
+            seed_candidates=(seed,),
+            semantic_mode=:ground_state,
+            rho0=Models.pnjl_module().ρ0,
+            p_num=16,
+            t_num=6,
+            residual_norm_max=1e-6,
+        )
+
+        @test default_result.converged
+        @test bridge_result.converged
+        @test isapprox(default_result.entropy, bridge_result.entropy; rtol=1e-3, atol=1e-5)
+        @test isapprox(default_result.pressure, bridge_result.pressure; rtol=1e-3, atol=1e-5)
+    end
+
+    @testset "FixedSigma default/bridge semantic parity (single point)" begin
+        model = Models.create_model(:PNJL)
+        mode = Models.FixedSigma(10.0)
+        T_fm = 100.0 / 197.327
+        seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
+        default_result = Models.solve(model, mode, T_fm;
+            seed_strategy=Models.DefaultSeed(seed, seed, :hadron),
+            p_num=16,
+            t_num=6,
+            residual_norm_max=1e-6,
+        )
+
+        bridge_result = Models.solve(model, mode, T_fm;
+            seed_strategy=Models.DefaultSeed(seed, seed, :hadron),
+            seed_guess=seed,
+            seed_candidates=(seed,),
+            semantic_mode=:ground_state,
+            rho0=Models.pnjl_module().ρ0,
+            p_num=16,
+            t_num=6,
+            residual_norm_max=1e-6,
+        )
+
+        @test default_result.converged
+        @test bridge_result.converged
+        @test isapprox(default_result.rho_norm, bridge_result.rho_norm; rtol=1e-3, atol=1e-5)
+        @test isapprox(default_result.pressure, bridge_result.pressure; rtol=1e-3, atol=1e-5)
+    end
 end

--- a/tests/unit/models/test_solver.jl
+++ b/tests/unit/models/test_solver.jl
@@ -146,4 +146,65 @@ Models.pnjl_module()
         @test isapprox(default_result.rho_norm, bridge_result.rho_norm; rtol=1e-3, atol=1e-5)
         @test isapprox(default_result.pressure, bridge_result.pressure; rtol=1e-3, atol=1e-5)
     end
+
+    @testset "FixedRho default/bridge semantic parity (single point)" begin
+        model = Models.create_model(:PNJL)
+        mode = Models.FixedRho(1.0)
+        T_fm = 100.0 / 197.327
+        seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
+        default_result = Models.solve(model, mode, T_fm;
+            seed_strategy=Models.DefaultSeed(seed, seed, :hadron),
+            p_num=16,
+            t_num=6,
+            residual_norm_max=1e-6,
+        )
+
+        bridge_result = Models.solve(model, mode, T_fm;
+            seed_strategy=Models.DefaultSeed(seed, seed, :hadron),
+            seed_guess=seed,
+            seed_candidates=(seed,),
+            semantic_mode=:ground_state,
+            p_num=16,
+            t_num=6,
+            residual_norm_max=1e-6,
+        )
+
+        @test default_result.converged
+        @test bridge_result.converged
+        @test isapprox(default_result.rho_norm, bridge_result.rho_norm; rtol=1e-3, atol=1e-5)
+        @test isapprox(default_result.pressure, bridge_result.pressure; rtol=1e-3, atol=1e-5)
+    end
+
+    @testset "FixedAsymmetricRho default/bridge semantic parity (single point)" begin
+        model = Models.create_model(:PNJL)
+        mode = Models.FixedAsymmetricRho(0.05, 1.0, 0.0)
+        T_fm = 100.0 / 197.327
+        seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
+        default_result = Models.solve(model, mode, T_fm;
+            seed_strategy=Models.DefaultSeed(seed, seed, :hadron),
+            p_num=8,
+            t_num=4,
+            iterations=120,
+            residual_norm_max=1e-6,
+        )
+
+        bridge_result = Models.solve(model, mode, T_fm;
+            seed_strategy=Models.DefaultSeed(seed, seed, :hadron),
+            seed_guess=seed,
+            seed_candidates=(seed,),
+            semantic_mode=:ground_state,
+            rho0=Models.pnjl_module().ρ0,
+            p_num=8,
+            t_num=4,
+            iterations=120,
+            residual_norm_max=1e-6,
+        )
+
+        @test default_result.converged
+        @test bridge_result.converged
+        @test isapprox(default_result.rho_norm, bridge_result.rho_norm; rtol=1e-3, atol=1e-5)
+        @test isapprox(default_result.pressure, bridge_result.pressure; rtol=1e-3, atol=1e-5)
+    end
 end

--- a/tests/unit/models/test_solver.jl
+++ b/tests/unit/models/test_solver.jl
@@ -152,18 +152,20 @@ Models.pnjl_module()
         mode = Models.FixedRho(1.0)
         T_fm = 100.0 / 197.327
         seed = copy(Models.pnjl_module().HADRON_SEED_8)
+        seed_strategy = Models.DefaultSeed(seed, seed, :hadron)
+        bridge_seed = Models.get_seed(seed_strategy, [T_fm], mode)
 
         default_result = Models.solve(model, mode, T_fm;
-            seed_strategy=Models.DefaultSeed(seed, seed, :hadron),
+            seed_strategy=seed_strategy,
             p_num=16,
             t_num=6,
             residual_norm_max=1e-6,
         )
 
         bridge_result = Models.solve(model, mode, T_fm;
-            seed_strategy=Models.DefaultSeed(seed, seed, :hadron),
-            seed_guess=seed,
-            seed_candidates=(seed,),
+            seed_strategy=seed_strategy,
+            seed_guess=bridge_seed,
+            seed_candidates=(bridge_seed,),
             semantic_mode=:ground_state,
             p_num=16,
             t_num=6,

--- a/tests/unit/models/test_solver.jl
+++ b/tests/unit/models/test_solver.jl
@@ -49,4 +49,41 @@ Models.pnjl_module()
         # FixedRho 可能需要额外参数；确保接口存在即可
         @test Models.solve_constraint isa Function
     end
+
+    @testset "non-FixedMu solve supports semantic bridge kwargs" begin
+        mode = Models.FixedEntropy(0.5)
+        T_fm = 100.0 / 197.327
+        seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
+        result = Models.solve(mode, T_fm;
+            seed_guess=seed,
+            seed_candidates=(seed,),
+            semantic_mode=:constrained_manifold,
+            p_num=8,
+            t_num=4,
+            rho0=0.16,
+            residual_norm_max=1e-6,
+        )
+
+        @test result isa Models.SolverResult
+        @test isfinite(result.residual_norm)
+    end
+
+    @testset "non-FixedMu solve_multi supports semantic bridge kwargs" begin
+        mode = Models.FixedAsymmetricRho(0.05, 1.0, 0.0)
+        T_fm = 100.0 / 197.327
+        seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
+        result = Models.solve_multi(mode, T_fm;
+            seed_candidates=(seed,),
+            semantic_mode=:constrained_manifold,
+            p_num=8,
+            t_num=4,
+            rho0=0.16,
+            residual_norm_max=1e-6,
+        )
+
+        @test result isa Models.SolverResult
+        @test isfinite(result.residual_norm)
+    end
 end

--- a/tests/unit/models/test_solver_dimension_agnostic.jl
+++ b/tests/unit/models/test_solver_dimension_agnostic.jl
@@ -22,9 +22,10 @@ const P = Models.pnjl_module()
         @test isdefined(Models, :solve_constraint)
         @test :create_implicit_solver ∉ names(Models)
         @test :solve_with_root_diagnostics ∉ names(Models)
-        @test :solve_weighted_block_fallback ∉ names(Models)
+        @test :solve_weighted_block_fallback in names(Models)
         @test !isdefined(Models.ImplicitSolver, :create_implicit_solver)
         @test !isdefined(Models.ImplicitSolver, :solve_with_root_diagnostics)
+        @test :solve_with_derivatives ∉ names(Models.ImplicitSolver)
     end
 
     @testset "SolverResult accepts non-5/3 state and mu" begin
@@ -61,6 +62,29 @@ const P = Models.pnjl_module()
         schema_driven = P.build_conditions(mode, params, schema; mu_dim=3)
 
         @test schema_driven(θ, x) ≈ legacy(θ, x) rtol=1e-12 atol=1e-12
+    end
+
+    @testset "mode dimension contract" begin
+        modes = (
+            Models.FixedMu(),
+            Models.FixedRho(0.2),
+            Models.FixedAsymmetricRho(0.2, 1.0, 0.0),
+            Models.FixedEntropy(0.5),
+            Models.FixedSigma(8.0),
+        )
+
+        for mode in modes
+            @test Models.solution_dim(mode) == Models.state_var_dim(mode) + Models.mu_var_dim(mode)
+            @test Models.state_dim(mode) == Models.solution_dim(mode)
+            @test Models.state_var_dim(mode) > 0
+            @test Models.mu_var_dim(mode) >= 0
+        end
+
+        @test Models.state_var_dim(Models.FixedMu()) == 5
+        @test Models.mu_var_dim(Models.FixedMu()) == 0
+
+        @test Models.state_var_dim(Models.FixedRho(0.2)) == 5
+        @test Models.mu_var_dim(Models.FixedRho(0.2)) == 3
     end
 
     @testset "solver backend defaults are model-agnostic" begin


### PR DESCRIPTION
## Summary
- introduce `ExtraConstraints` into the ProblemSpec contract with default no-op behavior
- thread `seed_extend` and `feasible` hooks through governed solving
- unify non-FixedRho modes under shared governed execution while aligning FixedRho outer planning/execution layers to the same abstractions
- keep the FixedRho joint-solve kernel intact, extracting only shared attempt-plan and candidate-executor scaffolding

## Scope
- in scope: architectural unification and constraint extensibility on top of rebuilt PR2
- out of scope: changing the numerical target semantics already established in PR1 + rebuilt PR2 chain

## Why
This PR is the final stacked step: represent mode differences with composable extra constraints instead of duplicated orchestration branches.

## Dependency
- base branch: `split/pr2-fixedrho-parity-rebased` (new PR2: #54)
- review after #54 is understood/merged to minimize diff noise

## Reviewer Guide
- first inspect ProblemSpec contract updates
- then follow governed chain wiring (`seed_extend` / `feasible`)
- finally inspect FixedRho outer-layer alignment to confirm kernel preservation

## Validation
- CI is the source of truth for this stacked PR state
- historical local checks for this PR line included:
  - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_contract.jl"; include("tests/unit/runtests.jl")'`
  - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl"; include("tests/unit/runtests.jl")'`
  - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_semantic_modes.jl"; include("tests/unit/runtests.jl")'`
  - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`
