### PR TITLE
refactor(models/solver): converge governance semantics and seed-pool assembly (PR-B)

### DIFF
--- a/docs/dev/active/2026-04-08_solver_能力链路收敛_PR-B任务单.md
+++ b/docs/dev/active/2026-04-08_solver_能力链路收敛_PR-B任务单.md
@@ -10,11 +10,11 @@
 
 ### 2.1 本期范围（PR-B）
 
-- [ ] B2.1 统一 candidate 最小 schema：`converged/residual_norm/hard_constraint_ok/failed_constraints/pressure/seed_index`。
-- [ ] B2.2 统一 success 判定入口，各层不再各写一套判定。
+- [x] B2.1 统一 candidate 最小 schema：`converged/residual_norm/hard_constraint_ok/failed_constraints/pressure/seed_index`。
+- [x] B2.2 统一 success 判定入口，各层不再各写一套判定。
 - [ ] B2.3 统一 selector 调用点，避免二次筛选与语义漂移。
-- [ ] B2.4 清理 `Solver.jl` 与 `ScanCommon.jl` 中重复治理判断。
-- [ ] B3.1 提取 mode-aware seed pool builder（单一入口）。
+- [x] B2.4 清理 `Solver.jl` 与 `ScanCommon.jl` 中重复治理判断。
+- [x] B3.1 提取 mode-aware seed pool builder（单一入口）。
 - [ ] B3.2 `solve_multi`、`ProblemSpec`、scan 侧统一复用 builder。
 - [ ] B3.3 统一 seed 去重/顺序/continuity 注入规则并文档化。
 
@@ -27,15 +27,34 @@
 
 ### 3.1 治理契约收敛
 
-- [ ] 提供 `normalize_candidate_for_governance(...)`（或等价入口），把不同来源 candidate 归一到最小 schema。
-- [ ] 提供 `evaluate_candidate_success(...)`（或等价入口）作为唯一 success 判定。
-- [ ] 在 `Solver` / `ProblemSpec` / `ScanCommon` 替换本地治理拼装逻辑，统一走上述入口。
+- [x] 提供 `normalize_candidate_for_governance(...)`（或等价入口），把不同来源 candidate 归一到最小 schema。
+- [x] 提供 `evaluate_candidate_success(...)`（或等价入口）作为唯一 success 判定。
+- [x] 在 `Solver` / `ProblemSpec` / `ScanCommon` 替换本地治理拼装逻辑，统一走上述入口。
+
+#### 3.1 进展记录（2026-04-08）
+
+- 新增统一入口：`CandidateGovernance.evaluate_candidate_success` 与 `CandidateGovernance.normalize_governance_candidate`。
+- `Solver.solve_multi(FixedMu/FixedRho/FixedAsymmetricRho)` 已改为统一调用归一化与 success 入口，移除局部口径分叉。
+- 已补单测：`tests/unit/models/test_candidate_governance_contract.jl` 新增 helper 契约测试。
+- 已回归验证：
+  - `tests/unit/models/test_candidate_governance_contract.jl`
+  - `tests/unit/models/test_solver.jl`
+  - `REGRESSION_FILES=models/test_solver_attempt_engine_convergence_regression.jl;pnjl/test_constraint_selection_regression.jl`
+- 追加收敛（本轮）：
+  - `ProblemSpec._execute_governed_attempt_plan` 接入统一 `normalize_governance_candidate/evaluate_candidate_success`。
+  - `ScanCommon.attempt_with_candidates` 接入统一 governance helper，移除本地 success 口径分叉。
 
 ### 3.2 seed pool 收敛
 
 - [ ] 提取 `build_seed_pool(mode, seed_guess, kwargs...)`（命名可按现有风格调整）。
 - [ ] 合并当前 `_build_default_seed_candidates` 的重复使用场景与散点 fallback。
 - [ ] 固化顺序稳定性（主 seed、显式候选、默认候选、去重策略）。
+
+#### 3.2 进展记录（2026-04-08）
+
+- 新增统一入口：`CandidateGovernance.build_seed_pool(mode; primary_seed, extra_seed_pool, provided_seed_pool, default_seed_pool, seed_extend)`。
+- `ProblemSpec._build_governed_attempt_plan` 已改为复用 `build_seed_pool`，固定顺序为主 seed -> extra -> provided -> default，并统一去重键。
+- `Solver/scan` 侧 seed 组装复用尚未完成（留在 B3.2）。
 
 ### 3.3 文档与契约同步
 

--- a/docs/dev/active/2026-04-08_solver_能力链路收敛_PR-B任务单.md
+++ b/docs/dev/active/2026-04-08_solver_能力链路收敛_PR-B任务单.md
@@ -15,8 +15,8 @@
 - [ ] B2.3 统一 selector 调用点，避免二次筛选与语义漂移。
 - [x] B2.4 清理 `Solver.jl` 与 `ScanCommon.jl` 中重复治理判断。
 - [x] B3.1 提取 mode-aware seed pool builder（单一入口）。
-- [ ] B3.2 `solve_multi`、`ProblemSpec`、scan 侧统一复用 builder。
-- [ ] B3.3 统一 seed 去重/顺序/continuity 注入规则并文档化。
+- [x] B3.2 `solve_multi`、`ProblemSpec`、scan 侧统一复用 builder。
+- [x] B3.3 统一 seed 去重/顺序/continuity 注入规则并文档化。
 
 ### 2.2 非范围（延后到 PR-C）
 
@@ -54,11 +54,12 @@
 
 - 新增统一入口：`CandidateGovernance.build_seed_pool(mode; primary_seed, extra_seed_pool, provided_seed_pool, default_seed_pool, seed_extend)`。
 - `ProblemSpec._build_governed_attempt_plan` 已改为复用 `build_seed_pool`，固定顺序为主 seed -> extra -> provided -> default，并统一去重键。
-- `Solver/scan` 侧 seed 组装复用尚未完成（留在 B3.2）。
+- `Solver.solve_multi(FixedMu/FixedRho/FixedAsymmetricRho)` 与 `TmuScan/TrhoScan` 已改为复用 `build_seed_pool`。
+- 去重/顺序/continuity 规则：continuity(若有) 作为 primary；随后 explicit/provided；最后默认候选；统一按 12 位 round-key 去重。
 
 ### 3.3 文档与契约同步
 
-- [ ] 在本任务单中补“能力 -> 唯一实现点”矩阵。
+- [x] 在本任务单中补“能力 -> 唯一实现点”矩阵。
 - [ ] 若导出 API 发生变化，更新 `docs/api/` 对应页面（仅在必要时）。
 
 ## 4. 影响文件（预期）
@@ -85,7 +86,28 @@ julia --project=. -e 'ENV["REGRESSION_FILES"]="models/test_solver_attempt_engine
 - [ ] 治理口径单点实现，调用方不再自行拼装 success/hard-constraint 判定。
 - [ ] seed pool 单点组装，调用方不再重复拼接候选。
 - [ ] 关键 unit/regression 全通过，无不可解释行为漂移。
+- [x] 关键 unit/regression 全通过，无不可解释行为漂移。
 - [ ] 本任务单状态、验证记录与代码实际一致。
+- [x] 本任务单状态、验证记录与代码实际一致。
+
+#### 本轮验证（2026-04-08，seed 收敛后）
+
+- unit:
+  - `ENV["UNIT_FILES"]="models/test_candidate_governance_contract.jl;models/test_solver.jl;models/test_problem_spec_contract.jl;models/test_scan_common.jl;models/test_tmu_scan.jl;models/test_trho_scan.jl"`
+  - 结果：`310 passed`
+- regression:
+  - `ENV["REGRESSION_FILES"]="models/test_solver_attempt_engine_convergence_regression.jl;pnjl/test_constraint_selection_regression.jl"`
+  - 结果：`36 passed`
+
+## 8. 能力 -> 唯一实现点矩阵（PR-B）
+
+| 能力 | 唯一实现点 | 说明 |
+|---|---|---|
+| candidate success 判定 | `CandidateGovernance.evaluate_candidate_success` | 各层统一调用，避免局部口径分叉。 |
+| candidate 最小 schema 归一 | `CandidateGovernance.normalize_governance_candidate` | 统一 `converged/residual_norm/hard_constraint_ok/failed_constraints/pressure/seed_index`。 |
+| seed pool 组装与去重 | `CandidateGovernance.build_seed_pool` | 统一 primary -> extra/provided -> default 顺序与去重规则。 |
+| ProblemSpec 治理执行 | `ProblemSpec._execute_governed_attempt_plan` | 统一调用 governance helper，不再本地判定 success。 |
+| scan 治理候选聚合 | `ScanCommon.attempt_with_candidates` | 统一调用 governance helper，selection 仍由 selector 决定。 |
 
 ## 7. 风险与回退
 

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -68,6 +68,7 @@ export ProblemSpec, build_problem_spec, ExtraConstraints, default_extra_constrai
 export AbstractConstraintComponent
 export constraint_name, constraint_dim, build_constraint_components, constraint_total_dim
 export HardRule, CandidateSelector, build_candidate_context
+export evaluate_candidate_success, normalize_governance_candidate, build_seed_pool
 export VarSchema, SchemaRegistry, register_schema!, schema_for, validate_schema
 export named_to_vec, vec_to_named
 export state_view, mu_view

--- a/src/models/scans/ScanCommon.jl
+++ b/src/models/scans/ScanCommon.jl
@@ -171,6 +171,7 @@ function attempt_with_candidates(candidates;
     governance_candidates = NamedTuple{(:pressure, :residual_norm, :hard_constraint_ok, :failed_constraints, :converged), Tuple{Float64, Float64, Bool, Vector{Symbol}, Bool}}[]
     point_results = Union{Nothing, SolverResult}[]
     candidate_labels = String[]
+    governance_residual_norm_max = 1e-6
 
     scanned = Main.Models.execute_attempt_pool(candidates;
         stop_on_first_success=stop_on_first_success,
@@ -205,7 +206,20 @@ function attempt_with_candidates(candidates;
                     converged=success,
                 ),
             )
-            return scanned_candidate, success
+            normalized = Main.Models.normalize_governance_candidate(scanned_candidate.governance;
+                seed_index=1,
+                residual_norm_max=governance_residual_norm_max,
+                failed_default=:scan_candidate_failed,
+            )
+            governance = (
+                pressure=normalized.pressure,
+                residual_norm=normalized.residual_norm,
+                hard_constraint_ok=normalized.hard_constraint_ok,
+                failed_constraints=normalized.failed_constraints,
+                converged=normalized.converged,
+            )
+            merged = (; scanned_candidate..., governance=governance)
+            return merged, Main.Models.evaluate_candidate_success(governance; residual_norm_max=governance_residual_norm_max)
         end,
         on_error=(candidate, _, _) -> begin
             push!(messages, format_candidate_failure(candidate.label, "", nothing))
@@ -220,7 +234,20 @@ function attempt_with_candidates(candidates;
                     converged=false,
                 ),
             )
-            return scanned_candidate, false
+            normalized = Main.Models.normalize_governance_candidate(scanned_candidate.governance;
+                seed_index=1,
+                residual_norm_max=governance_residual_norm_max,
+                failed_default=:scan_candidate_failed,
+            )
+            governance = (
+                pressure=normalized.pressure,
+                residual_norm=normalized.residual_norm,
+                hard_constraint_ok=normalized.hard_constraint_ok,
+                failed_constraints=normalized.failed_constraints,
+                converged=normalized.converged,
+            )
+            merged = (; scanned_candidate..., governance=governance)
+            return merged, Main.Models.evaluate_candidate_success(governance; residual_norm_max=governance_residual_norm_max)
         end,
     )
 
@@ -232,7 +259,7 @@ function attempt_with_candidates(candidates;
 
     isempty(governance_candidates) && return nothing, join_messages(messages)
 
-    has_success = any(c -> c.converged, governance_candidates)
+    has_success = any(c -> Main.Models.evaluate_candidate_success(c; residual_norm_max=governance_residual_norm_max), governance_candidates)
     selected = Main.Models.select_pressure_max_candidate(governance_candidates, nothing, nothing)
     selected_idx = Int(selected.selected_index)
     selection_note = "governance.selection=$(selected.selection_reason);seed=$(candidate_labels[selected_idx])"

--- a/src/models/scans/TmuScan.jl
+++ b/src/models/scans/TmuScan.jl
@@ -306,41 +306,79 @@ _seed_continuation_key(T, xi) = ScanCommon.key2(T, xi; digits=SEED_KEY_DIGITS)
     return nothing
 end
 
+@inline function _seed_pool_source_to_label(source::Symbol, idx::Int)
+    if source == :primary
+        return "continuation"
+    elseif source == :provided
+        return "multiseed_$(idx)"
+    elseif source == :extra
+        return "fallback_$(idx)"
+    end
+    return "default_$(idx)"
+end
+
 """构建初值候选列表（连续性 + 多初值全评估）"""
 function _build_seed_candidates_v2(cache::Dict, T, mu, xi, T_fm, μ_fm; bootstrap_multiseed::Bool)
-    candidates = NamedTuple{(:label, :state), Tuple{String, Vector{Float64}}}[]
-    seen_states = Set{String}()
-    
+    provided_seed_pool = Vector{Vector{Float64}}()
+    default_seed_pool = Vector{Vector{Float64}}()
+    primary_seed = nothing
+
     # 1. 连续性种子（最优先）
     seed_key = _seed_continuation_key(T, xi)
     if haskey(cache, seed_key)
-        _push_unique_candidate!(candidates, seen_states, "continuation", cache[seed_key])
+        primary_seed = Float64.(cache[seed_key])
     end
 
     # 2. 多初值候选（可选）
     if bootstrap_multiseed
         multiseeds = get_all_seeds(MultiSeed(), [T_fm, μ_fm], FixedMu())
-        for (idx, seed) in enumerate(multiseeds)
-            _push_unique_candidate!(candidates, seen_states, "multiseed_$(idx)", seed)
-        end
+        append!(provided_seed_pool, [Float64.(seed) for seed in multiseeds])
     end
     
     # 3. 基于相位启发式的基础候选（兜底）
     hint = auto_phase_hint(T_fm, μ_fm)
     if hint === :quark
-        _push_unique_candidate!(candidates, seen_states, "quark", QUARK_SEED_5)
-        _push_unique_candidate!(candidates, seen_states, "hadron", HADRON_SEED_5)
+        push!(default_seed_pool, Float64.(QUARK_SEED_5))
+        push!(default_seed_pool, Float64.(HADRON_SEED_5))
     else
-        _push_unique_candidate!(candidates, seen_states, "hadron", HADRON_SEED_5)
-        _push_unique_candidate!(candidates, seen_states, "quark", QUARK_SEED_5)
+        push!(default_seed_pool, Float64.(HADRON_SEED_5))
+        push!(default_seed_pool, Float64.(QUARK_SEED_5))
     end
 
     # 4. 温区兜底候选（高温/弱手征场景）
-    _push_unique_candidate!(candidates, seen_states, "weak_chiral_conf", WEAK_CHIRAL_CONF_SEED_5)
-    _push_unique_candidate!(candidates, seen_states, "ht_0p8", HT_GUESS_0p8_SEED_5)
-    _push_unique_candidate!(candidates, seen_states, "ht_0p9", HT_GUESS_0p9_SEED_5)
-    _push_unique_candidate!(candidates, seen_states, "ht_0p95", HT_GUESS_0p95_SEED_5)
-    
+    append!(default_seed_pool, (
+        Float64.(WEAK_CHIRAL_CONF_SEED_5),
+        Float64.(HT_GUESS_0p8_SEED_5),
+        Float64.(HT_GUESS_0p9_SEED_5),
+        Float64.(HT_GUESS_0p95_SEED_5),
+    ))
+
+    if primary_seed === nothing
+        if !isempty(provided_seed_pool)
+            primary_seed = provided_seed_pool[1]
+            provided_seed_pool = provided_seed_pool[2:end]
+        elseif !isempty(default_seed_pool)
+            primary_seed = default_seed_pool[1]
+            default_seed_pool = default_seed_pool[2:end]
+        else
+            primary_seed = Float64.(HADRON_SEED_5)
+        end
+    end
+
+    seed_pool = Main.Models.build_seed_pool(FixedMu();
+        primary_seed=primary_seed,
+        provided_seed_pool=provided_seed_pool,
+        default_seed_pool=default_seed_pool,
+        seed_extend=(seed, _) -> Float64.(seed),
+    )
+
+    candidates = NamedTuple{(:label, :state), Tuple{String, Vector{Float64}}}[]
+    seen_states = Set{String}()
+    for (idx, entry) in enumerate(seed_pool)
+        label = _seed_pool_source_to_label(entry.source, idx)
+        _push_unique_candidate!(candidates, seen_states, label, entry.seed)
+    end
+
     return candidates
 end
 

--- a/src/models/scans/TrhoScan.jl
+++ b/src/models/scans/TrhoScan.jl
@@ -373,6 +373,17 @@ end
 
 _seed_continuation_key(T, xi) = ScanCommon.key2(T, xi; digits=SEED_KEY_DIGITS)
 
+@inline function _seed_pool_source_to_label(source::Symbol, idx::Int)
+    if source == :primary
+        return "continuation"
+    elseif source == :provided
+        return "provided_$(idx)"
+    elseif source == :extra
+        return "extra_$(idx)"
+    end
+    return "default_$(idx)"
+end
+
 """根据密度选择合适的初值"""
 function _select_seed_for_rho(rho::Float64)
     if rho < 0.5
@@ -386,31 +397,48 @@ end
 
 """构建初值候选列表"""
 function _build_seed_candidates(cache::Dict, seed_key, T, rho)
-    candidates = NamedTuple{(:label, :state), Tuple{String, Vector{Float64}}}[]
-    
+    primary_seed = nothing
+    default_seed_pool = Vector{Vector{Float64}}()
+
     # 1. 连续性种子（优先）
     if haskey(cache, seed_key)
         cached = cache[seed_key]
         # 确保是 8 维
         if length(cached) == 8
-            push!(candidates, (label="continuation", state=copy(cached)))
+            primary_seed = Float64.(cached)
         elseif length(cached) >= 5
             # 扩展为 8 维
             extended = extend_seed(cached, FixedRho(rho))
-            push!(candidates, (label="continuation-ext", state=extended))
+            primary_seed = Float64.(extended)
         end
     end
     
     # 2. 基于密度的默认种子
     primary = _select_seed_for_rho(rho)
-    push!(candidates, (label="density-based", state=copy(primary)))
+    push!(default_seed_pool, copy(primary))
     
     # 3. 其他候选
     if rho >= 0.5
-        push!(candidates, (label="hadron", state=copy(HADRON_SEED_8)))
+        push!(default_seed_pool, copy(HADRON_SEED_8))
     end
     if rho < 2.0
-        push!(candidates, (label="high-density", state=copy(HIGH_DENSITY_SEED_8)))
+        push!(default_seed_pool, copy(HIGH_DENSITY_SEED_8))
+    end
+
+    if primary_seed === nothing
+        primary_seed = default_seed_pool[1]
+        default_seed_pool = default_seed_pool[2:end]
+    end
+
+    seed_pool = Main.Models.build_seed_pool(FixedRho(rho);
+        primary_seed=primary_seed,
+        default_seed_pool=default_seed_pool,
+        seed_extend=(seed, _) -> Float64.(seed),
+    )
+
+    candidates = NamedTuple{(:label, :state), Tuple{String, Vector{Float64}}}[]
+    for (idx, entry) in enumerate(seed_pool)
+        push!(candidates, (label=_seed_pool_source_to_label(entry.source, idx), state=entry.seed))
     end
     
     return candidates

--- a/src/models/solver/CandidateGovernance.jl
+++ b/src/models/solver/CandidateGovernance.jl
@@ -5,6 +5,95 @@
 const HardRule = Function
 const CandidateSelector = Function
 
+@inline function _seed_pool_key(seed_vec::AbstractVector{<:Real})
+    return join(round.(Float64.(seed_vec); digits=12), ",")
+end
+
+@inline function _push_seed_pool_entry!(
+    pool::Vector{NamedTuple{(:seed, :source), Tuple{Vector{Float64}, Symbol}}},
+    seen::Set{String},
+    seed::AbstractVector{<:Real},
+    source::Symbol,
+    mode::ConstraintMode,
+    seed_extend::Function,
+)
+    normalized = Float64.(seed_extend(Float64.(seed), mode))
+    key = _seed_pool_key(normalized)
+    key in seen && return nothing
+    push!(pool, (seed=normalized, source=source))
+    push!(seen, key)
+    return nothing
+end
+
+function build_seed_pool(
+    mode::ConstraintMode;
+    primary_seed::Union{Nothing, AbstractVector{<:Real}}=nothing,
+    extra_seed_pool=(),
+    provided_seed_pool=(),
+    default_seed_pool=(),
+    seed_extend::Function=(seed, _mode) -> Float64.(seed),
+)
+    pool = NamedTuple{(:seed, :source), Tuple{Vector{Float64}, Symbol}}[]
+    seen = Set{String}()
+
+    if primary_seed !== nothing
+        _push_seed_pool_entry!(pool, seen, primary_seed, :primary, mode, seed_extend)
+    end
+    for seed in extra_seed_pool
+        _push_seed_pool_entry!(pool, seen, seed, :extra, mode, seed_extend)
+    end
+    for seed in provided_seed_pool
+        _push_seed_pool_entry!(pool, seen, seed, :provided, mode, seed_extend)
+    end
+    for seed in default_seed_pool
+        _push_seed_pool_entry!(pool, seen, seed, :default, mode, seed_extend)
+    end
+    return pool
+end
+
+@inline function evaluate_candidate_success(candidate; residual_norm_max::Real=1e-6)
+    if hasproperty(candidate, :hard_constraint_ok) && Bool(getproperty(candidate, :hard_constraint_ok))
+        return true
+    end
+    Bool(get(candidate, :converged, false)) && return true
+    residual = Float64(get(candidate, :residual_norm, Inf))
+    return isfinite(residual) && residual <= Float64(residual_norm_max)
+end
+
+@inline function normalize_governance_candidate(candidate;
+    seed_index::Int,
+    residual_norm_max::Real=1e-6,
+    failed_default::Symbol=:residual_too_large,
+)
+    pressure = Float64(get(candidate, :pressure, -Inf))
+    residual_norm = Float64(get(candidate, :residual_norm, Inf))
+    converged = Bool(get(candidate, :converged, false))
+    hard_ok = if hasproperty(candidate, :hard_constraint_ok)
+        Bool(getproperty(candidate, :hard_constraint_ok))
+    else
+        evaluate_candidate_success(candidate; residual_norm_max=residual_norm_max)
+    end
+    failed_constraints = if hasproperty(candidate, :failed_constraints)
+        Symbol.(getproperty(candidate, :failed_constraints))
+    elseif hard_ok
+        Symbol[]
+    elseif !isfinite(residual_norm) && !converged
+        Symbol[:solver_failed]
+    elseif failed_default == :solver_failed
+        Symbol[:solver_failed]
+    else
+        Symbol[failed_default]
+    end
+    return (
+        converged=converged,
+        pressure=(isfinite(pressure) ? pressure : -Inf),
+        residual_norm=(isfinite(residual_norm) ? residual_norm : Inf),
+        hard_constraint_ok=hard_ok,
+        failed_constraints=failed_constraints,
+        seed_index=seed_index,
+    )
+end
+
 @inline function build_candidate_context(
     mode::ConstraintMode;
     continuity_seed_available::Bool=false,

--- a/src/models/solver/CandidateGovernance.jl
+++ b/src/models/solver/CandidateGovernance.jl
@@ -52,8 +52,8 @@ function build_seed_pool(
 end
 
 @inline function evaluate_candidate_success(candidate; residual_norm_max::Real=1e-6)
-    if hasproperty(candidate, :hard_constraint_ok) && Bool(getproperty(candidate, :hard_constraint_ok))
-        return true
+    if hasproperty(candidate, :hard_constraint_ok)
+        return Bool(getproperty(candidate, :hard_constraint_ok))
     end
     Bool(get(candidate, :converged, false)) && return true
     residual = Float64(get(candidate, :residual_norm, Inf))

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -37,10 +37,6 @@ end
     return vcat(collect(rules), [extra_rule])
 end
 
-@inline function _seed_key(seed_vec::AbstractVector{<:Real})
-    return join(round.(Float64.(seed_vec); digits=12), ",")
-end
-
 const DIAGNOSTIC_LEVELS = (:none, :summary, :full)
 
 @inline function _resolve_diagnostic_level(kwargs::Dict{Symbol,Any})::Symbol
@@ -110,40 +106,18 @@ function _build_governed_attempt_plan(
     fallback_method,
     extra_fallback_seeds=Vector{Vector{Float64}}(),
 )
-    primary_seed_vec = _extend_seed_with_extra(Float64.(primary_seed), mode, extra_constraints)
+    seed_extend = (seed, local_mode) -> _extend_seed_with_extra(seed, local_mode, extra_constraints)
+    seed_pool = build_seed_pool(mode;
+        primary_seed=primary_seed,
+        extra_seed_pool=extra_fallback_seeds,
+        provided_seed_pool=provided_seed_pool,
+        default_seed_pool=default_seed_pool,
+        seed_extend=seed_extend,
+    )
 
-    fallback_seeds = Vector{Vector{Float64}}()
-    seed_seen = Set{String}()
-
-    primary_key = _seed_key(primary_seed_vec)
-    push!(seed_seen, primary_key)
-
-    for seed in extra_fallback_seeds
-        normalized_seed = _extend_seed_with_extra(seed, mode, extra_constraints)
-        key = _seed_key(normalized_seed)
-        if !(key in seed_seen)
-            push!(fallback_seeds, normalized_seed)
-            push!(seed_seen, key)
-        end
-    end
-
-    for seed in provided_seed_pool
-        normalized_seed = _extend_seed_with_extra(seed, mode, extra_constraints)
-        key = _seed_key(normalized_seed)
-        if !(key in seed_seen)
-            push!(fallback_seeds, normalized_seed)
-            push!(seed_seen, key)
-        end
-    end
-
-    for seed in default_seed_pool
-        normalized_seed = _extend_seed_with_extra(seed, mode, extra_constraints)
-        key = _seed_key(normalized_seed)
-        if !(key in seed_seen)
-            push!(fallback_seeds, normalized_seed)
-            push!(seed_seen, key)
-        end
-    end
+    isempty(seed_pool) && throw(ArgumentError("build_seed_pool produced empty pool for $(typeof(mode))"))
+    primary_seed_vec = seed_pool[1].seed
+    fallback_seeds = [entry.seed for entry in seed_pool[2:end]]
 
     attempt_plan = NamedTuple[]
     push!(attempt_plan, (
@@ -608,12 +582,44 @@ function _execute_governed_attempt_plan(
             raw = solve_attempt(local_kwargs, attempt_cfg, attempt_index)
             ok, failed = evaluate_hard_constraints(raw, hard_constraints)
             candidate = (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, seed_index=Int(attempt_index))
-            return candidate, ok
+            normalized = normalize_governance_candidate(candidate;
+                seed_index=Int(attempt_index),
+                residual_norm_max=Float64(get(local_kwargs, :residual_norm_max, 1e-6)),
+                failed_default=:residual_too_large,
+            )
+            merged = (; candidate...,
+                converged=normalized.converged,
+                pressure=normalized.pressure,
+                residual_norm=normalized.residual_norm,
+                hard_constraint_ok=normalized.hard_constraint_ok,
+                failed_constraints=normalized.failed_constraints,
+                seed_index=normalized.seed_index,
+            )
+            success = evaluate_candidate_success(merged;
+                residual_norm_max=Float64(get(local_kwargs, :residual_norm_max, 1e-6)),
+            )
+            return merged, success
         end,
         on_error=(attempt_cfg, attempt_index, _) -> begin
             raw = failure_attempt(kwargs, attempt_cfg, attempt_index)
             candidate = (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index))
-            return candidate, false
+            normalized = normalize_governance_candidate(candidate;
+                seed_index=Int(attempt_index),
+                residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
+                failed_default=:solver_failed,
+            )
+            merged = (; candidate...,
+                converged=normalized.converged,
+                pressure=normalized.pressure,
+                residual_norm=normalized.residual_norm,
+                hard_constraint_ok=normalized.hard_constraint_ok,
+                failed_constraints=normalized.failed_constraints,
+                seed_index=normalized.seed_index,
+            )
+            success = evaluate_candidate_success(merged;
+                residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
+            )
+            return merged, success
         end,
     )
 

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -360,10 +360,23 @@ function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm:
                 failed_constraints=(ok ? Symbol[] : Symbol[:residual_too_large]),
                 seed_index=Int(seed_index),
             )
-            return candidate, ok
+            normalized = normalize_governance_candidate(candidate;
+                seed_index=Int(seed_index),
+                residual_norm_max=residual_norm_max,
+                failed_default=:residual_too_large,
+            )
+            merged = (; candidate...,
+                converged=normalized.converged,
+                pressure=normalized.pressure,
+                residual_norm=normalized.residual_norm,
+                hard_constraint_ok=normalized.hard_constraint_ok,
+                failed_constraints=normalized.failed_constraints,
+                seed_index=normalized.seed_index,
+            )
+            return merged, evaluate_candidate_success(merged; residual_norm_max=residual_norm_max)
         end,
         on_error=(_, seed_index, _) -> begin
-            return (
+            candidate = (
                 converged=false,
                 solution=Float64[],
                 x_state=zeros(5),
@@ -379,7 +392,21 @@ function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm:
                 hard_constraint_ok=false,
                 failed_constraints=Symbol[:solver_failed],
                 seed_index=Int(seed_index),
-            ), false
+            )
+            normalized = normalize_governance_candidate(candidate;
+                seed_index=Int(seed_index),
+                residual_norm_max=residual_norm_max,
+                failed_default=:solver_failed,
+            )
+            merged = (; candidate...,
+                converged=normalized.converged,
+                pressure=normalized.pressure,
+                residual_norm=normalized.residual_norm,
+                hard_constraint_ok=normalized.hard_constraint_ok,
+                failed_constraints=normalized.failed_constraints,
+                seed_index=normalized.seed_index,
+            )
+            return merged, evaluate_candidate_success(merged; residual_norm_max=residual_norm_max)
         end,
     )
 
@@ -456,16 +483,6 @@ function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymme
                 residual_norm_max=bridge.residual_norm_max,
                 forwarded...,
             )
-            ok = if hasproperty(raw, :hard_constraint_ok)
-                Bool(getproperty(raw, :hard_constraint_ok))
-            else
-                Bool(raw.converged) && isfinite(raw.residual_norm) && raw.residual_norm <= max(bridge.residual_norm_max, 1e-3)
-            end
-            failed = if hasproperty(raw, :failed_constraints)
-                Symbol.(getproperty(raw, :failed_constraints))
-            else
-                (ok ? Symbol[] : Symbol[:residual_too_large])
-            end
             candidate = (
                 converged=Bool(raw.converged),
                 solution=Float64.(raw.solution),
@@ -479,14 +496,27 @@ function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymme
                 masses=raw.masses,
                 iterations=Int(raw.iterations),
                 residual_norm=Float64(raw.residual_norm),
-                hard_constraint_ok=ok,
-                failed_constraints=failed,
+                hard_constraint_ok=(hasproperty(raw, :hard_constraint_ok) ? Bool(getproperty(raw, :hard_constraint_ok)) : false),
+                failed_constraints=(hasproperty(raw, :failed_constraints) ? Symbol.(getproperty(raw, :failed_constraints)) : Symbol[]),
                 seed_index=Int(seed_index),
             )
-            return candidate, ok
+            normalized = normalize_governance_candidate(candidate;
+                seed_index=Int(seed_index),
+                residual_norm_max=max(bridge.residual_norm_max, 1e-3),
+                failed_default=:residual_too_large,
+            )
+            merged = (; candidate...,
+                converged=normalized.converged,
+                pressure=normalized.pressure,
+                residual_norm=normalized.residual_norm,
+                hard_constraint_ok=normalized.hard_constraint_ok,
+                failed_constraints=normalized.failed_constraints,
+                seed_index=normalized.seed_index,
+            )
+            return merged, evaluate_candidate_success(merged; residual_norm_max=max(bridge.residual_norm_max, 1e-3))
         end,
         on_error=(_, seed_index, _) -> begin
-            return (
+            candidate = (
                 converged=false,
                 solution=Float64[],
                 x_state=zeros(5),
@@ -502,7 +532,21 @@ function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymme
                 hard_constraint_ok=false,
                 failed_constraints=Symbol[:solver_failed],
                 seed_index=Int(seed_index),
-            ), false
+            )
+            normalized = normalize_governance_candidate(candidate;
+                seed_index=Int(seed_index),
+                residual_norm_max=max(bridge.residual_norm_max, 1e-3),
+                failed_default=:solver_failed,
+            )
+            merged = (; candidate...,
+                converged=normalized.converged,
+                pressure=normalized.pressure,
+                residual_norm=normalized.residual_norm,
+                hard_constraint_ok=normalized.hard_constraint_ok,
+                failed_constraints=normalized.failed_constraints,
+                seed_index=normalized.seed_index,
+            )
+            return merged, evaluate_candidate_success(merged; residual_norm_max=max(bridge.residual_norm_max, 1e-3))
         end,
     )
 

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -307,12 +307,41 @@ function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm:
     evaluate_all_attempts = Bool(get(kwargs, :evaluate_all_attempts, true))
     seed_strategy = get(kwargs, :seed_strategy, MultiSeed())
 
-    seeds = if haskey(kwargs, :seeds)
+    explicit_seeds = if haskey(kwargs, :seeds)
         [Float64.(s) for s in kwargs[:seeds]]
     else
-        get_all_seeds(seed_strategy, [T_fm, μ_fm], mode)
+        Vector{Vector{Float64}}()
     end
-    isempty(seeds) && (seeds = [get_seed(DefaultSeed(), [T_fm, μ_fm], mode)])
+    strategy_seeds = if isempty(explicit_seeds)
+        if seed_strategy isa MultiSeed
+            get_all_seeds(seed_strategy, [T_fm, μ_fm], mode)
+        else
+            [get_seed(seed_strategy, [T_fm, μ_fm], mode)]
+        end
+    else
+        Vector{Vector{Float64}}()
+    end
+    fallback_default = [get_seed(DefaultSeed(), [T_fm, μ_fm], mode)]
+    seed_pool = if !isempty(explicit_seeds)
+        build_seed_pool(mode;
+            primary_seed=explicit_seeds[1],
+            extra_seed_pool=explicit_seeds[2:end],
+            seed_extend=(seed, _) -> Float64.(seed),
+        )
+    elseif !isempty(strategy_seeds)
+        build_seed_pool(mode;
+            primary_seed=strategy_seeds[1],
+            extra_seed_pool=strategy_seeds[2:end],
+            default_seed_pool=fallback_default,
+            seed_extend=(seed, _) -> Float64.(seed),
+        )
+    else
+        build_seed_pool(mode;
+            primary_seed=fallback_default[1],
+            seed_extend=(seed, _) -> Float64.(seed),
+        )
+    end
+    seeds = [entry.seed for entry in seed_pool]
 
     forwarded = _strip_forward_kwargs(kwargs, (
         :seed_strategy,
@@ -436,14 +465,54 @@ function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymme
     evaluate_all_attempts = Bool(get(kwargs, :evaluate_all_attempts, true))
 
     seed_strategy = get(kwargs, :seed_strategy, MultiSeed())
-    seeds = if haskey(kwargs, :seeds)
+    explicit_seeds = if haskey(kwargs, :seeds)
         [Float64.(s) for s in kwargs[:seeds]]
-    elseif haskey(kwargs, :seed_candidates)
+    else
+        Vector{Vector{Float64}}()
+    end
+    provided_seed_pool = if haskey(kwargs, :seed_candidates)
         [Float64.(s) for s in kwargs[:seed_candidates]]
     else
-        get_all_seeds(seed_strategy, [T_fm], mode)
+        Vector{Vector{Float64}}()
     end
-    isempty(seeds) && (seeds = [Float64.(bridge.seed_guess)])
+    strategy_seeds = if isempty(explicit_seeds) && isempty(provided_seed_pool)
+        if seed_strategy isa MultiSeed
+            get_all_seeds(seed_strategy, [T_fm], mode)
+        else
+            [get_seed(seed_strategy, [T_fm], mode)]
+        end
+    else
+        Vector{Vector{Float64}}()
+    end
+    seed_pool = if !isempty(explicit_seeds)
+        build_seed_pool(mode;
+            primary_seed=explicit_seeds[1],
+            extra_seed_pool=explicit_seeds[2:end],
+            provided_seed_pool=provided_seed_pool,
+            default_seed_pool=[Float64.(bridge.seed_guess)],
+            seed_extend=(seed, _) -> Float64.(seed),
+        )
+    elseif !isempty(provided_seed_pool)
+        build_seed_pool(mode;
+            primary_seed=provided_seed_pool[1],
+            extra_seed_pool=provided_seed_pool[2:end],
+            default_seed_pool=[Float64.(bridge.seed_guess)],
+            seed_extend=(seed, _) -> Float64.(seed),
+        )
+    elseif !isempty(strategy_seeds)
+        build_seed_pool(mode;
+            primary_seed=strategy_seeds[1],
+            extra_seed_pool=strategy_seeds[2:end],
+            default_seed_pool=[Float64.(bridge.seed_guess)],
+            seed_extend=(seed, _) -> Float64.(seed),
+        )
+    else
+        build_seed_pool(mode;
+            primary_seed=Float64.(bridge.seed_guess),
+            seed_extend=(seed, _) -> Float64.(seed),
+        )
+    end
+    seeds = [entry.seed for entry in seed_pool]
 
     forwarded = _strip_forward_kwargs(kwargs, (
         :seed_strategy,

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -552,6 +552,13 @@ function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymme
                 residual_norm_max=bridge.residual_norm_max,
                 forwarded...,
             )
+            inferred_ok = Bool(raw.converged) && isfinite(raw.residual_norm) && raw.residual_norm <= max(bridge.residual_norm_max, 1e-3)
+            hard_ok = hasproperty(raw, :hard_constraint_ok) ? Bool(getproperty(raw, :hard_constraint_ok)) : inferred_ok
+            failed = if hasproperty(raw, :failed_constraints)
+                Symbol.(getproperty(raw, :failed_constraints))
+            else
+                (hard_ok ? Symbol[] : Symbol[:residual_too_large])
+            end
             candidate = (
                 converged=Bool(raw.converged),
                 solution=Float64.(raw.solution),
@@ -565,8 +572,8 @@ function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymme
                 masses=raw.masses,
                 iterations=Int(raw.iterations),
                 residual_norm=Float64(raw.residual_norm),
-                hard_constraint_ok=(hasproperty(raw, :hard_constraint_ok) ? Bool(getproperty(raw, :hard_constraint_ok)) : false),
-                failed_constraints=(hasproperty(raw, :failed_constraints) ? Symbol.(getproperty(raw, :failed_constraints)) : Symbol[]),
+                hard_constraint_ok=hard_ok,
+                failed_constraints=failed,
                 seed_index=Int(seed_index),
             )
             normalized = normalize_governance_candidate(candidate;

--- a/tests/unit/models/test_candidate_governance_contract.jl
+++ b/tests/unit/models/test_candidate_governance_contract.jl
@@ -6,6 +6,48 @@ if !isdefined(Main, :Models)
     include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
 end
 
+@testset "candidate governance normalization helpers" begin
+    normalized_ok = Models.normalize_governance_candidate((;
+        converged=true,
+        pressure=5.0,
+        residual_norm=1e-8,
+        hard_constraint_ok=true,
+        failed_constraints=Symbol[],
+    ); seed_index=3)
+
+    @test normalized_ok.seed_index == 3
+    @test normalized_ok.converged
+    @test normalized_ok.hard_constraint_ok
+    @test normalized_ok.failed_constraints == Symbol[]
+
+    normalized_fail = Models.normalize_governance_candidate((;
+        converged=false,
+        pressure=NaN,
+        residual_norm=Inf,
+    ); seed_index=2)
+
+    @test normalized_fail.seed_index == 2
+    @test !normalized_fail.hard_constraint_ok
+    @test normalized_fail.failed_constraints == Symbol[:solver_failed]
+    @test normalized_fail.pressure == -Inf
+
+    @test Models.evaluate_candidate_success((; converged=true, residual_norm=1e-2, hard_constraint_ok=false); residual_norm_max=1e-6)
+    @test Models.evaluate_candidate_success((; converged=false, residual_norm=1e-8, hard_constraint_ok=true); residual_norm_max=1e-6)
+    @test !Models.evaluate_candidate_success((; converged=false, residual_norm=1e-2, hard_constraint_ok=false); residual_norm_max=1e-6)
+
+    pool = Models.build_seed_pool(Models.FixedEntropy(0.5);
+        primary_seed=[1.0, 2.0, 3.0],
+        extra_seed_pool=([4.0, 5.0, 6.0], [1.0, 2.0, 3.0]),
+        provided_seed_pool=([7.0, 8.0, 9.0],),
+        default_seed_pool=([7.0, 8.0, 9.0], [10.0, 11.0, 12.0]),
+    )
+    @test length(pool) == 4
+    @test pool[1].source == :primary
+    @test pool[2].source == :extra
+    @test pool[3].source == :provided
+    @test pool[4].source == :default
+end
+
 @testset "candidate governance contract" begin
     @test isdefined(Models, :build_candidate_context)
     @test isdefined(Models, :evaluate_hard_constraints)

--- a/tests/unit/models/test_candidate_governance_contract.jl
+++ b/tests/unit/models/test_candidate_governance_contract.jl
@@ -31,9 +31,10 @@ end
     @test normalized_fail.failed_constraints == Symbol[:solver_failed]
     @test normalized_fail.pressure == -Inf
 
-    @test Models.evaluate_candidate_success((; converged=true, residual_norm=1e-2, hard_constraint_ok=false); residual_norm_max=1e-6)
+    @test !Models.evaluate_candidate_success((; converged=true, residual_norm=1e-2, hard_constraint_ok=false); residual_norm_max=1e-6)
     @test Models.evaluate_candidate_success((; converged=false, residual_norm=1e-8, hard_constraint_ok=true); residual_norm_max=1e-6)
     @test !Models.evaluate_candidate_success((; converged=false, residual_norm=1e-2, hard_constraint_ok=false); residual_norm_max=1e-6)
+    @test !Models.evaluate_candidate_success((; converged=true, residual_norm=1e-8, hard_constraint_ok=false); residual_norm_max=1e-6)
 
     pool = Models.build_seed_pool(Models.FixedEntropy(0.5);
         primary_seed=[1.0, 2.0, 3.0],

--- a/tests/unit/models/test_tmu_scan.jl
+++ b/tests/unit/models/test_tmu_scan.jl
@@ -38,6 +38,18 @@ const _TMS = Models.TmuScan
         @test _TMS.run_tmu_scan isa Function
     end
 
+    @testset "seed pool builder keeps deterministic order" begin
+        cache = Dict{Tuple{Float64, Float64}, Vector{Float64}}(
+            _TMS._seed_continuation_key(120.0, 0.0) => copy(Models.HADRON_SEED_5),
+        )
+        candidates = _TMS._build_seed_candidates_v2(cache, 120.0, 100.0, 0.0, 120.0 / 197.327, 100.0 / 197.327; bootstrap_multiseed=false)
+        @test !isempty(candidates)
+        @test candidates[1].label == "continuation"
+        @test candidates[1].state == Float64.(Models.HADRON_SEED_5)
+        keys = Set(join(round.(c.state; digits=8), ",") for c in candidates)
+        @test length(keys) == length(candidates)
+    end
+
     @testset "auto backend 语义路由配置" begin
         @test _TMS._effective_solver_backend(:auto, :PNJL; auto_pnjl_backend=:models) == :models
         @test _TMS._effective_solver_backend(:auto, :PNJL; auto_pnjl_backend=:legacy) == :legacy  # route preserved; execution guard rejects legacy backend

--- a/tests/unit/models/test_trho_scan.jl
+++ b/tests/unit/models/test_trho_scan.jl
@@ -47,6 +47,17 @@ const _TS = Models.TrhoScan
         @test _TS.run_trho_scan isa Function
     end
 
+    @testset "seed pool builder uses continuation as primary" begin
+        key = _TS._seed_continuation_key(120.0, 0.0)
+        cache = Dict{Tuple{Float64, Float64}, Vector{Float64}}(key => copy(Models.HADRON_SEED_8))
+        candidates = _TS._build_seed_candidates(cache, key, 120.0, 0.2)
+        @test !isempty(candidates)
+        @test candidates[1].label == "continuation"
+        @test candidates[1].state == Float64.(Models.HADRON_SEED_8)
+        keys = Set(join(round.(c.state; digits=8), ",") for c in candidates)
+        @test length(keys) == length(candidates)
+    end
+
     @testset "auto backend 语义路由配置" begin
         @test _TS._effective_solver_backend(:auto, :PNJL; auto_pnjl_backend=:models) == :models
         @test _TS._effective_solver_backend(:auto, :PNJL; auto_pnjl_backend=:legacy) == :legacy  # route preserved; execution guard rejects legacy backend


### PR DESCRIPTION
## Summary
- unify governance semantics through shared helpers by routing `Solver`, `ProblemSpec`, and `ScanCommon` candidate normalization/success evaluation through `normalize_governance_candidate` and `evaluate_candidate_success`
- add a single mode-aware seed-pool builder `build_seed_pool` in `CandidateGovernance` and converge seed assembly call sites in `ProblemSpec`, `solve_multi` (FixedMu/FixedRho/FixedAsymmetricRho), and scan candidate builders (`TmuScan`/`TrhoScan`)
- update PR-B task sheet with completed items, capability-to-single-implementation matrix, and passing verification evidence

## Validation
- `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_candidate_governance_contract.jl;models/test_solver.jl;models/test_problem_spec_contract.jl;models/test_scan_common.jl"; include("tests/unit/runtests.jl")'`
- `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_candidate_governance_contract.jl;models/test_solver.jl;models/test_problem_spec_contract.jl;models/test_scan_common.jl;models/test_tmu_scan.jl;models/test_trho_scan.jl"; include("tests/unit/runtests.jl")'`
- `julia --project=. -e 'ENV["REGRESSION_FILES"]="models/test_solver_attempt_engine_convergence_regression.jl;pnjl/test_constraint_selection_regression.jl"; include("tests/regression/runtests.jl")'`