### PR TITLE
refactor(models/solver): unify ProblemSpec governed chain with extra constraints

### DIFF
--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -686,3 +686,27 @@ Files:
   5) 阶段结论：
      - 非 FixedRho 三模式已全部完成“统一主执行器 + 额外约束输入”收敛；
      - 后续可进入 `FixedRho` 外层编排统一评估（风险更高，建议单独 gate 与回归矩阵）。
+
+- 2026-04-05："额外约束作为通用输入" 阶段 5（FixedRho 外层编排统一第一步）
+  1) 目标：
+     - 在不触碰 `FixedRho` 联合求解内核的前提下，先收敛其外层 attempt-plan 构建逻辑，和 non-rho 主链复用同一套 seed 计划生成器。
+  2) 生产实现（`src/models/solver/ProblemSpec.jl`）：
+     - 新增 `_build_governed_attempt_plan(...)`：
+       - 统一处理 primary/provided/default/extra_fallback seeds 去重；
+       - 统一生成 `:primary / :method_rescue / :seed_rescue` attempt 序列；
+       - 内建 `extra_constraints.seed_extend` 接缝。
+     - `FixedRho` 与 `_governed_nonrho_problem_spec_forward_solve(...)` 均改为复用该统一 attempt-plan 构建器；
+     - 保留 `FixedRho` 既有 legacy-mode seed 注入逻辑，作为 `extra_fallback_seeds` 传入（保持稳定性）。
+  3) 测试补强：
+     - 在 `tests/unit/models/test_problem_spec_contract.jl` 新增
+       `fixedrho forward_solve accepts extra_constraints hook`：
+       - 断言 `seed_extend` 被调用；
+       - 断言 `feasible=false` 会触发 `:extra_constraint_failed`。
+  4) 验证结果：
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_contract.jl"; include("tests/unit/runtests.jl")'`（176/176）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl"; include("tests/unit/runtests.jl")'`（25/25）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_semantic_modes.jl"; include("tests/unit/runtests.jl")'`（7/7）
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
+  5) 阶段结论：
+     - `FixedRho` 已完成“外层计划编排”与通用主链的第一层统一；
+     - 当前仍保留 `FixedRho` 专用 joint solve 主体，后续若继续统一，应把“候选执行与结果整形”再抽一层通用执行器，并单独跑 parity/regression gate。

--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -584,6 +584,105 @@ Files:
      - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl"; include("tests/unit/runtests.jl")'`（25/25）
      - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
      - `julia --project=. -e 'ENV["REGRESSION_FILES"]="models/test_problem_spec_fixedrho_parity_regression.jl"; include("tests/regression/runtests.jl")'`（78/78）
-  5) 结论：
-     - 该红灯已由“吸引盆地覆盖不足”被修复；
-     - 该改动不改变求解器主干结构，仅增加一条 mode-aware 候选 seed，属于低风险稳态增强。
+   5) 结论：
+      - 该红灯已由“吸引盆地覆盖不足”被修复；
+      - 该改动不改变求解器主干结构，仅增加一条 mode-aware 候选 seed，属于低风险稳态增强。
+
+- 2026-04-05："额外约束作为通用输入" 最小改动实施（阶段 1：护栏 + 壳层）
+  1) 目标与策略：
+     - 按“可回退、可验证、单点替换”推进，不改现有模式求解行为；
+     - 先在 `ProblemSpec` 层引入通用 `ExtraConstraints` 壳层，默认实现为 no-op，确保零行为变化。
+  2) TDD 护栏（先红后绿）：
+     - 在 `tests/unit/models/test_problem_spec_contract.jl` 新增 `problem spec extra constraints shell contract`：
+       - 要求 `Models.ExtraConstraints`、`Models.default_extra_constraints` 可见；
+       - 要求 `build_problem_spec(mode)` 返回的 `spec` 带 `extra_constraints` 字段；
+       - 要求默认 `seed_extend` 为 identity、`feasible` 恒真、`residual!` no-op。
+     - 先运行该测试出现预期红灯（符号/字段不存在），再实现生产代码并转绿。
+  3) 生产实现（零行为变化）：
+     - `src/models/solver/ProblemSpec.jl`：
+       - 新增 `ExtraConstraints` 结构（`residual!`, `feasible`, `seed_extend`）；
+       - 新增默认 no-op 适配 `default_extra_constraints()`；
+       - `ProblemSpec` 增加 `extra_constraints` 字段；
+       - `ProblemSpec(...)` 构造器新增关键字 `extra_constraints=default_extra_constraints()`。
+     - `src/models/Models.jl`：导出 `ExtraConstraints` 与 `default_extra_constraints`。
+  4) 验证：
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_contract.jl"; include("tests/unit/runtests.jl")'`（167/167）。
+  5) 阶段结论：
+     - 已完成你要求的最小接缝注入："模式差异可转为 extra constraints 输入" 的结构基础到位；
+     - 当前默认实现不改变任何既有解算路径行为，后续可在阶段 2/3 逐步接入主执行器钩子与两模式迁移。
+
+- 2026-04-05："额外约束作为通用输入" 阶段 2（主执行器钩子接入，保持默认行为）
+  1) 目标：
+     - 在不改变默认数值行为的前提下，让 `extra_constraints` 真正进入 `ProblemSpec` 主执行路径；
+     - 接入点仅限两类：`seed_extend` 与 `feasible`（`residual!` 先保留接口，不在本阶段强接）。
+  2) 实施改动：
+     - `src/models/solver/ProblemSpec.jl`
+       - 新增工具函数：
+         - `_resolve_extra_constraints(kwargs)`
+         - `_extend_seed_with_extra(seed, mode, extra)`
+         - `_append_extra_feasible_rule(rules, extra, mode)`
+       - `ProblemSpec(...)` 构造器保持兼容，同时将 `extra_constraints` 注入默认 `forward_solve` keyword；
+       - `_strip_problemspec_forwardsolve_kwargs!` 增加 `:extra_constraints`，防止下游 solver 收到无关键字；
+       - 在 `FixedRho/FixedEntropy/FixedSigma/FixedAsymmetricRho` 的 `forward_solve` 中统一接入：
+         - `primary_seed/provided_seed_pool/default_seed_pool` 均经过 `extra.seed_extend(...)`；
+         - `hard_constraints` 追加 `extra.feasible(...) => :extra_constraint_failed` 规则。
+     - `tests/unit/models/test_problem_spec_contract.jl`
+       - 新增 `problem spec extra constraints hooks are wired in forward_solve`：
+         - 通过 `extra_constraints=ec` 显式传入，断言 `seed_extend` 被调用；
+         - 断言 `feasible=false` 会使 `hard_constraint_ok=false` 且失败原因包含 `:extra_constraint_failed`。
+  3) 验证结果：
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_contract.jl"; include("tests/unit/runtests.jl")'`（170/170）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl"; include("tests/unit/runtests.jl")'`（25/25）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_semantic_modes.jl"; include("tests/unit/runtests.jl")'`（7/7）
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
+  4) 阶段结论：
+     - 已完成“通用额外约束输入”在主执行器的最小可用接入：可影响种子扩展与可行域判定；
+     - 默认 `default_extra_constraints()` 仍为 no-op，故对既有调用方保持行为兼容；
+     - 下阶段可迁移 `FixedEntropy/FixedSigma` 为“仅差异化提供 extra_constraints”以进一步消解 mode 分叉实现。
+
+- 2026-04-05："额外约束作为通用输入" 阶段 3（先迁移 FixedEntropy + FixedSigma）
+  1) 目标：
+     - 将 `FixedEntropy` / `FixedSigma` 的 ProblemSpec 前向求解实现收敛到统一非 rho 主链执行器；
+     - 保持行为等价（只抽公共编排，不变更物理求解内核）。
+  2) TDD 与重构策略：
+     - 先沿用阶段 1/2 已建立的 `problem_spec_contract + solver + semantic_modes + integration smoke` 作为回归护栏；
+     - 在 `ProblemSpec` 中新增统一执行器 `_governed_nonrho_problem_spec_forward_solve(...)`，将重复逻辑（seed pool、attempt plan、hard rules、selector、治理元数据）抽象；
+     - `FixedEntropy/FixedSigma` 改为仅提供：
+       - mode label（报错文本）；
+       - mode 特有 attempt-origin 字段名；
+       - mode 特有 constraint solve 闭包（分别调用 `_solve_constraint_fixedentropy/_fixedsigma`）。
+  3) 关键实现点（`src/models/solver/ProblemSpec.jl`）：
+     - 新增 `_governed_nonrho_problem_spec_forward_solve(...)` 通用函数；
+     - `FixedEntropy/FixedSigma` wrapper 显著瘦身，迁移到“参数化调用通用执行器”；
+     - 保留原有输出契约字段（`governed_*`, `legacy_fallback_used`, `selection_reason`, `candidate_count` 等）不变。
+  4) 验证：
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_contract.jl"; include("tests/unit/runtests.jl")'`（170/170）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl"; include("tests/unit/runtests.jl")'`（25/25）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_semantic_modes.jl"; include("tests/unit/runtests.jl")'`（7/7）
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
+  5) 阶段结论：
+     - 已完成你指定的“先两模式迁移”：`FixedEntropy` 与 `FixedSigma` 的分叉编排明显收敛；
+     - 当前模式差异主要集中在“额外约束/模式参数输入 + mode 专有内核调用”，符合“把额外约束当作通用输入”的主方向；
+     - 下一步可按同样方式迁移 `FixedAsymmetricRho`，再评估 `FixedRho` 外层编排统一的收益/风险比。
+
+- 2026-04-05："额外约束作为通用输入" 阶段 4（迁移 FixedAsymmetricRho）
+  1) 目标：
+     - 将 `FixedAsymmetricRho` 迁移到与 `FixedEntropy/FixedSigma` 相同的统一非 rho 主执行器，进一步压缩 mode 分叉编排。
+  2) TDD 护栏：
+     - 在 `tests/unit/models/test_problem_spec_contract.jl` 新增
+       `fixedasymrho forward_solve accepts extra_constraints hook`：
+       - 断言 `seed_extend` 被调用；
+       - 断言 `feasible=false` 会触发 `:extra_constraint_failed`。
+  3) 生产实现：
+     - `src/models/solver/ProblemSpec.jl`
+       - `_fixedasymrho_problem_spec_forward_solve(...)` 改为参数化调用
+         `_governed_nonrho_problem_spec_forward_solve(...)`；
+       - 仅保留 mode 差异输入（label / attempt-origin key / mode-specific solve closure）。
+  4) 验证结果：
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_contract.jl"; include("tests/unit/runtests.jl")'`（173/173）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl"; include("tests/unit/runtests.jl")'`（25/25）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_semantic_modes.jl"; include("tests/unit/runtests.jl")'`（7/7）
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
+  5) 阶段结论：
+     - 非 FixedRho 三模式已全部完成“统一主执行器 + 额外约束输入”收敛；
+     - 后续可进入 `FixedRho` 外层编排统一评估（风险更高，建议单独 gate 与回归矩阵）。

--- a/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
+++ b/docs/dev/active/2026-04-04_Models求解器主链收敛与ImplicitSolver退役任务单.md
@@ -710,3 +710,21 @@ Files:
   5) 阶段结论：
      - `FixedRho` 已完成“外层计划编排”与通用主链的第一层统一；
      - 当前仍保留 `FixedRho` 专用 joint solve 主体，后续若继续统一，应把“候选执行与结果整形”再抽一层通用执行器，并单独跑 parity/regression gate。
+
+- 2026-04-05："额外约束作为通用输入" 阶段 6（候选执行器统一层）
+  1) 目标：
+     - 进一步收敛 `FixedRho` 与 non-rho 的共同外层流程，将“attempt 执行 + hard-rule 评估 + selector 选优”抽成统一执行器。
+  2) 生产实现（`src/models/solver/ProblemSpec.jl`）：
+     - 新增 `_execute_governed_attempt_plan(...)`：
+       - 输入 `attempt_plan + solve_attempt + failure_attempt + hard_constraints + selector`；
+       - 统一处理 candidate 生成、约束评估、提前收敛退出、最终 selector 选取。
+     - `FixedRho` 前向求解与 `_governed_nonrho_problem_spec_forward_solve(...)` 改为复用该统一执行器；
+     - 维持原始输出契约不变（包括 `fixedrho_joint_*` 与 `governed_*` 字段）。
+  3) 验证结果：
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_contract.jl"; include("tests/unit/runtests.jl")'`（176/176）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl"; include("tests/unit/runtests.jl")'`（25/25）
+     - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_semantic_modes.jl"; include("tests/unit/runtests.jl")'`（7/7）
+     - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`（43/43）
+  4) 阶段结论：
+     - `FixedRho` 与 non-rho 已在“计划生成 + 候选执行 + 选优治理”三层对齐；
+     - 当前剩余 mode 差异已主要收敛到“内核 solve closure + 结果字段差异（joint metadata）”，符合逐层去分叉目标。

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -60,7 +60,7 @@ export solve, solve_multi, SolverResult
 export ModelStateSchema, schema_for_model, flatten_state, unflatten_state
 export ConstraintModes
 export state_var_dim, mu_var_dim, solution_dim
-export ProblemSpec, build_problem_spec
+export ProblemSpec, build_problem_spec, ExtraConstraints, default_extra_constraints
 export AbstractConstraintComponent
 export constraint_name, constraint_dim, build_constraint_components, constraint_total_dim
 export HardRule, CandidateSelector, build_candidate_context

--- a/src/models/constraint_solver.jl
+++ b/src/models/constraint_solver.jl
@@ -35,8 +35,7 @@ end
     return x_state, mu_vec
 end
 
-@inline function _empty_candidate(; state_n::Int=5, mu_n::Int=3, residual_norm_max::Real)
-    solution_n = state_n + mu_n
+@inline function _empty_candidate(; state_n::Int=5, mu_n::Int=3, solution_n::Int=(state_n + mu_n), residual_norm_max::Real)
     return (
         solution=fill(NaN, solution_n),
         x_state=SVector{state_n}(fill(NaN, state_n)),
@@ -509,7 +508,7 @@ function _solve_constraint_fixedmu(
         end
 
         if !pushed
-            raw = _empty_candidate(; state_n=5, mu_n=3, residual_norm_max=residual_norm_max)
+            raw = _empty_candidate(; state_n=5, mu_n=3, solution_n=5, residual_norm_max=residual_norm_max)
             push!(candidates, (; raw..., seed_index=Int(seed_index)))
         end
     end

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -96,7 +96,7 @@ function _build_governed_attempt_plan(
         attempt_origin=:primary,
     ))
 
-    if primary_method != :trust_region && !(primary_use_fallback && fallback_method == :trust_region)
+    if primary_method != :trust_region
         push!(attempt_plan, (
             seed=primary_seed_vec,
             method=:trust_region,

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -759,13 +759,13 @@ end
         components = build_constraint_components(mode)
         extra_constraints = default_extra_constraints()
         forward_solve = if mode isa FixedRho
-            (model, T_fm; fwd_kwargs...) -> _fixedrho_problem_spec_forward_solve(model, mode, T_fm; extra_constraints=extra_constraints, fwd_kwargs...)
+            (model, T_fm; fwd_kwargs...) -> _fixedrho_problem_spec_forward_solve(model, mode, T_fm; fwd_kwargs...)
         elseif mode isa FixedEntropy
-            (model, T_fm; fwd_kwargs...) -> _fixedentropy_problem_spec_forward_solve(model, mode, T_fm; extra_constraints=extra_constraints, fwd_kwargs...)
+            (model, T_fm; fwd_kwargs...) -> _fixedentropy_problem_spec_forward_solve(model, mode, T_fm; fwd_kwargs...)
         elseif mode isa FixedSigma
-            (model, T_fm; fwd_kwargs...) -> _fixedsigma_problem_spec_forward_solve(model, mode, T_fm; extra_constraints=extra_constraints, fwd_kwargs...)
+            (model, T_fm; fwd_kwargs...) -> _fixedsigma_problem_spec_forward_solve(model, mode, T_fm; fwd_kwargs...)
         elseif mode isa FixedAsymmetricRho
-            (model, T_fm; fwd_kwargs...) -> _fixedasymrho_problem_spec_forward_solve(model, mode, T_fm; extra_constraints=extra_constraints, fwd_kwargs...)
+            (model, T_fm; fwd_kwargs...) -> _fixedasymrho_problem_spec_forward_solve(model, mode, T_fm; fwd_kwargs...)
         else
             (model, T_fm; fwd_kwargs...) -> solve_constraint(model, mode, T_fm; fwd_kwargs...)
         end

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -3,7 +3,41 @@
 
 约束问题契约：统一描述 mode、维度以及求解/后处理回调。
 """
-struct ProblemSpec{M,R,F,C,U,P,H,S}
+struct ExtraConstraints{R,F,S}
+    residual!::R
+    feasible::F
+    seed_extend::S
+end
+
+@inline _default_extra_residual!(F, x, theta, cfg, mode) = nothing
+@inline _default_extra_feasible(candidate, params, mode) = true
+@inline _default_seed_extend(seed, mode) = Float64.(seed)
+
+@inline function default_extra_constraints()
+    return ExtraConstraints(
+        _default_extra_residual!,
+        _default_extra_feasible,
+        _default_seed_extend,
+    )
+end
+
+@inline function _resolve_extra_constraints(kwargs)
+    extra = get(kwargs, :extra_constraints, default_extra_constraints())
+    extra isa ExtraConstraints || throw(ArgumentError("extra_constraints must be ExtraConstraints, got $(typeof(extra))"))
+    return extra
+end
+
+@inline function _extend_seed_with_extra(seed::AbstractVector{<:Real}, mode::ConstraintMode, extra::ExtraConstraints)
+    extended = extra.seed_extend(Float64.(seed), mode)
+    return Float64.(extended)
+end
+
+@inline function _append_extra_feasible_rule(rules, extra::ExtraConstraints, mode::ConstraintMode)
+    extra_rule = c -> (Bool(extra.feasible(c, nothing, mode)), :extra_constraint_failed)
+    return vcat(collect(rules), [extra_rule])
+end
+
+struct ProblemSpec{M,R,F,C,U,P,H,S,E}
     mode::M
     x_dim::Int
     theta_dim::Int
@@ -14,6 +48,7 @@ struct ProblemSpec{M,R,F,C,U,P,H,S}
     postprocess::P
     hard_rules::H
     selector::S
+    extra_constraints::E
 end
 
 @inline function ProblemSpec(
@@ -27,10 +62,18 @@ end
     postprocess=identity,
     hard_rules=default_hard_constraint_rules(),
     selector=select_pressure_max_candidate,
+    extra_constraints=default_extra_constraints(),
 )
     x_dim > 0 || throw(ArgumentError("x_dim must be positive, got $(x_dim)"))
     theta_dim > 0 || throw(ArgumentError("theta_dim must be positive, got $(theta_dim)"))
-    return ProblemSpec(mode, x_dim, theta_dim, residual!, forward_solve, conditions, unpack_solution, postprocess, hard_rules, selector)
+    wrapped_forward_solve = function (model, T_fm; fwd_kwargs...)
+        if haskey(fwd_kwargs, :extra_constraints)
+            return forward_solve(model, T_fm; fwd_kwargs...)
+        end
+        return forward_solve(model, T_fm; extra_constraints=extra_constraints, fwd_kwargs...)
+    end
+
+    return ProblemSpec(mode, x_dim, theta_dim, residual!, wrapped_forward_solve, conditions, unpack_solution, postprocess, hard_rules, selector, extra_constraints)
 end
 
 @inline _unimplemented_residual(F, x, theta, cfg, mode) = throw(ArgumentError("residual! is not configured for $(typeof(mode))"))
@@ -54,7 +97,7 @@ end
 end
 
 @inline function _strip_problemspec_forwardsolve_kwargs!(kwargs::Dict{Symbol,Any})
-    for key in (:seed_candidates, :hard_constraints, :semantic_mode, :selector, :fixedrho_joint_solve, :continuity_seed)
+    for key in (:seed_candidates, :hard_constraints, :semantic_mode, :selector, :fixedrho_joint_solve, :continuity_seed, :extra_constraints)
         delete!(kwargs, key)
     end
     return kwargs
@@ -236,6 +279,7 @@ end
 
 function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::FixedRho, T_fm::Real; fwd_kwargs...)
     kwargs = Dict{Symbol,Any}(pairs(fwd_kwargs))
+    extra_constraints = _resolve_extra_constraints(kwargs)
     fixedrho_joint_solve = get(kwargs, :fixedrho_joint_solve, true)
     fixedrho_joint_solve isa Bool || throw(ArgumentError("fixedrho_joint_solve must be Bool, got $(typeof(fixedrho_joint_solve))"))
     fixedrho_joint_solve || throw(ArgumentError("fixedrho_joint_solve=false is no longer supported; FixedRho uses joint solve only"))
@@ -250,7 +294,7 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
     end
     default_seed_pool = _build_default_seed_candidates(seed_guess)
 
-    primary_seed = Float64.(seed_guess)
+    primary_seed = _extend_seed_with_extra(Float64.(seed_guess), mode, extra_constraints)
     primary_method = if haskey(kwargs, :nlsolve_method)
         kwargs[:nlsolve_method]
     else
@@ -267,9 +311,9 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
     push!(seed_seen, primary_key)
 
     legacy_seed = if length(primary_seed) >= 5
-        Float64.(extend_seed(Float64.(primary_seed[1:5]), mode))
+        _extend_seed_with_extra(Float64.(extend_seed(Float64.(primary_seed[1:5]), mode)), mode, extra_constraints)
     else
-        Float64.(extend_seed(primary_seed, mode))
+        _extend_seed_with_extra(Float64.(extend_seed(primary_seed, mode)), mode, extra_constraints)
     end
     legacy_key = seed_key(legacy_seed)
     if !(legacy_key in seed_seen)
@@ -278,6 +322,7 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
     end
 
     for seed in provided_seed_pool
+        seed = _extend_seed_with_extra(seed, mode, extra_constraints)
         k = seed_key(seed)
         if !(k in seed_seen)
             push!(fallback_seeds, seed)
@@ -285,6 +330,7 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
         end
     end
     for seed in default_seed_pool
+        seed = _extend_seed_with_extra(seed, mode, extra_constraints)
         k = seed_key(seed)
         if !(k in seed_seen)
             push!(fallback_seeds, seed)
@@ -323,6 +369,7 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
 
     physicality_check = get(kwargs, :physicality_check, ((_, _) -> true))
     hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
+    hard_constraints = _append_extra_feasible_rule(hard_constraints, extra_constraints, mode)
 
     candidates = NamedTuple[]
     for (attempt_index, attempt_cfg) in enumerate(attempt_plan)
@@ -485,10 +532,18 @@ function _governed_mode_forward_solve(
     )
 end
 
-function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode::FixedEntropy, T_fm::Real; fwd_kwargs...)
-    kwargs = Dict{Symbol,Any}(pairs(fwd_kwargs))
+function _governed_nonrho_problem_spec_forward_solve(
+    model::AbstractQCDModel,
+    mode::ConstraintMode,
+    T_fm::Real,
+    kwargs::Dict{Symbol,Any},
+    mode_label::AbstractString,
+    attempt_origin_key::Symbol,
+    solve_mode_constraint::Function,
+)
+    extra_constraints = _resolve_extra_constraints(kwargs)
     seed_guess = get(kwargs, :seed_guess, nothing)
-    seed_guess === nothing && throw(ArgumentError("seed_guess is required for ProblemSpec FixedEntropy forward_solve"))
+    seed_guess === nothing && throw(ArgumentError("seed_guess is required for ProblemSpec $(mode_label) forward_solve"))
 
     provided_seed_pool = if haskey(kwargs, :seed_candidates)
         [Float64.(s) for s in kwargs[:seed_candidates]]
@@ -497,7 +552,7 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
     end
     default_seed_pool = _build_default_seed_candidates(seed_guess)
 
-    primary_seed = Float64.(seed_guess)
+    primary_seed = _extend_seed_with_extra(Float64.(seed_guess), mode, extra_constraints)
     primary_method = if haskey(kwargs, :nlsolve_method)
         kwargs[:nlsolve_method]
     else
@@ -513,6 +568,7 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
     push!(seed_seen, primary_key)
 
     for seed in provided_seed_pool
+        seed = _extend_seed_with_extra(seed, mode, extra_constraints)
         k = seed_key(seed)
         if !(k in seed_seen)
             push!(fallback_seeds, seed)
@@ -520,6 +576,7 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
         end
     end
     for seed in default_seed_pool
+        seed = _extend_seed_with_extra(seed, mode, extra_constraints)
         k = seed_key(seed)
         if !(k in seed_seen)
             push!(fallback_seeds, seed)
@@ -558,6 +615,7 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
 
     physicality_check = get(kwargs, :physicality_check, ((_, _) -> true))
     hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
+    hard_constraints = _append_extra_feasible_rule(hard_constraints, extra_constraints, mode)
 
     candidates = NamedTuple[]
     for (attempt_index, attempt_cfg) in enumerate(attempt_plan)
@@ -570,9 +628,10 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
             delete!(local_kwargs, :trust_region_fallback)
             delete!(local_kwargs, :fallback_method)
 
-            haskey(local_kwargs, :rho0) || throw(ArgumentError("rho0 is required for ProblemSpec FixedEntropy forward_solve"))
+            haskey(local_kwargs, :rho0) || throw(ArgumentError("rho0 is required for ProblemSpec $(mode_label) forward_solve"))
             local_kwargs[:allow_legacy_fallback] = Bool(get(kwargs, :allow_legacy_fallback, true))
-            solved = _solve_constraint_fixedentropy(model, T_fm, mode.s_target; pairs(local_kwargs)...)
+
+            solved = solve_mode_constraint(local_kwargs)
             solver_converged = Bool(solved.converged)
             attempt_quality = if solver_converged
                 :degraded
@@ -587,8 +646,8 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
                 governed_selected_quality=attempt_quality,
                 governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
                 governed_attempt_origin=attempt_cfg.attempt_origin,
-                entropy_attempt_origin=attempt_cfg.attempt_origin,
             )
+            raw = (; raw..., attempt_origin_key => attempt_cfg.attempt_origin)
             ok, failed = evaluate_hard_constraints(raw, hard_constraints)
             selected_quality = ok ? :good : raw.governed_selected_quality
             push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, governed_selected_quality=selected_quality, seed_index=Int(attempt_index)))
@@ -615,8 +674,8 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
                 governed_selected_quality=:bad,
                 governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
                 governed_attempt_origin=attempt_cfg.attempt_origin,
-                entropy_attempt_origin=attempt_cfg.attempt_origin,
             )
+            raw = (; raw..., attempt_origin_key => attempt_cfg.attempt_origin)
             push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
         end
     end
@@ -646,348 +705,60 @@ function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode:
         governed_selected_quality=(hasproperty(s, :governed_selected_quality) ? getproperty(s, :governed_selected_quality) : :bad),
         governed_fallback_used=(hasproperty(s, :governed_fallback_used) ? Bool(getproperty(s, :governed_fallback_used)) : false),
         legacy_fallback_used=(hasproperty(s, :legacy_fallback_used) ? Bool(getproperty(s, :legacy_fallback_used)) : false),
+    )
+end
+
+function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode::FixedEntropy, T_fm::Real; fwd_kwargs...)
+    kwargs = Dict{Symbol,Any}(pairs(fwd_kwargs))
+    return _governed_nonrho_problem_spec_forward_solve(
+        model,
+        mode,
+        T_fm,
+        kwargs,
+        "FixedEntropy",
+        :entropy_attempt_origin,
+        local_kwargs -> _solve_constraint_fixedentropy(model, T_fm, mode.s_target; pairs(local_kwargs)...),
     )
 end
 
 function _fixedsigma_problem_spec_forward_solve(model::AbstractQCDModel, mode::FixedSigma, T_fm::Real; fwd_kwargs...)
     kwargs = Dict{Symbol,Any}(pairs(fwd_kwargs))
-    seed_guess = get(kwargs, :seed_guess, nothing)
-    seed_guess === nothing && throw(ArgumentError("seed_guess is required for ProblemSpec FixedSigma forward_solve"))
-
-    provided_seed_pool = if haskey(kwargs, :seed_candidates)
-        [Float64.(s) for s in kwargs[:seed_candidates]]
-    else
-        Vector{Vector{Float64}}()
-    end
-    default_seed_pool = _build_default_seed_candidates(seed_guess)
-
-    primary_seed = Float64.(seed_guess)
-    primary_method = if haskey(kwargs, :nlsolve_method)
-        kwargs[:nlsolve_method]
-    else
-        Bool(get(kwargs, :continuity_seed, false)) ? :newton : :trust_region
-    end
-    primary_use_fallback = Bool(get(kwargs, :trust_region_fallback, true))
-    fallback_method = get(kwargs, :fallback_method, :trust_region)
-
-    fallback_seeds = Vector{Vector{Float64}}()
-    seed_seen = Set{String}()
-    seed_key(seed_vec::AbstractVector{<:Real}) = join(round.(Float64.(seed_vec); digits=12), ",")
-    primary_key = seed_key(primary_seed)
-    push!(seed_seen, primary_key)
-
-    for seed in provided_seed_pool
-        k = seed_key(seed)
-        if !(k in seed_seen)
-            push!(fallback_seeds, seed)
-            push!(seed_seen, k)
-        end
-    end
-    for seed in default_seed_pool
-        k = seed_key(seed)
-        if !(k in seed_seen)
-            push!(fallback_seeds, seed)
-            push!(seed_seen, k)
-        end
-    end
-
-    attempt_plan = NamedTuple[]
-    push!(attempt_plan, (
-        seed=primary_seed,
-        method=primary_method,
-        use_fallback=primary_use_fallback,
-        fallback_method=fallback_method,
-        attempt_origin=:primary,
-    ))
-
-    if primary_method != :trust_region
-        push!(attempt_plan, (
-            seed=primary_seed,
-            method=:trust_region,
-            use_fallback=false,
-            fallback_method=:trust_region,
-            attempt_origin=:method_rescue,
-        ))
-    end
-
-    for seed in fallback_seeds
-        push!(attempt_plan, (
-            seed=seed,
-            method=:trust_region,
-            use_fallback=false,
-            fallback_method=:trust_region,
-            attempt_origin=:seed_rescue,
-        ))
-    end
-
-    physicality_check = get(kwargs, :physicality_check, ((_, _) -> true))
-    hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
-
-    candidates = NamedTuple[]
-    for (attempt_index, attempt_cfg) in enumerate(attempt_plan)
-        local raw
-        try
-            local_kwargs = Dict{Symbol,Any}(kwargs)
-            local_kwargs[:seed_guess] = attempt_cfg.seed
-            local_kwargs[:nlsolve_method] = attempt_cfg.method
-            _strip_problemspec_forwardsolve_kwargs!(local_kwargs)
-            delete!(local_kwargs, :trust_region_fallback)
-            delete!(local_kwargs, :fallback_method)
-
-            haskey(local_kwargs, :rho0) || throw(ArgumentError("rho0 is required for ProblemSpec FixedSigma forward_solve"))
-            local_kwargs[:allow_legacy_fallback] = Bool(get(kwargs, :allow_legacy_fallback, true))
-            solved = _solve_constraint_fixedsigma(model, T_fm, mode.sigma_target; pairs(local_kwargs)...)
-            solver_converged = Bool(solved.converged)
-            attempt_quality = if solver_converged
-                :degraded
-            else
-                :bad
-            end
-            raw = (
-                ; solved...,
-                residual_norm_max=get(local_kwargs, :residual_norm_max, 1e-6),
-                solver_converged=solver_converged,
-                governed_selected_method=attempt_cfg.method,
-                governed_selected_quality=attempt_quality,
-                governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
-                governed_attempt_origin=attempt_cfg.attempt_origin,
-                sigma_attempt_origin=attempt_cfg.attempt_origin,
-            )
-            ok, failed = evaluate_hard_constraints(raw, hard_constraints)
-            selected_quality = ok ? :good : raw.governed_selected_quality
-            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, governed_selected_quality=selected_quality, seed_index=Int(attempt_index)))
-            if ok
-                break
-            end
-        catch
-            raw = (
-                converged=false,
-                solution=Float64[],
-                x_state=zeros(5),
-                mu_vec=zeros(3),
-                omega=NaN,
-                pressure=-Inf,
-                rho_norm=NaN,
-                entropy=NaN,
-                energy=NaN,
-                masses=zeros(3),
-                iterations=0,
-                residual_norm=Inf,
-                residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
-                solver_converged=false,
-                governed_selected_method=attempt_cfg.method,
-                governed_selected_quality=:bad,
-                governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
-                governed_attempt_origin=attempt_cfg.attempt_origin,
-                sigma_attempt_origin=attempt_cfg.attempt_origin,
-            )
-            push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
-        end
-    end
-
-    selector_fn = _resolve_candidate_selector(kwargs)
-    selected = selector_fn(candidates)
-    s = selected.selected_candidate
-    return (
-        converged=Bool(s.converged),
-        solution=Vector{Float64}(s.solution),
-        x_state=s.x_state,
-        mu_vec=s.mu_vec,
-        omega=s.omega,
-        pressure=s.pressure,
-        rho_norm=s.rho_norm,
-        entropy=s.entropy,
-        energy=s.energy,
-        masses=s.masses,
-        iterations=s.iterations,
-        residual_norm=s.residual_norm,
-        hard_constraint_ok=s.hard_constraint_ok,
-        failed_constraints=s.failed_constraints,
-        selection_reason=selected.selection_reason,
-        selected_index=selected.selected_index,
-        candidate_count=length(candidates),
-        governed_selected_method=(hasproperty(s, :governed_selected_method) ? getproperty(s, :governed_selected_method) : :none),
-        governed_selected_quality=(hasproperty(s, :governed_selected_quality) ? getproperty(s, :governed_selected_quality) : :bad),
-        governed_fallback_used=(hasproperty(s, :governed_fallback_used) ? Bool(getproperty(s, :governed_fallback_used)) : false),
-        legacy_fallback_used=(hasproperty(s, :legacy_fallback_used) ? Bool(getproperty(s, :legacy_fallback_used)) : false),
+    return _governed_nonrho_problem_spec_forward_solve(
+        model,
+        mode,
+        T_fm,
+        kwargs,
+        "FixedSigma",
+        :sigma_attempt_origin,
+        local_kwargs -> _solve_constraint_fixedsigma(model, T_fm, mode.sigma_target; pairs(local_kwargs)...),
     )
 end
 
 function _fixedasymrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::FixedAsymmetricRho, T_fm::Real; fwd_kwargs...)
     kwargs = Dict{Symbol,Any}(pairs(fwd_kwargs))
-    seed_guess = get(kwargs, :seed_guess, nothing)
-    seed_guess === nothing && throw(ArgumentError("seed_guess is required for ProblemSpec FixedAsymmetricRho forward_solve"))
-
-    provided_seed_pool = if haskey(kwargs, :seed_candidates)
-        [Float64.(s) for s in kwargs[:seed_candidates]]
-    else
-        Vector{Vector{Float64}}()
-    end
-    default_seed_pool = _build_default_seed_candidates(seed_guess)
-
-    primary_seed = Float64.(seed_guess)
-    primary_method = if haskey(kwargs, :nlsolve_method)
-        kwargs[:nlsolve_method]
-    else
-        Bool(get(kwargs, :continuity_seed, false)) ? :newton : :trust_region
-    end
-    primary_use_fallback = Bool(get(kwargs, :trust_region_fallback, true))
-    fallback_method = get(kwargs, :fallback_method, :trust_region)
-
-    fallback_seeds = Vector{Vector{Float64}}()
-    seed_seen = Set{String}()
-    seed_key(seed_vec::AbstractVector{<:Real}) = join(round.(Float64.(seed_vec); digits=12), ",")
-    primary_key = seed_key(primary_seed)
-    push!(seed_seen, primary_key)
-
-    for seed in provided_seed_pool
-        k = seed_key(seed)
-        if !(k in seed_seen)
-            push!(fallback_seeds, seed)
-            push!(seed_seen, k)
-        end
-    end
-    for seed in default_seed_pool
-        k = seed_key(seed)
-        if !(k in seed_seen)
-            push!(fallback_seeds, seed)
-            push!(seed_seen, k)
-        end
-    end
-
-    attempt_plan = NamedTuple[]
-    push!(attempt_plan, (
-        seed=primary_seed,
-        method=primary_method,
-        use_fallback=primary_use_fallback,
-        fallback_method=fallback_method,
-        attempt_origin=:primary,
-    ))
-
-    if primary_method != :trust_region
-        push!(attempt_plan, (
-            seed=primary_seed,
-            method=:trust_region,
-            use_fallback=false,
-            fallback_method=:trust_region,
-            attempt_origin=:method_rescue,
-        ))
-    end
-
-    for seed in fallback_seeds
-        push!(attempt_plan, (
-            seed=seed,
-            method=:trust_region,
-            use_fallback=false,
-            fallback_method=:trust_region,
-            attempt_origin=:seed_rescue,
-        ))
-    end
-
-    physicality_check = get(kwargs, :physicality_check, ((_, _) -> true))
-    hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
-
-    candidates = NamedTuple[]
-    for (attempt_index, attempt_cfg) in enumerate(attempt_plan)
-        local raw
-        try
-            local_kwargs = Dict{Symbol,Any}(kwargs)
-            local_kwargs[:seed_guess] = attempt_cfg.seed
-            local_kwargs[:nlsolve_method] = attempt_cfg.method
-            _strip_problemspec_forwardsolve_kwargs!(local_kwargs)
-            delete!(local_kwargs, :trust_region_fallback)
-            delete!(local_kwargs, :fallback_method)
-
-            haskey(local_kwargs, :rho0) || throw(ArgumentError("rho0 is required for ProblemSpec FixedAsymmetricRho forward_solve"))
-            local_kwargs[:allow_legacy_fallback] = Bool(get(kwargs, :allow_legacy_fallback, true))
-            solved = _solve_constraint_fixedasymrho(model, T_fm, mode.rho_target, mode.ud_ratio_target, mode.s_target; pairs(local_kwargs)...)
-            solver_converged = Bool(solved.converged)
-            attempt_quality = if solver_converged
-                :degraded
-            else
-                :bad
-            end
-            raw = (
-                ; solved...,
-                residual_norm_max=get(local_kwargs, :residual_norm_max, 1e-6),
-                solver_converged=solver_converged,
-                governed_selected_method=attempt_cfg.method,
-                governed_selected_quality=attempt_quality,
-                governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
-                governed_attempt_origin=attempt_cfg.attempt_origin,
-                asym_attempt_origin=attempt_cfg.attempt_origin,
-            )
-            ok, failed = evaluate_hard_constraints(raw, hard_constraints)
-            selected_quality = ok ? :good : raw.governed_selected_quality
-            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, governed_selected_quality=selected_quality, seed_index=Int(attempt_index)))
-            if ok
-                break
-            end
-        catch
-            raw = (
-                converged=false,
-                solution=Float64[],
-                x_state=zeros(5),
-                mu_vec=zeros(3),
-                omega=NaN,
-                pressure=-Inf,
-                rho_norm=NaN,
-                entropy=NaN,
-                energy=NaN,
-                masses=zeros(3),
-                iterations=0,
-                residual_norm=Inf,
-                residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
-                solver_converged=false,
-                governed_selected_method=attempt_cfg.method,
-                governed_selected_quality=:bad,
-                governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
-                governed_attempt_origin=attempt_cfg.attempt_origin,
-                asym_attempt_origin=attempt_cfg.attempt_origin,
-            )
-            push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
-        end
-    end
-
-    selector_fn = _resolve_candidate_selector(kwargs)
-    selected = selector_fn(candidates)
-    s = selected.selected_candidate
-    return (
-        converged=Bool(s.converged),
-        solution=Vector{Float64}(s.solution),
-        x_state=s.x_state,
-        mu_vec=s.mu_vec,
-        omega=s.omega,
-        pressure=s.pressure,
-        rho_norm=s.rho_norm,
-        entropy=s.entropy,
-        energy=s.energy,
-        masses=s.masses,
-        iterations=s.iterations,
-        residual_norm=s.residual_norm,
-        hard_constraint_ok=s.hard_constraint_ok,
-        failed_constraints=s.failed_constraints,
-        selection_reason=selected.selection_reason,
-        selected_index=selected.selected_index,
-        candidate_count=length(candidates),
-        governed_selected_method=(hasproperty(s, :governed_selected_method) ? getproperty(s, :governed_selected_method) : :none),
-        governed_selected_quality=(hasproperty(s, :governed_selected_quality) ? getproperty(s, :governed_selected_quality) : :bad),
-        governed_fallback_used=(hasproperty(s, :governed_fallback_used) ? Bool(getproperty(s, :governed_fallback_used)) : false),
-        legacy_fallback_used=(hasproperty(s, :legacy_fallback_used) ? Bool(getproperty(s, :legacy_fallback_used)) : false),
+    return _governed_nonrho_problem_spec_forward_solve(
+        model,
+        mode,
+        T_fm,
+        kwargs,
+        "FixedAsymmetricRho",
+        :asym_attempt_origin,
+        local_kwargs -> _solve_constraint_fixedasymrho(model, T_fm, mode.rho_target, mode.ud_ratio_target, mode.s_target; pairs(local_kwargs)...),
     )
 end
 
 @inline function build_problem_spec(mode::ConstraintMode; kwargs...)
     if isempty(kwargs)
         components = build_constraint_components(mode)
+        extra_constraints = default_extra_constraints()
         forward_solve = if mode isa FixedRho
-            (model, T_fm; fwd_kwargs...) -> _fixedrho_problem_spec_forward_solve(model, mode, T_fm; fwd_kwargs...)
+            (model, T_fm; fwd_kwargs...) -> _fixedrho_problem_spec_forward_solve(model, mode, T_fm; extra_constraints=extra_constraints, fwd_kwargs...)
         elseif mode isa FixedEntropy
-            (model, T_fm; fwd_kwargs...) -> _fixedentropy_problem_spec_forward_solve(model, mode, T_fm; fwd_kwargs...)
+            (model, T_fm; fwd_kwargs...) -> _fixedentropy_problem_spec_forward_solve(model, mode, T_fm; extra_constraints=extra_constraints, fwd_kwargs...)
         elseif mode isa FixedSigma
-            (model, T_fm; fwd_kwargs...) -> _fixedsigma_problem_spec_forward_solve(model, mode, T_fm; fwd_kwargs...)
+            (model, T_fm; fwd_kwargs...) -> _fixedsigma_problem_spec_forward_solve(model, mode, T_fm; extra_constraints=extra_constraints, fwd_kwargs...)
         elseif mode isa FixedAsymmetricRho
-            (model, T_fm; fwd_kwargs...) -> _fixedasymrho_problem_spec_forward_solve(model, mode, T_fm; fwd_kwargs...)
+            (model, T_fm; fwd_kwargs...) -> _fixedasymrho_problem_spec_forward_solve(model, mode, T_fm; extra_constraints=extra_constraints, fwd_kwargs...)
         else
             (model, T_fm; fwd_kwargs...) -> solve_constraint(model, mode, T_fm; fwd_kwargs...)
         end
@@ -996,6 +767,7 @@ end
             x_dim=constraint_total_dim(components),
             conditions=params -> build_conditions(mode, params),
             forward_solve=forward_solve,
+            extra_constraints=extra_constraints,
         )
     end
     return ProblemSpec(mode; kwargs...)

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -37,6 +37,88 @@ end
     return vcat(collect(rules), [extra_rule])
 end
 
+@inline function _seed_key(seed_vec::AbstractVector{<:Real})
+    return join(round.(Float64.(seed_vec); digits=12), ",")
+end
+
+function _build_governed_attempt_plan(
+    mode::ConstraintMode,
+    primary_seed::AbstractVector{<:Real},
+    provided_seed_pool,
+    default_seed_pool,
+    extra_constraints::ExtraConstraints;
+    primary_method,
+    primary_use_fallback::Bool,
+    fallback_method,
+    extra_fallback_seeds=Vector{Vector{Float64}}(),
+)
+    primary_seed_vec = _extend_seed_with_extra(Float64.(primary_seed), mode, extra_constraints)
+
+    fallback_seeds = Vector{Vector{Float64}}()
+    seed_seen = Set{String}()
+
+    primary_key = _seed_key(primary_seed_vec)
+    push!(seed_seen, primary_key)
+
+    for seed in extra_fallback_seeds
+        normalized_seed = _extend_seed_with_extra(seed, mode, extra_constraints)
+        key = _seed_key(normalized_seed)
+        if !(key in seed_seen)
+            push!(fallback_seeds, normalized_seed)
+            push!(seed_seen, key)
+        end
+    end
+
+    for seed in provided_seed_pool
+        normalized_seed = _extend_seed_with_extra(seed, mode, extra_constraints)
+        key = _seed_key(normalized_seed)
+        if !(key in seed_seen)
+            push!(fallback_seeds, normalized_seed)
+            push!(seed_seen, key)
+        end
+    end
+
+    for seed in default_seed_pool
+        normalized_seed = _extend_seed_with_extra(seed, mode, extra_constraints)
+        key = _seed_key(normalized_seed)
+        if !(key in seed_seen)
+            push!(fallback_seeds, normalized_seed)
+            push!(seed_seen, key)
+        end
+    end
+
+    attempt_plan = NamedTuple[]
+    push!(attempt_plan, (
+        seed=primary_seed_vec,
+        method=primary_method,
+        use_fallback=primary_use_fallback,
+        fallback_method=fallback_method,
+        attempt_origin=:primary,
+    ))
+
+    if primary_method != :trust_region && !(primary_use_fallback && fallback_method == :trust_region)
+        push!(attempt_plan, (
+            seed=primary_seed_vec,
+            method=:trust_region,
+            use_fallback=false,
+            fallback_method=:trust_region,
+            attempt_origin=:method_rescue,
+        ))
+    end
+
+    for seed in fallback_seeds
+        push!(attempt_plan, (
+            seed=seed,
+            method=:trust_region,
+            use_fallback=false,
+            fallback_method=:trust_region,
+            attempt_origin=:seed_rescue,
+        ))
+    end
+
+    return attempt_plan
+end
+
 struct ProblemSpec{M,R,F,C,U,P,H,S,E}
     mode::M
     x_dim::Int
@@ -294,7 +376,7 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
     end
     default_seed_pool = _build_default_seed_candidates(seed_guess)
 
-    primary_seed = _extend_seed_with_extra(Float64.(seed_guess), mode, extra_constraints)
+    primary_seed = Float64.(seed_guess)
     primary_method = if haskey(kwargs, :nlsolve_method)
         kwargs[:nlsolve_method]
     else
@@ -303,69 +385,22 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
     primary_use_fallback = Bool(get(kwargs, :trust_region_fallback, true))
     fallback_method = get(kwargs, :fallback_method, :trust_region)
 
-    fallback_seeds = Vector{Vector{Float64}}()
-    seed_seen = Set{String}()
-    seed_key(seed_vec::AbstractVector{<:Real}) = join(round.(Float64.(seed_vec); digits=12), ",")
-
-    primary_key = seed_key(primary_seed)
-    push!(seed_seen, primary_key)
-
     legacy_seed = if length(primary_seed) >= 5
         _extend_seed_with_extra(Float64.(extend_seed(Float64.(primary_seed[1:5]), mode)), mode, extra_constraints)
     else
         _extend_seed_with_extra(Float64.(extend_seed(primary_seed, mode)), mode, extra_constraints)
     end
-    legacy_key = seed_key(legacy_seed)
-    if !(legacy_key in seed_seen)
-        push!(fallback_seeds, legacy_seed)
-        push!(seed_seen, legacy_key)
-    end
-
-    for seed in provided_seed_pool
-        seed = _extend_seed_with_extra(seed, mode, extra_constraints)
-        k = seed_key(seed)
-        if !(k in seed_seen)
-            push!(fallback_seeds, seed)
-            push!(seed_seen, k)
-        end
-    end
-    for seed in default_seed_pool
-        seed = _extend_seed_with_extra(seed, mode, extra_constraints)
-        k = seed_key(seed)
-        if !(k in seed_seen)
-            push!(fallback_seeds, seed)
-            push!(seed_seen, k)
-        end
-    end
-
-    attempt_plan = NamedTuple[]
-    push!(attempt_plan, (
-        seed=primary_seed,
-        method=primary_method,
-        use_fallback=primary_use_fallback,
+    attempt_plan = _build_governed_attempt_plan(
+        mode,
+        primary_seed,
+        provided_seed_pool,
+        default_seed_pool,
+        extra_constraints;
+        primary_method=primary_method,
+        primary_use_fallback=primary_use_fallback,
         fallback_method=fallback_method,
-        attempt_origin=:primary,
-    ))
-
-    if primary_method != :trust_region
-        push!(attempt_plan, (
-            seed=primary_seed,
-            method=:trust_region,
-            use_fallback=false,
-            fallback_method=:trust_region,
-            attempt_origin=:method_rescue,
-        ))
-    end
-
-    for seed in fallback_seeds
-        push!(attempt_plan, (
-            seed=seed,
-            method=:trust_region,
-            use_fallback=false,
-            fallback_method=:trust_region,
-            attempt_origin=:seed_rescue,
-        ))
-    end
+        extra_fallback_seeds=[legacy_seed],
+    )
 
     physicality_check = get(kwargs, :physicality_check, ((_, _) -> true))
     hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
@@ -552,7 +587,7 @@ function _governed_nonrho_problem_spec_forward_solve(
     end
     default_seed_pool = _build_default_seed_candidates(seed_guess)
 
-    primary_seed = _extend_seed_with_extra(Float64.(seed_guess), mode, extra_constraints)
+    primary_seed = Float64.(seed_guess)
     primary_method = if haskey(kwargs, :nlsolve_method)
         kwargs[:nlsolve_method]
     else
@@ -561,57 +596,16 @@ function _governed_nonrho_problem_spec_forward_solve(
     primary_use_fallback = Bool(get(kwargs, :trust_region_fallback, true))
     fallback_method = get(kwargs, :fallback_method, :trust_region)
 
-    fallback_seeds = Vector{Vector{Float64}}()
-    seed_seen = Set{String}()
-    seed_key(seed_vec::AbstractVector{<:Real}) = join(round.(Float64.(seed_vec); digits=12), ",")
-    primary_key = seed_key(primary_seed)
-    push!(seed_seen, primary_key)
-
-    for seed in provided_seed_pool
-        seed = _extend_seed_with_extra(seed, mode, extra_constraints)
-        k = seed_key(seed)
-        if !(k in seed_seen)
-            push!(fallback_seeds, seed)
-            push!(seed_seen, k)
-        end
-    end
-    for seed in default_seed_pool
-        seed = _extend_seed_with_extra(seed, mode, extra_constraints)
-        k = seed_key(seed)
-        if !(k in seed_seen)
-            push!(fallback_seeds, seed)
-            push!(seed_seen, k)
-        end
-    end
-
-    attempt_plan = NamedTuple[]
-    push!(attempt_plan, (
-        seed=primary_seed,
-        method=primary_method,
-        use_fallback=primary_use_fallback,
+    attempt_plan = _build_governed_attempt_plan(
+        mode,
+        primary_seed,
+        provided_seed_pool,
+        default_seed_pool,
+        extra_constraints;
+        primary_method=primary_method,
+        primary_use_fallback=primary_use_fallback,
         fallback_method=fallback_method,
-        attempt_origin=:primary,
-    ))
-
-    if primary_method != :trust_region
-        push!(attempt_plan, (
-            seed=primary_seed,
-            method=:trust_region,
-            use_fallback=false,
-            fallback_method=:trust_region,
-            attempt_origin=:method_rescue,
-        ))
-    end
-
-    for seed in fallback_seeds
-        push!(attempt_plan, (
-            seed=seed,
-            method=:trust_region,
-            use_fallback=false,
-            fallback_method=:trust_region,
-            attempt_origin=:seed_rescue,
-        ))
-    end
+    )
 
     physicality_check = get(kwargs, :physicality_check, ((_, _) -> true))
     hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -406,19 +406,16 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
     hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
     hard_constraints = _append_extra_feasible_rule(hard_constraints, extra_constraints, mode)
 
-    candidates = NamedTuple[]
-    for (attempt_index, attempt_cfg) in enumerate(attempt_plan)
-        local raw
-        try
-            local_kwargs = Dict{Symbol,Any}(kwargs)
-            local_kwargs[:seed_guess] = attempt_cfg.seed
-            local_kwargs[:nlsolve_method] = attempt_cfg.method
-            local_kwargs[:trust_region_fallback] = attempt_cfg.use_fallback
-            local_kwargs[:fallback_method] = attempt_cfg.fallback_method
+    selector_fn = _resolve_candidate_selector(kwargs)
+    selected, candidates = _execute_governed_attempt_plan(
+        attempt_plan,
+        kwargs,
+        hard_constraints,
+        selector_fn,
+        function (local_kwargs, attempt_cfg, _)
             _strip_problemspec_forwardsolve_kwargs!(local_kwargs)
-
             solved = _fixedrho_joint_problem_spec_forward_solve(model, mode, T_fm; pairs(local_kwargs)...)
-            raw = (
+            return (
                 converged=Bool(solved.converged),
                 solution=Float64.(solved.solution),
                 x_state=solved.x_state,
@@ -440,13 +437,9 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
                 fixedrho_joint_fallback_used=get(solved, :fixedrho_joint_fallback_used, false),
                 fixedrho_joint_attempt_origin=attempt_cfg.attempt_origin,
             )
-            ok, failed = evaluate_hard_constraints(raw, hard_constraints)
-            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, seed_index=Int(attempt_index)))
-            if ok
-                break
-            end
-        catch
-            raw = (
+        end,
+        function (base_kwargs, attempt_cfg, _)
+            return (
                 converged=false,
                 solution=Float64[],
                 x_state=zeros(5),
@@ -459,7 +452,7 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
                 masses=zeros(3),
                 iterations=0,
                 residual_norm=Inf,
-                residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
+                residual_norm_max=Float64(get(base_kwargs, :residual_norm_max, 1e-6)),
                 fixedrho_joint_solve_requested=fixedrho_joint_solve,
                 fixedrho_joint_solve_active=false,
                 fixedrho_joint_fallback=false,
@@ -468,12 +461,8 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
                 fixedrho_joint_fallback_used=false,
                 fixedrho_joint_attempt_origin=attempt_cfg.attempt_origin,
             )
-            push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
-        end
-    end
-
-    selector_fn = _resolve_candidate_selector(kwargs)
-    selected = selector_fn(candidates)
+        end,
+    )
     s = selected.selected_candidate
     return (
         converged=Bool(s.converged),
@@ -567,6 +556,39 @@ function _governed_mode_forward_solve(
     )
 end
 
+function _execute_governed_attempt_plan(
+    attempt_plan,
+    kwargs::Dict{Symbol,Any},
+    hard_constraints,
+    selector_fn::Function,
+    solve_attempt::Function,
+    failure_attempt::Function,
+)
+    candidates = NamedTuple[]
+    for (attempt_index, attempt_cfg) in enumerate(attempt_plan)
+        try
+            local_kwargs = Dict{Symbol,Any}(kwargs)
+            local_kwargs[:seed_guess] = attempt_cfg.seed
+            local_kwargs[:nlsolve_method] = attempt_cfg.method
+            local_kwargs[:trust_region_fallback] = attempt_cfg.use_fallback
+            local_kwargs[:fallback_method] = attempt_cfg.fallback_method
+
+            raw = solve_attempt(local_kwargs, attempt_cfg, attempt_index)
+            ok, failed = evaluate_hard_constraints(raw, hard_constraints)
+            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, seed_index=Int(attempt_index)))
+            if ok
+                break
+            end
+        catch
+            raw = failure_attempt(kwargs, attempt_cfg, attempt_index)
+            push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
+        end
+    end
+
+    selected = selector_fn(candidates)
+    return selected, candidates
+end
+
 function _governed_nonrho_problem_spec_forward_solve(
     model::AbstractQCDModel,
     mode::ConstraintMode,
@@ -611,13 +633,13 @@ function _governed_nonrho_problem_spec_forward_solve(
     hard_constraints = get(kwargs, :hard_constraints, default_hard_constraint_rules(; physicality_check=physicality_check))
     hard_constraints = _append_extra_feasible_rule(hard_constraints, extra_constraints, mode)
 
-    candidates = NamedTuple[]
-    for (attempt_index, attempt_cfg) in enumerate(attempt_plan)
-        local raw
-        try
-            local_kwargs = Dict{Symbol,Any}(kwargs)
-            local_kwargs[:seed_guess] = attempt_cfg.seed
-            local_kwargs[:nlsolve_method] = attempt_cfg.method
+    selector_fn = _resolve_candidate_selector(kwargs)
+    selected, candidates = _execute_governed_attempt_plan(
+        attempt_plan,
+        kwargs,
+        hard_constraints,
+        selector_fn,
+        function (local_kwargs, attempt_cfg, _)
             _strip_problemspec_forwardsolve_kwargs!(local_kwargs)
             delete!(local_kwargs, :trust_region_fallback)
             delete!(local_kwargs, :fallback_method)
@@ -641,14 +663,9 @@ function _governed_nonrho_problem_spec_forward_solve(
                 governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
                 governed_attempt_origin=attempt_cfg.attempt_origin,
             )
-            raw = (; raw..., attempt_origin_key => attempt_cfg.attempt_origin)
-            ok, failed = evaluate_hard_constraints(raw, hard_constraints)
-            selected_quality = ok ? :good : raw.governed_selected_quality
-            push!(candidates, (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, governed_selected_quality=selected_quality, seed_index=Int(attempt_index)))
-            if ok
-                break
-            end
-        catch
+            return (; raw..., attempt_origin_key => attempt_cfg.attempt_origin)
+        end,
+        function (base_kwargs, attempt_cfg, _)
             raw = (
                 converged=false,
                 solution=Float64[],
@@ -662,20 +679,16 @@ function _governed_nonrho_problem_spec_forward_solve(
                 masses=zeros(3),
                 iterations=0,
                 residual_norm=Inf,
-                residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
+                residual_norm_max=Float64(get(base_kwargs, :residual_norm_max, 1e-6)),
                 solver_converged=false,
                 governed_selected_method=attempt_cfg.method,
                 governed_selected_quality=:bad,
                 governed_fallback_used=(attempt_cfg.attempt_origin == :method_rescue),
                 governed_attempt_origin=attempt_cfg.attempt_origin,
             )
-            raw = (; raw..., attempt_origin_key => attempt_cfg.attempt_origin)
-            push!(candidates, (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index)))
-        end
-    end
-
-    selector_fn = _resolve_candidate_selector(kwargs)
-    selected = selector_fn(candidates)
+            return (; raw..., attempt_origin_key => attempt_cfg.attempt_origin)
+        end,
+    )
     s = selected.selected_candidate
     return (
         converged=Bool(s.converged),

--- a/tests/unit/models/test_constraint_solver.jl
+++ b/tests/unit/models/test_constraint_solver.jl
@@ -60,6 +60,10 @@ Models.pnjl_module()
         @test all(isnan, empty_candidate.solution)
         @test empty_candidate.failed_constraints == [:solver_failed]
         @test !empty_candidate.converged
+
+        fixedmu_empty = Models._empty_candidate(state_n=5, mu_n=3, solution_n=5, residual_norm_max=1e-6)
+        @test length(fixedmu_empty.solution) == 5
+        @test all(isnan, fixedmu_empty.solution)
     end
 
     @testset "solve_constraint(FixedMu) NJL" begin

--- a/tests/unit/models/test_problem_spec_contract.jl
+++ b/tests/unit/models/test_problem_spec_contract.jl
@@ -39,6 +39,60 @@ end
         end
     end
 
+    @testset "problem spec extra constraints shell contract" begin
+        @test isdefined(Models, :ExtraConstraints)
+        @test isdefined(Models, :default_extra_constraints)
+
+        mode = Models.FixedEntropy(0.5)
+        spec = Models.build_problem_spec(mode)
+        @test hasproperty(spec, :extra_constraints)
+
+        ec = spec.extra_constraints
+        @test ec isa Models.ExtraConstraints
+
+        seed = [-1.5, -1.5, -2.1, 0.2, 0.2, 1.5, 1.5, 1.5]
+        @test ec.seed_extend(seed, mode) == Float64.(seed)
+        @test ec.feasible((; converged=true), (;), mode)
+
+        residual_vec = zeros(Float64, 0)
+        ec.residual!(residual_vec, Float64[], Float64[], (;), mode)
+        @test isempty(residual_vec)
+    end
+
+    @testset "problem spec extra constraints hooks are wired in forward_solve" begin
+        model = Models.create_model(:PNJL)
+        mode = Models.FixedEntropy(0.5)
+        T_fm = 100.0 / 197.327
+        seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
+        seed_extend_calls = Ref(0)
+        ec = Models.ExtraConstraints(
+            (F, x, theta, cfg, mode) -> nothing,
+            (candidate, params, mode) -> false,
+            (seed_vec, mode) -> begin
+                seed_extend_calls[] += 1
+                return Float64.(seed_vec)
+            end,
+        )
+
+        spec = Models.build_problem_spec(mode)
+        solved = spec.forward_solve(
+            model,
+            T_fm;
+            extra_constraints=ec,
+            seed_guess=seed,
+            rho0=0.16,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+            iterations=120,
+        )
+
+        @test seed_extend_calls[] >= 1
+        @test solved.hard_constraint_ok == false
+        @test :extra_constraint_failed in solved.failed_constraints
+    end
+
     @testset "fixedrho spec conditions and forward solve are wired" begin
         model = Models.create_model(:PNJL)
         mode = Models.FixedRho(0.2)
@@ -457,6 +511,40 @@ end
             iterations=120,
         )
         @test custom.selection_reason == :custom_selector
+    end
+
+    @testset "fixedasymrho forward_solve accepts extra_constraints hook" begin
+        model = Models.create_model(:PNJL)
+        mode = Models.FixedAsymmetricRho(0.05, 1.0, 0.0)
+        spec = Models.build_problem_spec(mode)
+        T_fm = 100.0 / 197.327
+        seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
+        seed_extend_calls = Ref(0)
+        ec = Models.ExtraConstraints(
+            (F, x, theta, cfg, mode) -> nothing,
+            (candidate, params, mode) -> false,
+            (seed_vec, mode) -> begin
+                seed_extend_calls[] += 1
+                return Float64.(seed_vec)
+            end,
+        )
+
+        solved = spec.forward_solve(
+            model,
+            T_fm;
+            extra_constraints=ec,
+            seed_guess=seed,
+            rho0=0.16,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+            iterations=120,
+        )
+
+        @test seed_extend_calls[] >= 1
+        @test solved.hard_constraint_ok == false
+        @test :extra_constraint_failed in solved.failed_constraints
     end
 
     @testset "build_conditions schema path parity for non-rho modes" begin

--- a/tests/unit/models/test_problem_spec_contract.jl
+++ b/tests/unit/models/test_problem_spec_contract.jl
@@ -113,6 +113,39 @@ end
         @test haskey(solved, :fixedrho_joint_solve_active)
     end
 
+    @testset "fixedrho forward_solve accepts extra_constraints hook" begin
+        model = Models.create_model(:PNJL)
+        mode = Models.FixedRho(0.2)
+        spec = Models.build_problem_spec(mode)
+        T_fm = 100.0 / 197.327
+        seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
+        seed_extend_calls = Ref(0)
+        ec = Models.ExtraConstraints(
+            (F, x, theta, cfg, mode) -> nothing,
+            (candidate, params, mode) -> false,
+            (seed_vec, mode) -> begin
+                seed_extend_calls[] += 1
+                return Float64.(seed_vec)
+            end,
+        )
+
+        solved = spec.forward_solve(
+            model,
+            T_fm;
+            extra_constraints=ec,
+            seed_guess=seed,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+            iterations=120,
+        )
+
+        @test seed_extend_calls[] >= 1
+        @test solved.hard_constraint_ok == false
+        @test :extra_constraint_failed in solved.failed_constraints
+    end
+
     @testset "fixedrho forward_solve accepts joint-solve flag" begin
         model = Models.create_model(:PNJL)
         mode = Models.FixedRho(0.2)


### PR DESCRIPTION
## Summary
- introduce `ExtraConstraints` into the ProblemSpec contract with default no-op behavior
- thread `seed_extend` and `feasible` hooks through governed solving
- unify non-FixedRho modes under shared governed execution while aligning FixedRho outer planning/execution layers to the same abstractions
- keep the FixedRho joint-solve kernel intact, extracting shared attempt-plan and candidate-executor scaffolding

## Scope
- in scope: architectural unification and constraint extensibility after PR2 merge
- out of scope: changing the numerical target semantics established in PR1+PR2

## Why
This PR is the final stacked step: represent mode differences via composable extra constraints instead of duplicated orchestration branches.

## Validation
- rely on GitHub CI as source of truth for current stacked state
- historical local checks for this branch line:
  - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_contract.jl"; include("tests/unit/runtests.jl")'`
  - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl"; include("tests/unit/runtests.jl")'`
  - `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_problem_spec_semantic_modes.jl"; include("tests/unit/runtests.jl")'`
  - `julia --project=. -e 'include("tests/integration/pnjl/test_solver_constraints_models_backend_smoke.jl")'`
