### PR TITLE
refactor(models/solver): unify error semantics and diagnostics contract (PR-C)

### DIFF
--- a/docs/dev/active/2026-04-08_solver_能力链路收敛_PR-C任务单.md
+++ b/docs/dev/active/2026-04-08_solver_能力链路收敛_PR-C任务单.md
@@ -10,10 +10,10 @@
 
 ### 2.1 本期范围（PR-C）
 
-- [ ] C4.1 全链统一异常语义：`InterruptException` 重抛；普通异常降级为候选失败。
-- [ ] C4.2 统一 diagnostics 字段：`error_kind/error_msg/attempt_origin/selection_reason` 等最小契约。
-- [ ] C4.3 贯通 scan 输出消息，避免多套字符串拼接语义。
-- [ ] C4.4 新增“异常注入回归 + 诊断契约回归”。
+- [x] C4.1 全链统一异常语义：`InterruptException` 重抛；普通异常降级为候选失败。
+- [x] C4.2 统一 diagnostics 字段：`error_kind/error_msg/attempt_origin/selection_reason` 等最小契约。
+- [x] C4.3 贯通 scan 输出消息，避免多套字符串拼接语义。
+- [x] C4.4 新增“异常注入回归 + 诊断契约回归”。
 
 ### 2.2 非范围
 
@@ -27,18 +27,27 @@
 - [ ] 在统一 attempt 执行链上固化错误分类（至少区分 interrupt / solver_error / constraint_error）。
 - [ ] on_error 回调统一返回结构，不允许调用方私有格式。
 - [ ] 清理历史 catch 分支中的语义不一致字段。
+- [x] 在统一 attempt 执行链上固化错误分类（至少区分 interrupt / solver_error / constraint_error）。
+- [x] on_error 回调统一返回结构，不允许调用方私有格式。
+- [x] 清理历史 catch 分支中的语义不一致字段。
 
 ### 3.2 诊断契约统一
 
 - [ ] 定义最小诊断字段集合与含义（文档化）。
 - [ ] `ProblemSpec` / `Solver` / `ScanCommon` 输出对齐该集合。
 - [ ] `_attach_solver_diagnostic`（若继续沿用）字段来源与优先级统一。
+- [x] 定义最小诊断字段集合与含义（文档化）。
+- [x] `ProblemSpec` / `Solver` / `ScanCommon` 输出对齐该集合。
+- [x] `_attach_solver_diagnostic`（若继续沿用）字段来源与优先级统一。
 
 ### 3.3 回归守护
 
 - [ ] 新增异常注入测试（验证 interrupt 不被吞、普通异常被降级）。
 - [ ] 新增诊断契约测试（字段存在性 + 语义稳定性）。
 - [ ] 关键回归纳入 smoke 或确保可通过 `REGRESSION_FILES` 单跑。
+- [x] 新增异常注入测试（验证 interrupt 不被吞、普通异常被降级）。
+- [x] 新增诊断契约测试（字段存在性 + 语义稳定性）。
+- [x] 关键回归纳入 smoke 或确保可通过 `REGRESSION_FILES` 单跑。
 
 ## 4. 影响文件（预期）
 
@@ -64,6 +73,33 @@ julia --project=. -e 'ENV["REGRESSION_FILES"]="models/test_solver_attempt_engine
 - [ ] diagnostics 字段集合稳定、可追踪、可回归。
 - [ ] scan 输出消息与 solver 诊断语义一致。
 - [ ] 相关 unit/regression 全通过，任务单记录与实现一致。
+- [x] 错误语义全链一致，`InterruptException` 行为受测试保护。
+- [x] diagnostics 字段集合稳定、可追踪、可回归。
+- [x] scan 输出消息与 solver 诊断语义一致。
+- [x] 相关 unit/regression 全通过，任务单记录与实现一致。
+
+## 8. PR-C 最小诊断契约（落地）
+
+- 最小字段集合：`error_kind` / `error_msg` / `attempt_origin` / `selection_reason`
+- 字段语义：
+  - `error_kind`：`:none | :interrupt | :solver_error | :constraint_error`
+  - `error_msg`：归一化短消息（去换行，长度受限）
+  - `attempt_origin`：attempt 来源（primary/method_rescue/seed_rescue 等）
+  - `selection_reason`：selector 最终选择原因
+- 落地点：
+  - `CandidateGovernance`: `classify_attempt_error`, `normalize_error_message`
+  - `ProblemSpec`: on_error 注入 `error_kind/error_msg`，`_attach_solver_diagnostic` 汇总
+  - `Solver`: `solve_multi` on_error 注入统一错误语义
+  - `ScanCommon`: scan 失败消息追加 `error.kind=...;error.msg=...`
+
+## 9. 本轮验证记录（2026-04-08）
+
+- unit:
+  - `ENV["UNIT_FILES"]="models/test_candidate_governance_contract.jl;models/test_solver_diagnostic_contract.jl;models/test_scan_common.jl"`
+  - 结果：`72 passed`
+- regression:
+  - `ENV["REGRESSION_FILES"]="models/test_solver_diagnostic_exception_regression.jl;models/test_solver_attempt_engine_convergence_regression.jl;pnjl/test_constraint_selection_regression.jl"`
+  - 结果：`40 passed`
 
 ## 7. 风险与回退
 

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -69,6 +69,7 @@ export AbstractConstraintComponent
 export constraint_name, constraint_dim, build_constraint_components, constraint_total_dim
 export HardRule, CandidateSelector, build_candidate_context
 export evaluate_candidate_success, normalize_governance_candidate, build_seed_pool
+export classify_attempt_error, normalize_error_message
 export VarSchema, SchemaRegistry, register_schema!, schema_for, validate_schema
 export named_to_vec, vec_to_named
 export state_view, mu_view

--- a/src/models/scans/ScanCommon.jl
+++ b/src/models/scans/ScanCommon.jl
@@ -223,7 +223,7 @@ function attempt_with_candidates(candidates;
         end,
         on_error=(candidate, _, err) -> begin
             err_kind = classify_attempt_error(err)
-            err_msg = normalize_error_message(err)
+            err_msg = clean_message(normalize_error_message(err))
             push!(messages, format_candidate_failure(candidate.label, "", nothing))
             push!(messages, "error.kind=$(err_kind);error.msg=$(err_msg)")
             scanned_candidate = (

--- a/src/models/scans/ScanCommon.jl
+++ b/src/models/scans/ScanCommon.jl
@@ -5,7 +5,7 @@ using Printf
 import Main.Models: ConstraintMode
 using ..SeedStrategies: SeedStrategy
 import ..SeedStrategies: get_seed
-import Main.Models: SolverResult
+import Main.Models: SolverResult, classify_attempt_error, normalize_error_message
 
 export fmt
 export clean_message
@@ -221,8 +221,11 @@ function attempt_with_candidates(candidates;
             merged = (; scanned_candidate..., governance=governance)
             return merged, Main.Models.evaluate_candidate_success(governance; residual_norm_max=governance_residual_norm_max)
         end,
-        on_error=(candidate, _, _) -> begin
+        on_error=(candidate, _, err) -> begin
+            err_kind = classify_attempt_error(err)
+            err_msg = normalize_error_message(err)
             push!(messages, format_candidate_failure(candidate.label, "", nothing))
+            push!(messages, "error.kind=$(err_kind);error.msg=$(err_msg)")
             scanned_candidate = (
                 label=String(candidate.label),
                 result=nothing,

--- a/src/models/solver/CandidateGovernance.jl
+++ b/src/models/solver/CandidateGovernance.jl
@@ -15,7 +15,7 @@ end
 @inline function normalize_error_message(err; max_chars::Int=240)::String
     msg = sprint(showerror, err)
     msg = replace(strip(msg), '\n' => ' ', '\r' => ' ')
-    if ncodeunits(msg) <= max_chars
+    if length(msg) <= max_chars
         return msg
     end
     return first(msg, max_chars)

--- a/src/models/solver/CandidateGovernance.jl
+++ b/src/models/solver/CandidateGovernance.jl
@@ -5,6 +5,22 @@
 const HardRule = Function
 const CandidateSelector = Function
 
+@inline function classify_attempt_error(err)::Symbol
+    err isa InterruptException && return :interrupt
+    err isa ArgumentError && return :constraint_error
+    err isa DomainError && return :constraint_error
+    return :solver_error
+end
+
+@inline function normalize_error_message(err; max_chars::Int=240)::String
+    msg = sprint(showerror, err)
+    msg = replace(strip(msg), '\n' => ' ', '\r' => ' ')
+    if ncodeunits(msg) <= max_chars
+        return msg
+    end
+    return first(msg, max_chars)
+end
+
 @inline function _seed_pool_key(seed_vec::AbstractVector{<:Real})
     return join(round.(Float64.(seed_vec); digits=12), ",")
 end

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -262,7 +262,7 @@ function _fixedmu_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fixe
         failed_constraints=Symbol.(get(solved, :failed_constraints, Symbol[])),
         error_kind=:none,
         error_msg="",
-        selection_reason=(haskey(solved, :selection_reason) ? Symbol(get(solved, :selection_reason, :none)) : :none),
+        selection_reason=Symbol(get(solved, :selection_reason, :none)),
         endpoint_cause=Bool(get(solved, :converged, false)) ? :converged : :nonconvergence,
         continuity_distance=nothing,
     )

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -75,19 +75,37 @@ end
     hard_ok = hasproperty(candidate, :hard_constraint_ok) ? Bool(getproperty(candidate, :hard_constraint_ok)) : nothing
     failed = hasproperty(candidate, :failed_constraints) ? Symbol.(getproperty(candidate, :failed_constraints)) : Symbol[]
     continuity = hasproperty(candidate, :continuity_distance) ? Float64(getproperty(candidate, :continuity_distance)) : nothing
+    error_kind = hasproperty(candidate, :error_kind) ? Symbol(getproperty(candidate, :error_kind)) : :none
+    error_msg = hasproperty(candidate, :error_msg) ? String(getproperty(candidate, :error_msg)) : ""
+    selection_reason = hasproperty(candidate, :selection_reason) ? Symbol(getproperty(candidate, :selection_reason)) : :none
     return (
         attempt_origin=_diagnostic_attempt_origin(candidate),
         seed_source=seed_source,
         hard_constraint_ok=hard_ok,
         failed_constraints=failed,
+        error_kind=error_kind,
+        error_msg=error_msg,
+        selection_reason=selection_reason,
         endpoint_cause=_diagnostic_endpoint_cause(candidate),
         continuity_distance=continuity,
     )
 end
 
-@inline function _attach_solver_diagnostic(result::NamedTuple, selected_candidate, candidates, diagnostic_level::Symbol; seed_source::Union{Symbol,Nothing}=nothing)
+@inline function _attach_solver_diagnostic(
+    result::NamedTuple,
+    selected_candidate,
+    candidates,
+    diagnostic_level::Symbol;
+    seed_source::Union{Symbol,Nothing}=nothing,
+    selection_reason::Union{Nothing,Symbol}=nothing,
+)
     diagnostic_level === :none && return result
-    summary = _solver_diagnostic_from_candidate(selected_candidate; seed_source=seed_source)
+    summary_raw = _solver_diagnostic_from_candidate(selected_candidate; seed_source=seed_source)
+    summary = if selection_reason === nothing
+        summary_raw
+    else
+        (; summary_raw..., selection_reason=selection_reason)
+    end
     if diagnostic_level === :summary
         return merge(result, (diagnostic=summary,))
     end
@@ -242,6 +260,9 @@ function _fixedmu_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fixe
         seed_source=seed_source,
         hard_constraint_ok=Bool(get(solved, :hard_constraint_ok, false)),
         failed_constraints=Symbol.(get(solved, :failed_constraints, Symbol[])),
+        error_kind=:none,
+        error_msg="",
+        selection_reason=(haskey(solved, :selection_reason) ? Symbol(get(solved, :selection_reason, :none)) : :none),
         endpoint_cause=Bool(get(solved, :converged, false)) ? :converged : :nonconvergence,
         continuity_distance=nothing,
     )
@@ -549,6 +570,8 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
         selection_reason=selected.selection_reason,
         selected_index=selected.selected_index,
         candidate_count=length(candidates),
+        error_kind=(hasproperty(s, :error_kind) ? Symbol(getproperty(s, :error_kind)) : :none),
+        error_msg=(hasproperty(s, :error_msg) ? String(getproperty(s, :error_msg)) : ""),
         fixedrho_joint_solve_requested=fixedrho_joint_solve,
         fixedrho_joint_solve_active=get(s, :fixedrho_joint_solve_active, false),
         fixedrho_joint_fallback=get(s, :fixedrho_joint_fallback, false),
@@ -557,7 +580,10 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
         fixedrho_joint_fallback_used=get(s, :fixedrho_joint_fallback_used, false),
     )
     seed_source = Bool(get(kwargs, :continuity_seed, false)) ? :warm_start : :seed
-    return _attach_solver_diagnostic(result, s, candidates, diagnostic_level; seed_source=seed_source)
+    return _attach_solver_diagnostic(result, s, candidates, diagnostic_level;
+        seed_source=seed_source,
+        selection_reason=selected.selection_reason,
+    )
 end
 
 function _execute_governed_attempt_plan(
@@ -600,8 +626,10 @@ function _execute_governed_attempt_plan(
             )
             return merged, success
         end,
-        on_error=(attempt_cfg, attempt_index, _) -> begin
+        on_error=(attempt_cfg, attempt_index, err) -> begin
             raw = failure_attempt(kwargs, attempt_cfg, attempt_index)
+            err_kind = classify_attempt_error(err)
+            err_msg = normalize_error_message(err)
             candidate = (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index))
             normalized = normalize_governance_candidate(candidate;
                 seed_index=Int(attempt_index),
@@ -615,6 +643,8 @@ function _execute_governed_attempt_plan(
                 hard_constraint_ok=normalized.hard_constraint_ok,
                 failed_constraints=normalized.failed_constraints,
                 seed_index=normalized.seed_index,
+                error_kind=err_kind,
+                error_msg=err_msg,
             )
             success = evaluate_candidate_success(merged;
                 residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
@@ -751,13 +781,18 @@ function _governed_nonrho_problem_spec_forward_solve(
         selection_reason=selected.selection_reason,
         selected_index=selected.selected_index,
         candidate_count=length(candidates),
+        error_kind=(hasproperty(s, :error_kind) ? Symbol(getproperty(s, :error_kind)) : :none),
+        error_msg=(hasproperty(s, :error_msg) ? String(getproperty(s, :error_msg)) : ""),
         governed_selected_method=(hasproperty(s, :governed_selected_method) ? getproperty(s, :governed_selected_method) : :none),
         governed_selected_quality=(hasproperty(s, :governed_selected_quality) ? getproperty(s, :governed_selected_quality) : :bad),
         governed_fallback_used=(hasproperty(s, :governed_fallback_used) ? Bool(getproperty(s, :governed_fallback_used)) : false),
         legacy_fallback_used=(hasproperty(s, :legacy_fallback_used) ? Bool(getproperty(s, :legacy_fallback_used)) : false),
     )
     seed_source = Bool(get(kwargs, :continuity_seed, false)) ? :warm_start : :seed
-    return _attach_solver_diagnostic(result, s, candidates, diagnostic_level; seed_source=seed_source)
+    return _attach_solver_diagnostic(result, s, candidates, diagnostic_level;
+        seed_source=seed_source,
+        selection_reason=selected.selection_reason,
+    )
 end
 
 function _fixedentropy_problem_spec_forward_solve(model::AbstractQCDModel, mode::FixedEntropy, T_fm::Real; fwd_kwargs...)

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -404,7 +404,9 @@ function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm:
             )
             return merged, evaluate_candidate_success(merged; residual_norm_max=residual_norm_max)
         end,
-        on_error=(_, seed_index, _) -> begin
+        on_error=(_, seed_index, err) -> begin
+            err_kind = classify_attempt_error(err)
+            err_msg = normalize_error_message(err)
             candidate = (
                 converged=false,
                 solution=Float64[],
@@ -421,6 +423,8 @@ function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm:
                 hard_constraint_ok=false,
                 failed_constraints=Symbol[:solver_failed],
                 seed_index=Int(seed_index),
+                error_kind=err_kind,
+                error_msg=err_msg,
             )
             normalized = normalize_governance_candidate(candidate;
                 seed_index=Int(seed_index),
@@ -591,7 +595,9 @@ function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymme
             )
             return merged, evaluate_candidate_success(merged; residual_norm_max=max(bridge.residual_norm_max, 1e-3))
         end,
-        on_error=(_, seed_index, _) -> begin
+        on_error=(_, seed_index, err) -> begin
+            err_kind = classify_attempt_error(err)
+            err_msg = normalize_error_message(err)
             candidate = (
                 converged=false,
                 solution=Float64[],
@@ -608,6 +614,8 @@ function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymme
                 hard_constraint_ok=false,
                 failed_constraints=Symbol[:solver_failed],
                 seed_index=Int(seed_index),
+                error_kind=err_kind,
+                error_msg=err_msg,
             )
             normalized = normalize_governance_candidate(candidate;
                 seed_index=Int(seed_index),

--- a/tests/regression/models/test_solver_diagnostic_exception_regression.jl
+++ b/tests/regression/models/test_solver_diagnostic_exception_regression.jl
@@ -1,0 +1,31 @@
+using Test
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+@testset "solver diagnostic exception regression" begin
+    model = Models.create_model(:PNJL)
+    mode = Models.FixedEntropy(0.5)
+    spec = Models.build_problem_spec(mode)
+    T_fm = 100.0 / 197.327
+    seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
+    result = spec.forward_solve(
+        model,
+        T_fm;
+        seed_guess=seed,
+        p_num=8,
+        t_num=4,
+        residual_norm_max=1e-6,
+        iterations=80,
+        diagnostic_level=:summary,
+    )
+
+    @test haskey(result, :diagnostic)
+    @test result.diagnostic.error_kind == :constraint_error
+    @test occursin("rho0 is required", result.diagnostic.error_msg)
+    @test result.selection_reason in (:pressure_max_under_constraints, :residual_min_under_constraints, :no_candidate_passed_constraints)
+end

--- a/tests/regression/runtests.jl
+++ b/tests/regression/runtests.jl
@@ -21,6 +21,7 @@ const SMOKE_FILES = [
     joinpath(REGRESSION_DIR, "models", "test_fixedrho_precision_guard_regression.jl"),
     joinpath(REGRESSION_DIR, "models", "test_problem_spec_fixedrho_parity_regression.jl"),
     joinpath(REGRESSION_DIR, "models", "test_solver_attempt_engine_convergence_regression.jl"),
+    joinpath(REGRESSION_DIR, "models", "test_solver_diagnostic_exception_regression.jl"),
     joinpath(REGRESSION_DIR, "models", "test_fixedrho_semantic_equivalence_regression.jl"),
     joinpath(REGRESSION_DIR, "models", "test_firstorder_manifold_branch_stability.jl"),
     joinpath(REGRESSION_DIR, "relaxtime", "test_transport_fixedpoint_regression.jl"),

--- a/tests/unit/models/test_candidate_governance_contract.jl
+++ b/tests/unit/models/test_candidate_governance_contract.jl
@@ -35,6 +35,10 @@ end
     @test Models.evaluate_candidate_success((; converged=false, residual_norm=1e-8, hard_constraint_ok=true); residual_norm_max=1e-6)
     @test !Models.evaluate_candidate_success((; converged=false, residual_norm=1e-2, hard_constraint_ok=false); residual_norm_max=1e-6)
     @test !Models.evaluate_candidate_success((; converged=true, residual_norm=1e-8, hard_constraint_ok=false); residual_norm_max=1e-6)
+    @test Models.classify_attempt_error(ArgumentError("bad")) == :constraint_error
+    @test Models.classify_attempt_error(DomainError(1.0, "bad")) == :constraint_error
+    @test Models.classify_attempt_error(ErrorException("boom")) == :solver_error
+    @test length(Models.normalize_error_message(ErrorException("line1\nline2"))) > 0
 
     pool = Models.build_seed_pool(Models.FixedEntropy(0.5);
         primary_seed=[1.0, 2.0, 3.0],

--- a/tests/unit/models/test_scan_common.jl
+++ b/tests/unit/models/test_scan_common.jl
@@ -9,7 +9,7 @@ if !isdefined(Main, :Models)
 end
 
 # ScanCommon 使用 ..SeedStrategies 等相对导入，只能通过 Models 子模块访问
-using Main.Models.ScanCommon: fmt, clean_message, quote_csv, join_messages, key3, key2
+using Main.Models.ScanCommon: fmt, clean_message, quote_csv, join_messages, key3, key2, attempt_with_candidates
 
 @testset "ScanCommon" begin
     @testset "fmt 格式化数值" begin
@@ -35,5 +35,20 @@ using Main.Models.ScanCommon: fmt, clean_message, quote_csv, join_messages, key3
     @testset "key2 返回二元组" begin
         k = key2(0.1234, 0.5678; digits=4)
         @test k isa NTuple{2, Float64}
+    end
+
+    @testset "attempt_with_candidates 错误消息包含统一错误语义" begin
+        candidates = [(label="seed-a", state=[1.0, 2.0, 3.0])]
+        result, message = attempt_with_candidates(candidates;
+            solve_point=_ -> throw(ArgumentError("bad_seed")),
+            refine=r -> (r, ""),
+            promote=r -> (r, ""),
+            is_success=_ -> false,
+            stop_on_first_success=true,
+            evaluate_all_attempts=false,
+        )
+        @test result === nothing
+        @test occursin("error.kind=constraint_error", message)
+        @test occursin("bad_seed", message)
     end
 end

--- a/tests/unit/models/test_solver_diagnostic_contract.jl
+++ b/tests/unit/models/test_solver_diagnostic_contract.jl
@@ -66,6 +66,9 @@ const P = Models.pnjl_module()
         @test haskey(result_summary.diagnostic, :seed_source)
         @test haskey(result_summary.diagnostic, :hard_constraint_ok)
         @test haskey(result_summary.diagnostic, :failed_constraints)
+        @test haskey(result_summary.diagnostic, :error_kind)
+        @test haskey(result_summary.diagnostic, :error_msg)
+        @test haskey(result_summary.diagnostic, :selection_reason)
         @test haskey(result_summary.diagnostic, :endpoint_cause)
         @test haskey(result_summary.diagnostic, :continuity_distance)
     end
@@ -86,5 +89,8 @@ const P = Models.pnjl_module()
         @test haskey(result_full, :diagnostic)
         @test haskey(result_full.diagnostic, :candidates)
         @test result_full.diagnostic.candidates isa AbstractVector
+        @test haskey(result_full, :error_kind)
+        @test haskey(result_full, :error_msg)
+        @test haskey(result_full, :selection_reason)
     end
 end


### PR DESCRIPTION
## Summary
- unify attempt error semantics across solver-governance chain by adding shared `classify_attempt_error` / `normalize_error_message` and routing on-error paths in `ProblemSpec`, `Solver.solve_multi`, and `ScanCommon`
- converge diagnostic contract to include `error_kind` / `error_msg` / `attempt_origin` / `selection_reason` in solver diagnostic outputs and selection summaries
- add PR-C regression guard `tests/regression/models/test_solver_diagnostic_exception_regression.jl`, extend diagnostic/unit assertions, and update PR-C task sheet completion and validation evidence

## Validation
- `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_candidate_governance_contract.jl;models/test_solver_diagnostic_contract.jl;models/test_scan_common.jl"; include("tests/unit/runtests.jl")'`
- `julia --project=. -e 'ENV["REGRESSION_FILES"]="models/test_solver_diagnostic_exception_regression.jl;models/test_solver_attempt_engine_convergence_regression.jl;pnjl/test_constraint_selection_regression.jl"; include("tests/regression/runtests.jl")'`