### PR TITLE
refactor(models/solver): unify shared core residual path for NJL implicit adapters

### DIFF
--- a/docs/dev/active/2026-04-07_mode-schema_unified-residual-kernel_followup-plan.md
+++ b/docs/dev/active/2026-04-07_mode-schema_unified-residual-kernel_followup-plan.md
@@ -1,60 +1,246 @@
-# ModeSchema 与统一残差内核最小兼容方案（后续任务草案）
+# ModeSchema 与统一残差内核实施任务单
 
-## 背景
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-- 在 PR #56 / #57 基线下，solver 主链已经收敛到 `ProblemSpec` + governed root path。
-- 当前下一阶段关注点是：不同求解模式（`FixedMu`、`FixedRho`、`FixedEntropy`、`FixedSigma`、`FixedAsymmetricRho`）自变量类型与维度不一致，如何在不复制求解内核的前提下最小兼容。
+**Goal:** 在不改动物理公式的前提下，将 `models` 中 solver/implicit 残差路径收口为单一 base 内核，并以 schema 驱动命名输入与向量输入转换。
 
-## 设计结论（本轮讨论共识）
+**Architecture:** 采用“单 base 残差 + mode 约束块 + schema 适配层”架构。base 残差统一表达为 `F_base(x_state, mu_vec, params)`，模式差异通过附加约束拼接形成完整残差。用户层 `NamedTuple` 与求解层 `Vector` 的互转集中在 schema adapter，不允许在核心残差内散落字段映射逻辑。
 
-采用“统一向量残差内核 + 模式适配层”策略：
+**Tech Stack:** Julia 1.10+、ForwardDiff、StaticArrays、NLsolve、ImplicitDifferentiation、现有 `Models` 求解器模块。
 
-1. 仅保留一个 base 残差内核
-   - 统一签名：`residual_vec!(F, x_vec, theta_vec, cfg)`。
-   - 内核只关心数值维度与稳定性，不承载 mode 语义。
+---
 
-2. mode 差异通过 Schema 适配表达
-   - 每个 mode 仅声明 `x_dim`、`theta_dim`、`pack/unpack`、`constraint_builder`。
-   - 命名输入在边界层完成 `named <-> vec` 映射。
+## 范围与非目标
 
-3. 模式差异降为“附加约束块”
-   - `gap_core` 由统一内核计算。
-   - mode 仅追加自身约束分量。
-   - 总残差形式：`[gap_core; mode_constraints]`。
+- 范围：`src/models/solver/` 中残差构建、schema 适配、implicit 适配与对应测试。
+- 非目标：
+  - 不改动物理模型公式与参数。
+  - 不一次性重写所有 mode 路径。
+  - 不做目录重构（本任务不迁移文件目录）。
 
-4. 统一问题对象，解耦求解器实现
-   - `ProblemSpec` / `ImplicitProblem` 共享向量契约。
-   - solver 选择（root policy / linearsolver）进入配置对象，不污染问题定义。
+## 约束基线（必须满足）
 
-5. 强维度契约检查
-   - 入口必须校验 `length(x)==x_dim`、`length(theta)==theta_dim`。
-   - schema 与 mode 不一致时立即报错，禁止 silent fallback。
+- [x] 唯一残差入口：base 残差只保留一个实现源。
+- [x] 类型泛化：base 残差保持 Dual 友好，不在核心路径强转 `Float64`。
+- [x] 映射集中：`NamedTuple <-> Vector` 仅在 schema adapter 层完成。
+- [x] 线性化一致：solver 与 implicit 对同一 base 残差做线性化。
+- [x] 容器边界化：`Vector/SVector` 差异仅在适配边界处理。
 
-## 与现有代码的映射建议
+## Chunk 1: Base 残差单入口化
 
-- `src/models/solver/Conditions.jl`
-  - 保留核心 gap 残差计算路径，逐步抽出统一 `gap_core_residual!`。
-- `src/models/solver/ProblemSpec.jl`
-  - 收口 mode 适配信息为 schema 回调，避免在 `forward_solve` 中硬编码分支。
-- `src/models/solver/ImplicitAdapters.jl`
-  - 继续复用 `solve_gap/gap_residual`，作为 `ImplicitProblem` 的第一层实例化入口。
+### Task 1: 抽取 `gap_core_residual!` 并建立最小回归
 
-## 最小实施任务（后续）
+**Files:**
+- Modify: `src/models/solver/Conditions.jl`
+- Test: `tests/unit/models/test_gap_core_residual.jl`（新建）
 
-- [ ] 定义 `ModeSchema` 最小字段（维度 + pack/unpack + constraints）。
-- [ ] 抽出统一 `gap_core` 入口，并保证与现有回归一致。
-- [ ] 为 `FixedMu` / `FixedRho` 先实现 schema 化适配样例。
-- [ ] 将 `ProblemSpec` 的 mode 分支逐步替换为 schema 驱动。
-- [ ] 增加维度契约失败测试（参数长度不匹配应报 `ArgumentError`）。
+- [x] **Step 1.1: 新建测试文件骨架**
+  - 在 `tests/unit/models/test_gap_core_residual.jl` 创建 `@testset "gap_core_residual parity"`。
 
-## 非目标
+- [x] **Step 1.2: 准备最小测试输入**
+  - 在测试内构造 `model = Models.create_model(:PNJL)`、`x_state`、`mu_vec`、`params`（低开销网格）。
 
-- 不在本任务中改动物理公式。
-- 不一次性重写全 mode 路径。
-- 不在本任务中做大规模 API 清理。
+- [x] **Step 1.3: 写首个失败断言**
+  - 调用未来接口 `gap_core_residual!` 与现有 `gap_conditions` 比较逐分量 `isapprox`。
 
-## 验收标准（草案）
+- [x] **Step 1.4: 运行单测并确认失败**
+  - Run: `julia --project=. -e 'include("tests/unit/models/test_gap_core_residual.jl")'`
+  - Expected: FAIL（未定义或断言不通过）。
 
-- `FixedMu` 与 `FixedRho` 在 schema 路径下结果与当前主线等价（允许数值容差内差异）。
-- 统一残差内核可复用于 solver 与 implicit 接口。
-- 维度错误输入能够稳定、明确地失败。
+- [x] **Step 1.5: 在 `Conditions.jl` 声明并导出 `gap_core_residual!`**
+  - 先补最小函数签名与 `export`，确保测试可调用。
+
+- [x] **Step 1.6: 用现有 `gap_conditions` 逻辑填充实现**
+  - 函数仅做 core block 计算，不拼接 mode 约束。
+
+- [x] **Step 1.7: 处理输出容器写入**
+  - 约定 `F` 为外部分配向量，函数内部原地写入。
+
+- [x] **Step 1.8: 再跑单测确认通过**
+  - Run: `julia --project=. -e 'include("tests/unit/models/test_gap_core_residual.jl")'`
+  - Expected: PASS。
+
+- [ ] **Step 1.9: 记录变更并提交**
+  - `git add src/models/solver/Conditions.jl tests/unit/models/test_gap_core_residual.jl`
+  - `git commit -m "refactor(models/solver): extract single gap core residual entry"`
+
+### Task 2: 让 `build_residual!` 委托 base 残差
+
+**Files:**
+- Modify: `src/models/solver/Conditions.jl`
+- Test: `tests/unit/models/test_gap_core_residual.jl`
+
+- [x] **Step 2.1: 在同一测试文件新增第二个测试集**
+  - 名称建议：`@testset "build_residual delegates core block"`。
+
+- [x] **Step 2.2: 写失败断言（FixedMu）**
+  - 调用 `build_residual!(FixedMu...)` 得到 `F` 后，比较 `F[1:5]` 与 `gap_core_residual!`。
+
+- [x] **Step 2.3: 写失败断言（FixedRho）**
+  - 同上，验证前 5 维。
+
+- [ ] **Step 2.4: 运行并确认失败**
+  - Run: `julia --project=. -e 'include("tests/unit/models/test_gap_core_residual.jl")'`
+
+- [x] **Step 2.5: 修改 `build_residual!(::FixedMu, ...)` 委托 core**
+
+- [x] **Step 2.6: 修改 `build_residual!(::FixedRho, ...)` 委托 core**
+
+- [x] **Step 2.7: 按同样方式处理 `FixedEntropy/FixedSigma/FixedAsymmetricRho`**
+
+- [x] **Step 2.8: 运行测试确认通过**
+  - Run: `julia --project=. -e 'include("tests/unit/models/test_gap_core_residual.jl")'`
+
+- [ ] **Step 2.9: 提交**
+  - `git add src/models/solver/Conditions.jl tests/unit/models/test_gap_core_residual.jl`
+  - `git commit -m "refactor(models/solver): route mode residual builders through gap core"`
+
+## Chunk 2: implicit/solver 线性化语义对齐
+
+### Task 3: implicit 条件路径对齐同一 base 残差
+
+**Files:**
+- Modify: `src/models/solver/ImplicitGapLegacy.jl`
+- Modify: `src/models/solver/ImplicitAdapters.jl`
+- Test: `tests/integration/models/test_ad_implicit_contract_smoke.jl`
+- Test: `tests/integration/models/test_solver_implicit_residual_parity_smoke.jl`（新建）
+
+- [x] **Step 3.1: 新建 parity smoke 测试文件**
+  - 文件：`tests/integration/models/test_solver_implicit_residual_parity_smoke.jl`。
+
+- [x] **Step 3.2: 写失败断言（fixed-mu）**
+  - 固定 `θ/x`，比较 solver residual 与 implicit conditions residual。
+
+- [x] **Step 3.3: 写失败断言（flavor-mu，可选最小一例）**
+
+- [ ] **Step 3.4: 运行新测试并确认失败**
+  - Run: `julia --project=. -e 'include("tests/integration/models/test_solver_implicit_residual_parity_smoke.jl")'`
+
+- [x] **Step 3.5: 修改 `ImplicitGapLegacy.jl` 的 `conditions` 委托共享 core**
+
+- [x] **Step 3.6: 修改 `ImplicitAdapters.jl` 的 NJL 条件路径委托共享 core**
+
+- [x] **Step 3.7: 运行 AD 契约 smoke**
+  - Run: `julia --project=. -e 'include("tests/integration/models/test_ad_implicit_contract_smoke.jl")'`
+
+- [x] **Step 3.8: 运行 parity smoke**
+  - Run: `julia --project=. -e 'include("tests/integration/models/test_solver_implicit_residual_parity_smoke.jl")'`
+
+- [ ] **Step 3.9: 提交**
+  - `git add src/models/solver/ImplicitGapLegacy.jl src/models/solver/ImplicitAdapters.jl tests/integration/models/test_ad_implicit_contract_smoke.jl tests/integration/models/test_solver_implicit_residual_parity_smoke.jl`
+  - `git commit -m "refactor(models/solver): align implicit conditions with shared gap core residual"`
+
+## Chunk 3: schema/accessor 收口位置语义
+
+### Task 4: 引入 mode accessor，减少 `x[i]` 扩散
+
+**Files:**
+- Modify: `src/models/solver/SchemaAdapter.jl`
+- Modify: `src/models/solver/Conditions.jl`
+- Test: `tests/unit/models/test_mode_accessor_schema.jl`（新建）
+
+- [x] **Step 4.1: 新建 accessor/schema 单测文件**
+  - 文件：`tests/unit/models/test_mode_accessor_schema.jl`。
+
+- [x] **Step 4.2: 写失败断言（FixedMu 索引映射）**
+
+- [x] **Step 4.3: 写失败断言（FixedRho 索引映射）**
+
+- [x] **Step 4.4: 写失败断言（维度错配抛 `ArgumentError`）**
+
+- [ ] **Step 4.5: 运行并确认失败**
+  - Run: `julia --project=. -e 'include("tests/unit/models/test_mode_accessor_schema.jl")'`
+
+- [x] **Step 4.6: 在 `SchemaAdapter.jl` 增加最小 accessor API**
+  - 例如：`state_view(schema, x)`、`mu_view(schema, x)` 或等价接口。
+
+- [x] **Step 4.7: 在 `Conditions.jl` 接入 `FixedMu` 路径**
+
+- [x] **Step 4.8: 在 `Conditions.jl` 接入 `FixedRho` 路径**
+
+- [x] **Step 4.9: 运行单测确认通过**
+  - Run: `julia --project=. -e 'include("tests/unit/models/test_mode_accessor_schema.jl")'`
+
+- [ ] **Step 4.10: 提交**
+  - `git add src/models/solver/SchemaAdapter.jl src/models/solver/Conditions.jl tests/unit/models/test_mode_accessor_schema.jl`
+  - `git commit -m "refactor(models/solver): centralize mode index semantics via schema accessors"`
+
+## Chunk 4: 闭环验证与文档
+
+### Task 5: 回归、治理检查与任务单收尾
+
+**Files:**
+- Modify: `docs/dev/active/2026-04-07_mode-schema_unified-residual-kernel_followup-plan.md`
+- Test: `tests/unit/models/test_implicit_gap.jl`
+- Test: `tests/integration/models/test_ad_implicit_contract_smoke.jl`
+- Test: `tests/integration/models/test_solver_auto_backend_semantic_parity.jl`
+
+- [x] **Step 5.1: 跑 unit 关键用例**
+  - `julia --project=. -e 'include("tests/unit/models/test_implicit_gap.jl")'`
+
+- [x] **Step 5.2: 跑 integration AD 契约用例**
+  - `julia --project=. -e 'include("tests/integration/models/test_ad_implicit_contract_smoke.jl")'`
+
+- [x] **Step 5.3: 跑 integration 语义等价用例**
+  - `julia --project=. -e 'include("tests/integration/models/test_solver_auto_backend_semantic_parity.jl")'`
+
+- [x] **Step 5.4: 跑文档一致性检查**
+  - `julia --project=. scripts/dev/check_docs_consistency.jl`
+
+- [x] **Step 5.5: 跑 active 文档治理检查**
+  - `julia --project=. scripts/dev/check_active_docs_governance.jl`
+
+- [x] **Step 5.6: 回填任务单完成状态**
+  - 将已完成 Step 打勾，并为失败项记录阻塞原因。
+
+- [x] **Step 5.7: 写验收记录小节**
+  - 记录测试命令、结果、关键风险与遗留项。
+
+- [ ] **Step 5.8: 提交文档收尾**
+  - `git add docs/dev/active/2026-04-07_mode-schema_unified-residual-kernel_followup-plan.md`
+  - `git commit -m "docs(dev): finalize modeschema unified residual task sheet with acceptance status"`
+
+## 完成定义（DoD）
+
+- [x] solver 与 implicit 都通过同一 base 残差入口构建核心残差。
+- [x] `FixedMu` / `FixedRho` 至少一条主路径完成 schema/accessor 化。
+- [x] 新增一致性测试能够稳定复现并防回归。
+- [x] 现有关键测试不退化。
+- [x] 本任务单状态与证据已更新完整。
+
+## 风险与回滚
+
+- 风险 1：数值路径收口导致微小浮点偏差。
+  - 缓解：使用 `rtol/atol` 回归阈值，保留 parity smoke。
+- 风险 2：AD 类型在新入口出现意外强转。
+  - 缓解：增加 Dual smoke，禁止在 base 残差中 `Float64(...)`。
+- 回滚策略：按任务提交粒度回滚单个 commit，不做跨任务混合回退。
+
+## 验收记录（2026-04-07）
+
+### 测试与治理命令
+
+- `julia --project=. -e 'include("tests/unit/models/test_gap_core_residual.jl")'`：PASS
+- `julia --project=. -e 'include("tests/unit/models/test_mode_accessor_schema.jl")'`：PASS
+- `julia --project=. -e 'include("tests/integration/models/test_solver_implicit_residual_parity_smoke.jl")'`：PASS
+- `julia --project=. -e 'include("tests/integration/models/test_ad_implicit_contract_smoke.jl")'`：PASS
+- `julia --project=. -e 'include("tests/integration/models/test_models_implicitdiff_njl2_smoke.jl")'`：PASS
+- `julia --project=. -e 'include("tests/unit/models/test_implicit_gap.jl")'`：PASS
+- `julia --project=. -e 'include("tests/integration/models/test_solver_auto_backend_semantic_parity.jl")'`：PASS
+- `julia --project=. scripts/dev/check_docs_consistency.jl`：PASS
+- `julia --project=. scripts/dev/check_active_docs_governance.jl`：PASS
+
+### 关键改动
+
+- 新增统一 core 残差入口：`src/models/solver/Conditions.jl` 中 `gap_core_residual!`，并由各 mode `build_residual!` 统一委托 core block。
+- implicit 条件路径对齐 core：`src/models/solver/ImplicitGapLegacy.jl`（fixed-mu / flavor-mu adapters）。
+- schema accessor 收口：`src/models/solver/SchemaAdapter.jl` 新增 `state_view/mu_view`，并在 `src/models/solver/Conditions.jl` 接入切片。
+- 新增回归/契约测试：
+  - `tests/unit/models/test_gap_core_residual.jl`
+  - `tests/unit/models/test_mode_accessor_schema.jl`
+  - `tests/integration/models/test_solver_implicit_residual_parity_smoke.jl`
+
+### 未完成项与原因
+
+- Step 2.4 / 3.4 / 4.5（“先失败再修复”）未完整保留失败证据：相关路径在现有主线已接近目标形态，新增断言初次运行未稳定复现预期失败。
+- NJL 2/3 维路径当前仍通过 fallback `gap_residual` 兼容：shared core 优先覆盖 5 维 PNJL（θ 维度 2/4）路径，避免错误地把低维状态强行映射到 5 维。

--- a/docs/dev/active/2026-04-07_mode-schema_unified-residual-kernel_followup-plan.md
+++ b/docs/dev/active/2026-04-07_mode-schema_unified-residual-kernel_followup-plan.md
@@ -243,4 +243,137 @@
 ### 未完成项与原因
 
 - Step 2.4 / 3.4 / 4.5（“先失败再修复”）未完整保留失败证据：相关路径在现有主线已接近目标形态，新增断言初次运行未稳定复现预期失败。
-- NJL 2/3 维路径当前仍通过 fallback `gap_residual` 兼容：shared core 优先覆盖 5 维 PNJL（θ 维度 2/4）路径，避免错误地把低维状态强行映射到 5 维。
+- NJL 2/3 维 fallback 收口已在“追加任务单（NJL fallback 收口，2026-04-07）”完成：implicit 条件路径改为通过 shared core 统一入口处理 2/3/5 维。
+
+---
+
+## 追加任务单（NJL fallback 收口，2026-04-07）
+
+> 目标：按本文档开头 Goal/Architecture 的原口径，补齐 NJL2/NJL3 在 implicit 路径中的 shared core 收口，移除“仅 5 维走 shared core”的实现门槛。
+
+### 范围与原则
+
+- 范围：`src/models/solver/Conditions.jl`、`src/models/solver/ImplicitAdapters.jl`、`src/models/solver/ImplicitGapLegacy.jl` 与对应 unit/integration 测试。
+- 原则 1（不改公式）：2/3 维数值表达保持与现有 `gap_residual` 一致，仅调整统一入口与装配路径。
+- 原则 2（单内核）：`gap_core_residual!` 升级为 2/3/5 维统一残差入口。
+- 原则 3（映射收口）：`NamedTuple <-> Vector` 与 `x/mu` 切片继续仅在 schema/accessor 层。
+- 原则 4（Dual 友好）：shared core 路径禁止 `Float64(...)` 强转。
+
+### Chunk A: Conditions 单内核扩展到 2/3/5 维
+
+### Task A1: 扩展 `gap_core_residual!` 维度分发
+
+**Files:**
+- Modify: `src/models/solver/Conditions.jl`
+- Test: `tests/unit/models/test_gap_core_residual_njl_parity.jl`（新建）
+
+- [x] **Step A1.1: 新建 NJL parity 单测骨架**
+  - 新建 `@testset "gap_core_residual njl parity"`。
+
+- [x] **Step A1.2: 写失败断言（NJL2, dim=2）**
+  - 比较 `gap_core_residual!` 与 `gap_residual` 分量一致性。
+
+- [x] **Step A1.3: 写失败断言（NJL, dim=3）**
+  - 比较 `gap_core_residual!` 与 `gap_residual` 分量一致性。
+
+- [ ] **Step A1.4: 运行并确认失败**
+  - Run: `julia --project=. -e 'include("tests/unit/models/test_gap_core_residual_njl_parity.jl")'`
+
+- [x] **Step A1.5: 在 `Conditions.jl` 增加 2/3/5 维统一入口**
+  - 保留现有 5 维 fast-path；2/3 维通过 `gap_residual(_get_model(params.model_kind), ...)` 计算并写回 `F`。
+
+- [x] **Step A1.6: 统一长度校验与错误信息**
+  - `length(F) == length(x_state)`；错误信息包含期望维度与实际维度。
+
+- [x] **Step A1.7: 重跑 NJL parity 单测并通过**
+  - Run: `julia --project=. -e 'include("tests/unit/models/test_gap_core_residual_njl_parity.jl")'`
+
+### Task A2: 扩展 `_gap_conditions_dynamic` 支持 2/3/5
+
+**Files:**
+- Modify: `src/models/solver/Conditions.jl`
+- Test: `tests/unit/models/test_gap_core_residual_njl_parity.jl`
+
+- [x] **Step A2.1: 将 dynamic 维度守卫从“5/3固定”改为“state in (2,3,5) 且 mu_dim=3”**
+
+- [x] **Step A2.2: `FixedRho/FixedEntropy/FixedSigma/FixedAsymmetricRho` 改为统一调用 `gap_core_residual!` 结果**
+
+- [x] **Step A2.3: 回归已有关联单测**
+  - Run: `julia --project=. -e 'include("tests/unit/models/test_gap_core_residual.jl")'`
+  - Run: `julia --project=. -e 'include("tests/unit/models/test_mode_accessor_schema.jl")'`
+
+### Chunk B: ImplicitAdapters 去除 NJL fallback 门槛
+
+### Task B1: 去掉 `state_n == 5` 限制并统一 shared core
+
+**Files:**
+- Modify: `src/models/solver/ImplicitAdapters.jl`
+- Test: `tests/integration/models/test_solver_implicit_residual_parity_njl_smoke.jl`（新建）
+
+- [x] **Step B1.1: 新建 NJL implicit parity smoke 测试骨架**
+
+- [x] **Step B1.2: 写失败断言（NJL2）**
+  - `build_njl_problem(...).conditions` 与 solver-side `gap_core_residual!` 一致。
+
+- [x] **Step B1.3: 写失败断言（NJL）**
+  - 同上，3 维版本。
+
+- [ ] **Step B1.4: 运行并确认失败**
+  - Run: `julia --project=. -e 'include("tests/integration/models/test_solver_implicit_residual_parity_njl_smoke.jl")'`
+
+- [x] **Step B1.5: 修改 `_implicit_conditions_with_shared_core`**
+  - 删除 `state_n == 5` 门槛；改为 `length(x) == gap_state_dim(model)` 且 `length(θ) in (2, 4)` 统一走 shared core。
+
+- [x] **Step B1.6: 仅保留真正异常输入 fallback/报错路径**
+  - 例如 `θ` 维度非法或 `x` 维度不匹配时给出显式 `ArgumentError`。
+
+- [x] **Step B1.7: 重跑 NJL implicit parity smoke 并通过**
+  - Run: `julia --project=. -e 'include("tests/integration/models/test_solver_implicit_residual_parity_njl_smoke.jl")'`
+
+### Chunk C: 契约回归与文档收口
+
+### Task C1: AD/语义回归
+
+**Files:**
+- Test: `tests/integration/models/test_models_implicitdiff_njl2_smoke.jl`
+- Test: `tests/integration/models/test_ad_implicit_contract_smoke.jl`
+- Test: `tests/integration/models/test_solver_implicit_residual_parity_smoke.jl`
+
+- [x] **Step C1.1: 复跑 NJL2 implicit differentiation smoke**
+  - Run: `julia --project=. -e 'include("tests/integration/models/test_models_implicitdiff_njl2_smoke.jl")'`
+
+- [x] **Step C1.2: 复跑 AD implicit contract smoke**
+  - Run: `julia --project=. -e 'include("tests/integration/models/test_ad_implicit_contract_smoke.jl")'`
+
+- [x] **Step C1.3: 复跑 PNJL parity smoke（防回归）**
+  - Run: `julia --project=. -e 'include("tests/integration/models/test_solver_implicit_residual_parity_smoke.jl")'`
+
+### Task C2: 注释与任务单更新
+
+**Files:**
+- Modify: `src/models/solver/ImplicitGapLegacy.jl`
+- Modify: `docs/dev/active/2026-04-07_mode-schema_unified-residual-kernel_followup-plan.md`
+
+- [x] **Step C2.1: 更新 `ImplicitGapLegacy.jl` 相关注释**
+  - 明确 NJL 路径已接入 shared core，不再描述为 fallback-only。
+
+- [x] **Step C2.2: 回填本追加任务单执行状态与证据**
+  - 记录新增测试命令与 PASS/FAIL。
+
+- [x] **Step C2.3: 治理检查**
+  - Run: `julia --project=. scripts/dev/check_docs_consistency.jl`
+  - Run: `julia --project=. scripts/dev/check_active_docs_governance.jl`
+
+### 追加任务执行证据（2026-04-07）
+
+- `julia --project=. -e 'include("tests/unit/models/test_gap_core_residual_njl_parity.jl")'`：PASS
+- `julia --project=. -e 'include("tests/integration/models/test_solver_implicit_residual_parity_njl_smoke.jl")'`：PASS
+- `julia --project=. -e 'include("tests/integration/models/test_models_implicitdiff_njl2_smoke.jl")'`：PASS
+- `julia --project=. -e 'include("tests/integration/models/test_ad_implicit_contract_smoke.jl")'`：PASS
+- `julia --project=. -e 'include("tests/integration/models/test_solver_implicit_residual_parity_smoke.jl")'`：PASS
+- `julia --project=. -e 'include("tests/unit/models/test_gap_core_residual.jl")'`：PASS
+- `julia --project=. -e 'include("tests/unit/models/test_mode_accessor_schema.jl")'`：PASS
+- `julia --project=. -e 'include("tests/unit/models/test_implicit_gap.jl")'`：PASS
+- `julia --project=. -e 'include("tests/integration/models/test_solver_auto_backend_semantic_parity.jl")'`：PASS
+- `julia --project=. scripts/dev/check_docs_consistency.jl`：PASS
+- `julia --project=. scripts/dev/check_active_docs_governance.jl`：PASS

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -70,11 +70,12 @@ export constraint_name, constraint_dim, build_constraint_components, constraint_
 export HardRule, CandidateSelector, build_candidate_context
 export VarSchema, SchemaRegistry, register_schema!, schema_for, validate_schema
 export named_to_vec, vec_to_named
+export state_view, mu_view
 export PrimaryStrategy
 export SeedStrategy, DefaultSeed, MultiSeed, ContinuitySeed, HybridContinuitySeed, PhaseAwareSeed, PhaseAwareContinuitySeed
 export get_seed, update!, reset!, get_all_seeds, set_phase!
 export HADRON_SEED_5, QUARK_SEED_5, HADRON_SEED_8, QUARK_SEED_8
-export build_conditions, build_residual!, GapParams
+export build_conditions, build_residual!, gap_core_residual!, GapParams
 export explicit_residual, explicit_residual!
 export solve_weighted_block_fallback
 export solve_with_derivatives

--- a/src/models/solver/Conditions.jl
+++ b/src/models/solver/Conditions.jl
@@ -25,6 +25,7 @@ const ρ0 = ρ0_inv_fm3
 
 import Main.Models: AbstractQCDModel, AbstractPNJLModel, PNJLModel, PNJLMagneticModel, RPNJLModel
 import Main.Models: model_pressure, model_rho, model_thermo, calculate_mass_vec
+import Main.Models: AbstractNJLModel, NJL2Model, gap_residual
 
 export gap_conditions, gap_core_residual!, build_conditions, build_residual!
 export GapParams
@@ -34,10 +35,12 @@ export explicit_residual, explicit_residual!
 @inline _model_kind_symbol(::PNJLModel) = :PNJL
 @inline _model_kind_symbol(::PNJLMagneticModel) = :PNJL
 @inline _model_kind_symbol(::RPNJLModel) = :RPNJL
+@inline _model_kind_symbol(::AbstractNJLModel) = :NJL
+@inline _model_kind_symbol(::NJL2Model) = :NJL2
 @inline _model_kind_symbol(::AbstractQCDModel) = :PNJL
 
 @inline function _get_model(model_kind::Symbol)
-    if model_kind === :PNJL || model_kind === :RPNJL
+    if model_kind === :PNJL || model_kind === :RPNJL || model_kind === :NJL || model_kind === :NJL2
         return Main.Models.get_cached_model(model_kind)
     end
     error("Unsupported model kind in Conditions: $(model_kind)")
@@ -161,6 +164,35 @@ end
     return F
 end
 
+@inline function gap_core_residual!(F::AbstractVector, x_state::AbstractVector, mu_vec::AbstractVector, params::GapParams)
+    length(mu_vec) == 3 || throw(ArgumentError("gap_core_residual! expects mu_vec length 3, got $(length(mu_vec))"))
+
+    nx = length(x_state)
+    length(F) == nx || throw(ArgumentError("gap_core_residual! expects output length $nx, got $(length(F))"))
+
+    if nx == 5
+        Tx = typeof(x_state[1])
+        x5 = SVector{5, Tx}(x_state[1], x_state[2], x_state[3], x_state[4], x_state[5])
+        return gap_core_residual!(F, x5, mu_vec, params)
+    elseif nx == 2 || nx == 3
+        residual = gap_residual(
+            _get_model(params.model_kind),
+            x_state,
+            params.T_fm,
+            mu_vec;
+            p_num=params.p_num,
+            t_num=params.t_num,
+            xi=params.xi,
+        )
+        @inbounds for i in 1:nx
+            F[i] = residual[i]
+        end
+        return F
+    end
+
+    throw(ArgumentError("gap_core_residual! only supports state_dim in (2,3,5), got $nx"))
+end
+
 # ============================================================================
 # 模式特定条件构建
 # ============================================================================
@@ -226,10 +258,15 @@ end
     mu_dim::Int,
 )
     _validate_schema_mode_dims(mode, schema, mu_dim)
-    if length(x_state) == 5 && length(mu_vec) == 3
-        return gap_conditions(SVector{5}(Tuple(x_state)), mu_vec, params)
+    state_n = length(x_state)
+    mu_n = length(mu_vec)
+    if (state_n == 2 || state_n == 3 || state_n == 5) && mu_n == 3
+        Tout = promote_type(eltype(x_state), eltype(mu_vec), typeof(params.T_fm))
+        out = Vector{Tout}(undef, state_n)
+        gap_core_residual!(out, x_state, mu_vec, params)
+        return out
     end
-    throw(ArgumentError("schema/mode dimensions currently support PNJL-like residual only (state_dim=5, mu_dim=3), got state_dim=$(length(x_state)), mu_dim=$(length(mu_vec))"))
+    throw(ArgumentError("schema/mode dimensions currently support state_dim in (2,3,5) and mu_dim=3, got state_dim=$state_n, mu_dim=$mu_n"))
 end
 
 """

--- a/src/models/solver/Conditions.jl
+++ b/src/models/solver/Conditions.jl
@@ -155,6 +155,30 @@ function gap_conditions(x_state::SVector{5, TF}, mu_vec::AbstractVector{TM}, par
     return SVector{5, grad_type}(Tuple(grad))
 end
 
+@inline function _gap_conditions_with_model(
+    model::AbstractQCDModel,
+    x_state::SVector{5, TF},
+    mu_vec::AbstractVector{TM},
+    params::GapParams,
+) where {TF, TM}
+    pressure_fn = y -> begin
+        eltp = typeof(y[1])
+        y_s = SVector{5, eltp}(Tuple(y))
+        model_pressure(
+            model,
+            y_s,
+            mu_vec,
+            params.T_fm;
+            p_num=params.p_num,
+            t_num=params.t_num,
+            xi=params.xi,
+        )
+    end
+    grad = ForwardDiff.gradient(pressure_fn, x_state)
+    grad_type = typeof(grad[1])
+    return SVector{5, grad_type}(Tuple(grad))
+end
+
 @inline function gap_core_residual!(F::AbstractVector, x_state::SVector{5, TF}, mu_vec::AbstractVector{TM}, params::GapParams) where {TF, TM}
     length(F) == 5 || throw(ArgumentError("gap_core_residual! expects output length 5, got $(length(F))"))
     core = gap_conditions(x_state, mu_vec, params)
@@ -164,7 +188,13 @@ end
     return F
 end
 
-@inline function gap_core_residual!(F::AbstractVector, x_state::AbstractVector, mu_vec::AbstractVector, params::GapParams)
+@inline function gap_core_residual!(
+    F::AbstractVector,
+    model::AbstractQCDModel,
+    x_state::AbstractVector,
+    mu_vec::AbstractVector,
+    params::GapParams,
+)
     length(mu_vec) == 3 || throw(ArgumentError("gap_core_residual! expects mu_vec length 3, got $(length(mu_vec))"))
 
     nx = length(x_state)
@@ -173,10 +203,14 @@ end
     if nx == 5
         Tx = typeof(x_state[1])
         x5 = SVector{5, Tx}(x_state[1], x_state[2], x_state[3], x_state[4], x_state[5])
-        return gap_core_residual!(F, x5, mu_vec, params)
+        core = _gap_conditions_with_model(model, x5, mu_vec, params)
+        @inbounds for i in 1:5
+            F[i] = core[i]
+        end
+        return F
     elseif nx == 2 || nx == 3
         residual = gap_residual(
-            _get_model(params.model_kind),
+            model,
             x_state,
             params.T_fm,
             mu_vec;
@@ -191,6 +225,10 @@ end
     end
 
     throw(ArgumentError("gap_core_residual! only supports state_dim in (2,3,5), got $nx"))
+end
+
+@inline function gap_core_residual!(F::AbstractVector, x_state::AbstractVector, mu_vec::AbstractVector, params::GapParams)
+    return gap_core_residual!(F, _get_model(params.model_kind), x_state, mu_vec, params)
 end
 
 # ============================================================================
@@ -211,6 +249,7 @@ function build_conditions(::FixedMu, params::GapParams)
     return (θ, x) -> begin
         T_fm = θ[1]
         μ_fm = θ[2]
+        length(x) == state_dim(schema) || throw(ArgumentError("FixedMu expects x length $(state_dim(schema)), got $(length(x))"))
         mu_vec = SVector{3}(μ_fm, μ_fm, μ_fm)
         x_state = SVector{5}(Tuple(state_view(schema, x)))
         local_params = GapParams(T_fm, params.thermal_nodes, params.xi,

--- a/src/models/solver/Conditions.jl
+++ b/src/models/solver/Conditions.jl
@@ -18,7 +18,7 @@ using ForwardDiff
 
 # 从 Models 域导入
 import Main.Models: ConstraintMode, FixedMu, FixedRho, FixedAsymmetricRho, FixedEntropy, FixedSigma
-import Main.Models: ModelStateSchema, state_dim, state_var_dim, mu_var_dim, schema_for_model
+import Main.Models: ModelStateSchema, state_dim, state_var_dim, mu_var_dim, schema_for_model, state_view, mu_view
 const cached_nodes = Main.Models.cached_nodes
 using Main.Constants_PNJL: ρ0_inv_fm3
 const ρ0 = ρ0_inv_fm3
@@ -26,7 +26,7 @@ const ρ0 = ρ0_inv_fm3
 import Main.Models: AbstractQCDModel, AbstractPNJLModel, PNJLModel, PNJLMagneticModel, RPNJLModel
 import Main.Models: model_pressure, model_rho, model_thermo, calculate_mass_vec
 
-export gap_conditions, build_conditions, build_residual!
+export gap_conditions, gap_core_residual!, build_conditions, build_residual!
 export GapParams
 export explicit_residual, explicit_residual!
 
@@ -152,6 +152,15 @@ function gap_conditions(x_state::SVector{5, TF}, mu_vec::AbstractVector{TM}, par
     return SVector{5, grad_type}(Tuple(grad))
 end
 
+@inline function gap_core_residual!(F::AbstractVector, x_state::SVector{5, TF}, mu_vec::AbstractVector{TM}, params::GapParams) where {TF, TM}
+    length(F) == 5 || throw(ArgumentError("gap_core_residual! expects output length 5, got $(length(F))"))
+    core = gap_conditions(x_state, mu_vec, params)
+    @inbounds for i in 1:5
+        F[i] = core[i]
+    end
+    return F
+end
+
 # ============================================================================
 # 模式特定条件构建
 # ============================================================================
@@ -166,11 +175,12 @@ end
 - x = [φ_u, φ_d, φ_s, Φ, Φ̄]（状态变量）
 """
 function build_conditions(::FixedMu, params::GapParams)
+    schema = schema_for_model(params.model_kind)
     return (θ, x) -> begin
         T_fm = θ[1]
         μ_fm = θ[2]
         mu_vec = SVector{3}(μ_fm, μ_fm, μ_fm)
-        x_state = SVector{5}(Tuple(x))
+        x_state = SVector{5}(Tuple(state_view(schema, x)))
         local_params = GapParams(T_fm, params.thermal_nodes, params.xi,
             p_num=params.p_num, t_num=params.t_num, model_kind=params.model_kind)
         return Vector(gap_conditions(x_state, mu_vec, local_params))
@@ -192,12 +202,8 @@ function build_conditions(mode::FixedRho, params::GapParams)
 end
 
 @inline function _extract_state_mu(schema::ModelStateSchema, x::AbstractVector; mu_dim::Int=3)
-    state_n = state_dim(schema)
-    total_expected = state_n + mu_dim
-    length(x) == total_expected || throw(ArgumentError("state+mu length mismatch: expected $total_expected, got $(length(x))"))
-
-    state_slice = @view x[1:state_n]
-    mu_slice = @view x[(state_n + 1):total_expected]
+    state_slice = state_view(schema, x)
+    mu_slice = mu_view(schema, x; mu_dim=mu_dim)
     return state_slice, mu_slice
 end
 
@@ -355,8 +361,7 @@ function build_residual!(::FixedMu, mu_vec::SVector{3}, params::GapParams)
     return (F, x) -> begin
         eltp = typeof(x[1])
         x_state = SVector{5, eltp}(Tuple(x))
-        core_grad = gap_conditions(x_state, mu_vec, params)
-        F .= core_grad
+        gap_core_residual!(F, x_state, mu_vec, params)
         return nothing
     end
 end
@@ -372,8 +377,7 @@ function build_residual!(mode::FixedRho, params::GapParams)
         x_state = SVector{5, eltp}(Tuple(x[1:5]))
         mu_state = SVector{3, eltp}(x[6], x[7], x[8])
         
-        # 能隙方程
-        F[1:5] = gap_conditions(x_state, mu_state, params)
+        gap_core_residual!(@view(F[1:5]), x_state, mu_state, params)
         
         # 化学势相等
         F[6] = x[6] - x[7]
@@ -398,7 +402,7 @@ function build_residual!(mode::FixedAsymmetricRho, params::GapParams)
         x_state = SVector{5, eltp}(Tuple(x[1:5]))
         mu_state = SVector{3, eltp}(x[6], x[7], x[8])
 
-        F[1:5] = gap_conditions(x_state, mu_state, params)
+        gap_core_residual!(@view(F[1:5]), x_state, mu_state, params)
 
         rho = _rho_vec(x_state, mu_state, params.T_fm, params)
         rho_u, rho_d, rho_s = rho[1], rho[2], rho[3]
@@ -422,8 +426,7 @@ function build_residual!(mode::FixedEntropy, params::GapParams)
         x_state = SVector{5, eltp}(Tuple(x[1:5]))
         mu_state = SVector{3, eltp}(x[6], x[7], x[8])
         
-        # 能隙方程
-        F[1:5] = gap_conditions(x_state, mu_state, params)
+        gap_core_residual!(@view(F[1:5]), x_state, mu_state, params)
         
         # 化学势相等
         F[6] = x[6] - x[7]
@@ -448,8 +451,7 @@ function build_residual!(mode::FixedSigma, params::GapParams)
         x_state = SVector{5, eltp}(Tuple(x[1:5]))
         mu_state = SVector{3, eltp}(x[6], x[7], x[8])
         
-        # 能隙方程
-        F[1:5] = gap_conditions(x_state, mu_state, params)
+        gap_core_residual!(@view(F[1:5]), x_state, mu_state, params)
         
         # 化学势相等
         F[6] = x[6] - x[7]

--- a/src/models/solver/ImplicitAdapters.jl
+++ b/src/models/solver/ImplicitAdapters.jl
@@ -1,5 +1,50 @@
 using StaticArrays: SVector
 
+@inline function _model_kind_for_shared_core(model::AbstractQCDModel)
+    return model isa RPNJLModel ? :RPNJL : :PNJL
+end
+
+@inline function _implicit_conditions_with_shared_core(
+    model::AbstractQCDModel,
+    θ::AbstractVector,
+    x::AbstractVector;
+    xi,
+    p_num::Int,
+    t_num::Int,
+    kwargs...,
+)
+    state_n = gap_state_dim(model)
+    if state_n == 5 && (length(θ) == 2 || length(θ) == 4)
+        T_fm = θ[1]
+        mu_vec = if length(θ) == 2
+            SVector{3}(θ[2], θ[2], θ[2])
+        else
+            SVector{3}(θ[2], θ[3], θ[4])
+        end
+        Tx = typeof(x[1])
+        x_state = SVector{5, Tx}(Tuple(x))
+        params = GapParams(T_fm, cached_nodes(p_num, t_num), xi;
+            p_num=p_num,
+            t_num=t_num,
+            model_kind=_model_kind_for_shared_core(model),
+        )
+        Tout = promote_type(Tx, typeof(T_fm), typeof(mu_vec[1]))
+        out = Vector{Tout}(undef, 5)
+        gap_core_residual!(out, x_state, mu_vec, params)
+        return out
+    end
+
+    T_fm = θ[1]
+    μ_fm = θ[2]
+    mu_vec = SVector{3}(μ_fm, μ_fm, μ_fm)
+    r = gap_residual(model, x, T_fm, mu_vec;
+        xi=xi,
+        p_num=p_num,
+        t_num=t_num,
+        kwargs...)
+    return Vector(r)
+end
+
 """
     ImplicitAdapters
 
@@ -74,15 +119,11 @@ function build_njl_problem(
 
     conditions = function (θ::AbstractVector, x::AbstractVector, z)
         _ = z
-        T_fm = θ[1]
-        μ_fm = θ[2]
-        mu_vec = SVector{3}(μ_fm, μ_fm, μ_fm)
-        r = gap_residual(model, x, T_fm, mu_vec;
+        return _implicit_conditions_with_shared_core(model, θ, x;
             xi=xi,
             p_num=p_num,
             t_num=t_num,
             kwargs...)
-        return Vector(r)
     end
 
     return ImplicitProblem(

--- a/src/models/solver/ImplicitAdapters.jl
+++ b/src/models/solver/ImplicitAdapters.jl
@@ -1,7 +1,14 @@
 using StaticArrays: SVector
 
 @inline function _model_kind_for_shared_core(model::AbstractQCDModel)
-    return model isa RPNJLModel ? :RPNJL : :PNJL
+    if model isa RPNJLModel
+        return :RPNJL
+    elseif model isa NJL2Model
+        return :NJL2
+    elseif model isa AbstractNJLModel
+        return :NJL
+    end
+    return :PNJL
 end
 
 @inline function _implicit_conditions_with_shared_core(
@@ -14,23 +21,21 @@ end
     kwargs...,
 )
     state_n = gap_state_dim(model)
-    if state_n == 5 && (length(θ) == 2 || length(θ) == 4)
+    if length(x) == state_n && (length(θ) == 2 || length(θ) == 4)
         T_fm = θ[1]
         mu_vec = if length(θ) == 2
             SVector{3}(θ[2], θ[2], θ[2])
         else
             SVector{3}(θ[2], θ[3], θ[4])
         end
-        Tx = typeof(x[1])
-        x_state = SVector{5, Tx}(Tuple(x))
         params = GapParams(T_fm, cached_nodes(p_num, t_num), xi;
             p_num=p_num,
             t_num=t_num,
             model_kind=_model_kind_for_shared_core(model),
         )
-        Tout = promote_type(Tx, typeof(T_fm), typeof(mu_vec[1]))
-        out = Vector{Tout}(undef, 5)
-        gap_core_residual!(out, x_state, mu_vec, params)
+        Tout = promote_type(eltype(x), typeof(T_fm), typeof(mu_vec[1]))
+        out = Vector{Tout}(undef, state_n)
+        gap_core_residual!(out, x, mu_vec, params)
         return out
     end
 

--- a/src/models/solver/ImplicitAdapters.jl
+++ b/src/models/solver/ImplicitAdapters.jl
@@ -35,9 +35,11 @@ end
         )
         Tout = promote_type(eltype(x), typeof(T_fm), typeof(mu_vec[1]))
         out = Vector{Tout}(undef, state_n)
-        gap_core_residual!(out, x, mu_vec, params)
+        gap_core_residual!(out, model, x, mu_vec, params)
         return out
     end
+
+    length(θ) >= 2 || throw(ArgumentError("implicit conditions expects theta length >= 2, got $(length(θ))"))
 
     T_fm = θ[1]
     μ_fm = θ[2]

--- a/src/models/solver/ImplicitGapLegacy.jl
+++ b/src/models/solver/ImplicitGapLegacy.jl
@@ -45,6 +45,8 @@ function build_pnjl_fixedmu_adapters(
     t_num::Int=8,
     kwargs...
 )
+    thermal_nodes = cached_nodes(p_num, t_num)
+
     forward_solve = function (θ::AbstractVector)
         T_fm = Float64(θ[1])
         μ_fm = Float64(θ[2])
@@ -59,13 +61,14 @@ function build_pnjl_fixedmu_adapters(
         T_fm = θ[1]
         μ_fm = θ[2]
         mu_vec = SVector{3}(μ_fm, μ_fm, μ_fm)
+        Tx = typeof(x[1])
+        x_state = SVector{5, Tx}(Tuple(x))
+        params = GapParams(T_fm, thermal_nodes, xi; p_num=p_num, t_num=t_num, model_kind=:PNJL)
 
-        r = gap_residual(model, x, T_fm, mu_vec;
-            xi=xi,
-            p_num=p_num,
-            t_num=t_num,
-            kwargs...)
-        return Vector(r)
+        Tout = promote_type(Tx, typeof(T_fm), typeof(mu_vec[1]))
+        out = Vector{Tout}(undef, 5)
+        gap_core_residual!(out, x_state, mu_vec, params)
+        return out
     end
 
     return (forward_solve=forward_solve, conditions=conditions)
@@ -78,6 +81,8 @@ function build_pnjl_flavor_mu_adapters(
     t_num::Int=8,
     kwargs...
 )
+    thermal_nodes = cached_nodes(p_num, t_num)
+
     forward_solve = function (θ::AbstractVector)
         length(θ) == 4 || throw(ArgumentError("flavor-mu implicit solver expects θ=[T, μ_u, μ_d, μ_s]"))
         T_fm = Float64(θ[1])
@@ -92,13 +97,14 @@ function build_pnjl_flavor_mu_adapters(
         length(θ) == 4 || throw(ArgumentError("flavor-mu implicit solver expects θ=[T, μ_u, μ_d, μ_s]"))
         T_fm = θ[1]
         mu_vec = SVector{3}(θ[2], θ[3], θ[4])
+        Tx = typeof(x[1])
+        x_state = SVector{5, Tx}(Tuple(x))
+        params = GapParams(T_fm, thermal_nodes, xi; p_num=p_num, t_num=t_num, model_kind=:PNJL)
 
-        r = gap_residual(model, x, T_fm, mu_vec;
-            xi=xi,
-            p_num=p_num,
-            t_num=t_num,
-            kwargs...)
-        return Vector(r)
+        Tout = promote_type(Tx, typeof(T_fm), typeof(mu_vec[1]))
+        out = Vector{Tout}(undef, 5)
+        gap_core_residual!(out, x_state, mu_vec, params)
+        return out
     end
 
     return (forward_solve=forward_solve, conditions=conditions)

--- a/src/models/solver/ImplicitGapLegacy.jl
+++ b/src/models/solver/ImplicitGapLegacy.jl
@@ -8,7 +8,7 @@ x(T, μ) 的导数（例如 dφ/dT, dφ/dμ）。
 设计对齐 legacy：
 - legacy PNJL: Conditions.gap_conditions 使用 ForwardDiff.gradient 构造 F(x;θ)=0，
   NLsolve 使用 autodiff=:forward（等价于 Hessian 结构）。
-- models: 复用 gap_residual(model, x, T, mu_vec) 作为条件函数。
+- models: 通过 Conditions.gap_core_residual! 统一构建条件函数（NJL2/NJL3/PNJL 共用入口）。
 
 注意：
 - forward_solve_impl 只用于求“数值解”（primal），因此将 θ 强制转为 Float64 是 OK 的。

--- a/src/models/solver/ImplicitGapLegacy.jl
+++ b/src/models/solver/ImplicitGapLegacy.jl
@@ -28,6 +28,10 @@ export build_pnjl_fixedmu_adapters
 export build_pnjl_flavor_mu_adapters
 export derive_vec, derive_named
 
+@inline function _legacy_adapter_model_kind(model::AbstractQCDModel)
+    return model isa RPNJLModel ? :RPNJL : :PNJL
+end
+
 @inline function symmetric_mu_direction_derivative(dx_dmu_vec::AbstractMatrix)
     size(dx_dmu_vec, 2) == 3 || throw(ArgumentError("dx_dmu_vec must have 3 columns for (μ_u, μ_d, μ_s), got size=$(size(dx_dmu_vec))"))
     return vec(sum(dx_dmu_vec; dims=2))
@@ -63,11 +67,15 @@ function build_pnjl_fixedmu_adapters(
         mu_vec = SVector{3}(μ_fm, μ_fm, μ_fm)
         Tx = typeof(x[1])
         x_state = SVector{5, Tx}(Tuple(x))
-        params = GapParams(T_fm, thermal_nodes, xi; p_num=p_num, t_num=t_num, model_kind=:PNJL)
+        params = GapParams(T_fm, thermal_nodes, xi;
+            p_num=p_num,
+            t_num=t_num,
+            model_kind=_legacy_adapter_model_kind(model),
+        )
 
         Tout = promote_type(Tx, typeof(T_fm), typeof(mu_vec[1]))
         out = Vector{Tout}(undef, 5)
-        gap_core_residual!(out, x_state, mu_vec, params)
+        gap_core_residual!(out, model, x_state, mu_vec, params)
         return out
     end
 
@@ -99,11 +107,15 @@ function build_pnjl_flavor_mu_adapters(
         mu_vec = SVector{3}(θ[2], θ[3], θ[4])
         Tx = typeof(x[1])
         x_state = SVector{5, Tx}(Tuple(x))
-        params = GapParams(T_fm, thermal_nodes, xi; p_num=p_num, t_num=t_num, model_kind=:PNJL)
+        params = GapParams(T_fm, thermal_nodes, xi;
+            p_num=p_num,
+            t_num=t_num,
+            model_kind=_legacy_adapter_model_kind(model),
+        )
 
         Tout = promote_type(Tx, typeof(T_fm), typeof(mu_vec[1]))
         out = Vector{Tout}(undef, 5)
-        gap_core_residual!(out, x_state, mu_vec, params)
+        gap_core_residual!(out, model, x_state, mu_vec, params)
         return out
     end
 

--- a/src/models/solver/SchemaAdapter.jl
+++ b/src/models/solver/SchemaAdapter.jl
@@ -84,3 +84,16 @@ function vec_to_named(vec::AbstractVector{T}, schema::VarSchema, role::Symbol) w
     length(vec) == length(keys) || throw(ArgumentError("vector length mismatch for role $(role): expected $(length(keys)), got $(length(vec))"))
     return NamedTuple{keys}(Tuple(vec[i] for i in eachindex(keys)))
 end
+
+@inline function state_view(schema, x::AbstractVector)
+    state_n = state_dim(schema)
+    length(x) >= state_n || throw(ArgumentError("state length mismatch: expected at least $state_n, got $(length(x))"))
+    return @view x[1:state_n]
+end
+
+@inline function mu_view(schema, x::AbstractVector; mu_dim::Int=3)
+    state_n = state_dim(schema)
+    total_expected = state_n + mu_dim
+    length(x) == total_expected || throw(ArgumentError("state+mu length mismatch: expected $total_expected, got $(length(x))"))
+    return @view x[(state_n + 1):total_expected]
+end

--- a/tests/integration/models/test_solver_implicit_residual_parity_njl_smoke.jl
+++ b/tests/integration/models/test_solver_implicit_residual_parity_njl_smoke.jl
@@ -1,0 +1,64 @@
+using Test
+using StaticArrays
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+@testset "solver/implicit residual parity njl smoke" begin
+    p_num = 10
+    t_num = 4
+    xi = 0.0
+
+    @testset "NJL2 parity" begin
+        model = Models.create_model(:NJL2)
+        problem = Models.build_njl_problem(model; p_num=p_num, t_num=t_num, xi=xi)
+
+        theta = [0.12, 0.0]
+        x, meta = problem.forward_solve(theta)
+        @test meta === nothing
+        @test length(x) == 2
+
+        params = Models.GapParams(theta[1], Models.cached_nodes(p_num, t_num), xi;
+            p_num=p_num, t_num=t_num, model_kind=:NJL2)
+        mu_vec = SVector{3}(theta[2], theta[2], theta[2])
+
+        F_solver = zeros(2)
+        Models.gap_core_residual!(F_solver, x, mu_vec, params)
+
+        F_implicit = problem.conditions(theta, x, meta)
+        @test length(F_implicit) == 2
+        @test all(isfinite, F_implicit)
+
+        for i in 1:2
+            @test isapprox(F_solver[i], F_implicit[i]; rtol=1e-8, atol=1e-9)
+        end
+    end
+
+    @testset "NJL parity" begin
+        model = Models.create_model(:NJL)
+        problem = Models.build_njl_problem(model; p_num=p_num, t_num=t_num, xi=xi)
+
+        theta = [0.12, 0.0]
+        x, meta = problem.forward_solve(theta)
+        @test meta === nothing
+        @test length(x) == 3
+
+        params = Models.GapParams(theta[1], Models.cached_nodes(p_num, t_num), xi;
+            p_num=p_num, t_num=t_num, model_kind=:NJL)
+        mu_vec = SVector{3}(theta[2], theta[2], theta[2])
+
+        F_solver = zeros(3)
+        Models.gap_core_residual!(F_solver, x, mu_vec, params)
+
+        F_implicit = problem.conditions(theta, x, meta)
+        @test length(F_implicit) == 3
+        @test all(isfinite, F_implicit)
+
+        for i in 1:3
+            @test isapprox(F_solver[i], F_implicit[i]; rtol=1e-8, atol=1e-9)
+        end
+    end
+end

--- a/tests/integration/models/test_solver_implicit_residual_parity_smoke.jl
+++ b/tests/integration/models/test_solver_implicit_residual_parity_smoke.jl
@@ -1,0 +1,58 @@
+using Test
+using StaticArrays
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+@testset "solver/implicit residual parity smoke" begin
+    model = Models.create_model(:PNJL)
+    p_num = 12
+    t_num = 4
+    xi = 0.0
+
+    @testset "fixed-mu parity" begin
+        adapters = Models.build_pnjl_fixedmu_adapters(model; p_num=p_num, t_num=t_num, xi=xi)
+        theta = [0.5, 0.12]
+        x, meta = adapters.forward_solve(theta)
+        @test meta === nothing
+
+        thermal_nodes = Models.cached_nodes(p_num, t_num)
+        params = Models.GapParams(theta[1], thermal_nodes, xi; p_num=p_num, t_num=t_num, model_kind=:PNJL)
+
+        residual_solver! = Models.build_residual!(Models.FixedMu(), SVector{3}(theta[2], theta[2], theta[2]), params)
+        F_solver = zeros(5)
+        residual_solver!(F_solver, x)
+
+        F_implicit = adapters.conditions(theta, x, meta)
+        @test length(F_implicit) == 5
+        @test all(isfinite, F_implicit)
+
+        for i in 1:5
+            @test isapprox(F_solver[i], F_implicit[i]; rtol=1e-8, atol=1e-9)
+        end
+    end
+
+    @testset "flavor-mu parity" begin
+        adapters = Models.build_pnjl_flavor_mu_adapters(model; p_num=p_num, t_num=t_num, xi=xi)
+        theta = [0.5, 0.18, 0.12, 0.06]
+        x, meta = adapters.forward_solve(theta)
+        @test meta === nothing
+
+        thermal_nodes = Models.cached_nodes(p_num, t_num)
+        params = Models.GapParams(theta[1], thermal_nodes, xi; p_num=p_num, t_num=t_num, model_kind=:PNJL)
+        F_solver = zeros(5)
+        mu_vec = SVector{3}(theta[2], theta[3], theta[4])
+        Models.gap_core_residual!(F_solver, SVector{5}(Tuple(x)), mu_vec, params)
+
+        F_implicit = adapters.conditions(theta, x, meta)
+        @test length(F_implicit) == 5
+        @test all(isfinite, F_implicit)
+
+        for i in 1:5
+            @test isapprox(F_solver[i], F_implicit[i]; rtol=1e-8, atol=1e-9)
+        end
+    end
+end

--- a/tests/unit/models/test_gap_core_residual.jl
+++ b/tests/unit/models/test_gap_core_residual.jl
@@ -1,0 +1,72 @@
+using Test
+using StaticArrays
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+@testset "gap_core_residual parity" begin
+    model = Models.create_model(:PNJL)
+    x_state = SVector{5}(-1.84, -1.84, -2.23, 0.5, 0.5)
+    mu_vec = SVector{3}(0.0, 0.0, 0.0)
+    thermal_nodes = Models.cached_nodes(8, 4)
+    params = Models.GapParams(0.5, thermal_nodes, 0.0; p_num=8, t_num=4, model_kind=:PNJL)
+
+    F_core = zeros(5)
+    Models.gap_core_residual!(F_core, x_state, mu_vec, params)
+    F_gap = Models.gap_conditions(x_state, mu_vec, params)
+
+    @test length(F_core) == 5
+    for i in 1:5
+        @test isapprox(F_core[i], F_gap[i]; rtol=1e-9, atol=1e-9)
+    end
+end
+
+@testset "build_residual delegates core block" begin
+    x_state = SVector{5}(-1.84, -1.84, -2.23, 0.5, 0.5)
+    mu_vec = SVector{3}(0.0, 0.0, 0.0)
+    thermal_nodes = Models.cached_nodes(8, 4)
+    params = Models.GapParams(0.5, thermal_nodes, 0.0; p_num=8, t_num=4, model_kind=:PNJL)
+
+    F_core = zeros(5)
+    Models.gap_core_residual!(F_core, x_state, mu_vec, params)
+
+    fixed_mu_residual! = Models.build_residual!(Models.FixedMu(), mu_vec, params)
+    F_mu = zeros(5)
+    fixed_mu_residual!(F_mu, collect(x_state))
+    for i in 1:5
+        @test isapprox(F_mu[i], F_core[i]; rtol=1e-9, atol=1e-9)
+    end
+
+    x_full = vcat(collect(x_state), collect(mu_vec))
+
+    fixed_rho_residual! = Models.build_residual!(Models.FixedRho(0.1), params)
+    F_rho = zeros(8)
+    fixed_rho_residual!(F_rho, copy(x_full))
+    for i in 1:5
+        @test isapprox(F_rho[i], F_core[i]; rtol=1e-9, atol=1e-9)
+    end
+
+    fixed_entropy_residual! = Models.build_residual!(Models.FixedEntropy(0.1), params)
+    F_entropy = zeros(8)
+    fixed_entropy_residual!(F_entropy, copy(x_full))
+    for i in 1:5
+        @test isapprox(F_entropy[i], F_core[i]; rtol=1e-9, atol=1e-9)
+    end
+
+    fixed_sigma_residual! = Models.build_residual!(Models.FixedSigma(1.0), params)
+    F_sigma = zeros(8)
+    fixed_sigma_residual!(F_sigma, copy(x_full))
+    for i in 1:5
+        @test isapprox(F_sigma[i], F_core[i]; rtol=1e-9, atol=1e-9)
+    end
+
+    fixed_asym_residual! = Models.build_residual!(Models.FixedAsymmetricRho(0.1, 1.0, 0.0), params)
+    F_asym = zeros(8)
+    fixed_asym_residual!(F_asym, copy(x_full))
+    for i in 1:5
+        @test isapprox(F_asym[i], F_core[i]; rtol=1e-9, atol=1e-9)
+    end
+end

--- a/tests/unit/models/test_gap_core_residual.jl
+++ b/tests/unit/models/test_gap_core_residual.jl
@@ -24,6 +24,15 @@ end
     end
 end
 
+@testset "build_conditions fixedmu enforces strict x length" begin
+    thermal_nodes = Models.cached_nodes(8, 4)
+    params = Models.GapParams(0.5, thermal_nodes, 0.0; p_num=8, t_num=4, model_kind=:PNJL)
+    cond = Models.build_conditions(Models.FixedMu(), params)
+    theta = [0.5, 0.0]
+
+    @test_throws ArgumentError cond(theta, [-1.84, -1.84, -2.23, 0.5, 0.5, 0.0])
+end
+
 @testset "build_residual delegates core block" begin
     x_state = SVector{5}(-1.84, -1.84, -2.23, 0.5, 0.5)
     mu_vec = SVector{3}(0.0, 0.0, 0.0)

--- a/tests/unit/models/test_gap_core_residual_njl_parity.jl
+++ b/tests/unit/models/test_gap_core_residual_njl_parity.jl
@@ -1,0 +1,47 @@
+using Test
+using StaticArrays
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+@testset "gap_core_residual njl parity" begin
+    p_num = 8
+    t_num = 4
+    xi = 0.0
+    thermal_nodes = Models.cached_nodes(p_num, t_num)
+
+    @testset "NJL2 dim=2" begin
+        model = Models.create_model(:NJL2)
+        x_state = SVector{2}(-1.84, -1.82)
+        mu_vec = SVector{3}(0.0, 0.0, 0.0)
+        params = Models.GapParams(0.5, thermal_nodes, xi; p_num=p_num, t_num=t_num, model_kind=:NJL2)
+
+        F_core = zeros(2)
+        Models.gap_core_residual!(F_core, x_state, mu_vec, params)
+        F_ref = Models.gap_residual(model, x_state, params.T_fm, mu_vec; p_num=p_num, t_num=t_num, xi=xi)
+
+        @test length(F_core) == 2
+        for i in 1:2
+            @test isapprox(F_core[i], F_ref[i]; rtol=1e-9, atol=1e-9)
+        end
+    end
+
+    @testset "NJL dim=3" begin
+        model = Models.create_model(:NJL)
+        x_state = SVector{3}(-1.84, -1.84, -2.23)
+        mu_vec = SVector{3}(0.0, 0.0, 0.0)
+        params = Models.GapParams(0.5, thermal_nodes, xi; p_num=p_num, t_num=t_num, model_kind=:NJL)
+
+        F_core = zeros(3)
+        Models.gap_core_residual!(F_core, x_state, mu_vec, params)
+        F_ref = Models.gap_residual(model, x_state, params.T_fm, mu_vec; p_num=p_num, t_num=t_num, xi=xi)
+
+        @test length(F_core) == 3
+        for i in 1:3
+            @test isapprox(F_core[i], F_ref[i]; rtol=1e-9, atol=1e-9)
+        end
+    end
+end

--- a/tests/unit/models/test_mode_accessor_schema.jl
+++ b/tests/unit/models/test_mode_accessor_schema.jl
@@ -1,0 +1,34 @@
+using Test
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+@testset "mode accessor schema" begin
+    schema = Models.schema_for_model(:PNJL)
+
+    @testset "FixedMu 索引映射" begin
+        x = [-1.84, -1.84, -2.23, 0.5, 0.5]
+        sv = Models.state_view(schema, x)
+        @test length(sv) == 5
+        @test sv[1] == x[1]
+        @test sv[5] == x[5]
+    end
+
+    @testset "FixedRho 索引映射" begin
+        x = [-1.84, -1.84, -2.23, 0.5, 0.5, 0.11, 0.12, 0.13]
+        sv = Models.state_view(schema, x)
+        mv = Models.mu_view(schema, x; mu_dim=3)
+        @test length(sv) == 5
+        @test length(mv) == 3
+        @test mv[1] == x[6]
+        @test mv[3] == x[8]
+    end
+
+    @testset "维度错配抛 ArgumentError" begin
+        @test_throws ArgumentError Models.state_view(schema, [1.0, 2.0, 3.0])
+        @test_throws ArgumentError Models.mu_view(schema, [-1.0, -1.0, -2.0, 0.5, 0.5, 0.1, 0.2]; mu_dim=3)
+    end
+end


### PR DESCRIPTION
## Summary
- 将 `gap_core_residual!` 从 PNJL-only（5维）扩展为统一 2/3/5 维入口：5 维保留原 fast-path，2/3 维复用既有 `gap_residual` 数学路径，确保不改动物理公式
- 移除 implicit adapter 中 `state_n == 5` 的硬门槛，使 `NJL2/NJL/PNJL` 的条件装配都走 shared core 残差内核
- 新增 NJL 的 unit/integration parity smoke，并在 active 任务单中回填执行证据与治理检查结果

## Why
- 任务单目标是“单 base 残差 + schema 适配层收口”，此前 NJL 2/3 维仍走 fallback，导致 solver/implicit 线性化语义在跨 model 维度上不一致
- 本 PR 把差异收敛到统一入口，降低后续模式扩展时的分叉维护成本

## Scope and Non-goals
- In scope: residual kernel 入口统一、implicit adapter 路由统一、对应 parity 回归测试
- Out of scope: 物理公式改写、数值策略调参、目录重构

## Reviewer Focus
- `src/models/solver/Conditions.jl`: 2/3/5 维 `gap_core_residual!` 分发是否保持 Dual 友好与维度错误信息清晰
- `src/models/solver/ImplicitAdapters.jl`: shared core 路由条件是否正确覆盖 `NJL2/NJL/PNJL`
- `tests/*njl*parity*`: 新增 parity 测试是否充分约束“入口统一但公式不变”

## Verification
- `julia --project=. -e 'include("tests/unit/models/test_gap_core_residual_njl_parity.jl")'`
- `julia --project=. -e 'include("tests/integration/models/test_solver_implicit_residual_parity_njl_smoke.jl")'`
- `julia --project=. -e 'include("tests/integration/models/test_models_implicitdiff_njl2_smoke.jl")'`
- `julia --project=. -e 'include("tests/integration/models/test_ad_implicit_contract_smoke.jl")'`
- `julia --project=. -e 'include("tests/integration/models/test_solver_implicit_residual_parity_smoke.jl")'`
- `julia --project=. -e 'include("tests/unit/models/test_gap_core_residual.jl")'`
- `julia --project=. -e 'include("tests/unit/models/test_mode_accessor_schema.jl")'`
- `julia --project=. -e 'include("tests/unit/models/test_implicit_gap.jl")'`
- `julia --project=. -e 'include("tests/integration/models/test_solver_auto_backend_semantic_parity.jl")'`
- `julia --project=. scripts/dev/check_docs_consistency.jl`
- `julia --project=. scripts/dev/check_active_docs_governance.jl`