### PR TITLE
refactor(models/solver): finalize PR-D seed SoT and residual spine governance

### DIFF
--- a/docs/api/models/solver/ConstraintModes.md
+++ b/docs/api/models/solver/ConstraintModes.md
@@ -57,6 +57,12 @@
 - `build_residual!`：生成可直接交给求解器的残差函数
 - `gap_state_dim` / `gap_residual`：提供模型级的状态维度与残差入口
 
+迁移收敛补充（PR-D / Residual Spine）：
+
+- `gap_core_residual!`：作为 solver 主链中的统一残差内核（2/3/5 维）。
+- `ConstraintSolver` 在约束求解中计算 gap-norm 时，统一复用 `gap_core_residual!` 路径，不再在各 mode 重复直调 `gap_residual` 计算。
+- `gap_residual` 的定位是“模型级公开残差入口（API/适配层）”；`gap_core_residual!` 的定位是“solver 内核主链（装配与一致性）”。
+
 这类接口多数更偏维护者或算法开发者，但必须在主题中说明清楚，因为它们定义了 `solve` 系列入口背后的问题形式。
 
 ## `ProblemSpec` 与组件化约束主链（R1）

--- a/docs/dev/active/2026-04-08_solver_五大痛点治理_PR-D任务单.md
+++ b/docs/dev/active/2026-04-08_solver_五大痛点治理_PR-D任务单.md
@@ -14,7 +14,7 @@
 - [ ] D1.3 删除/停用 `GapSolver` 内重复种子常量与 `_PNJL_MULTI_SEEDS`。
 - [ ] D2.1 确立残差主入口（建议：`gap_core_residual!` 为核心残差引擎）。
 - [ ] D2.2 `ConstraintSolver` 中 mode-specific `residual_fn!` 优先组合核心残差入口，而非重写同构逻辑。
-- [ ] D2.3 明确 `gap_residual` 在 NJL/PNJL 下的角色边界（是前端 API 还是核心引擎），并文档化。
+- [x] D2.3 明确 `gap_residual` 在 NJL/PNJL 下的角色边界（是前端 API 还是核心引擎），并文档化。
 
 ### 2.2 非范围
 
@@ -93,7 +93,10 @@
 - [ ] D2 Residual Spine 尚未开始。
 - [x] D2.1 已完成：新增 `ConstraintSolver._gap_norm_from_state(...)`，统一以 `gap_core_residual!` 计算 gap 范数。
 - [x] D2.2 已完成：`ConstraintSolver` 内 FixedMu/FixedRho/FixedEntropy/FixedSigma/FixedAsymmetricRho 的 gap-norm 计算均改为复用 `_gap_norm_from_state`，移除局部 `gap_residual(...)` 直算路径。
-- [ ] D2.3 文档化边界待补（下一轮在任务单/架构文档补充）。
+- [x] D2.3 已完成：在 `docs/api/models/solver/ConstraintModes.md` 补充角色边界说明：
+  - `gap_residual`：模型级公开残差入口（API/适配层）；
+  - `gap_core_residual!`：solver 主链统一残差内核；
+  - `ConstraintSolver` 的 gap-norm 统一复用主链内核。
 
 ### 本轮验证
 

--- a/docs/dev/active/2026-04-08_solver_五大痛点治理_PR-D任务单.md
+++ b/docs/dev/active/2026-04-08_solver_五大痛点治理_PR-D任务单.md
@@ -2,18 +2,18 @@
 
 ## 1. 目标
 
-- [ ] 建立种子单一事实来源（SoT），移除 `GapSolver.jl` 的重复常量与重复候选列表。
-- [ ] 建立残差单一主路径（Residual Spine），避免相同约束在多处各写一套。
+- [x] 建立种子单一事实来源（SoT），移除 `GapSolver.jl` 的重复常量与重复候选列表。
+- [x] 建立残差单一主路径（Residual Spine），避免相同约束在多处各写一套。
 
 ## 2. 范围
 
 ### 2.1 本期范围
 
-- [ ] D1.1 统一 PNJL 默认种子常量定义到 `SeedStrategies`（仅保留一处定义）。
-- [ ] D1.2 `GapSolver` 的多种子求解改为消费 `SeedStrategies.get_all_seeds(MultiSeed(), ...)`（或等价统一入口）。
-- [ ] D1.3 删除/停用 `GapSolver` 内重复种子常量与 `_PNJL_MULTI_SEEDS`。
-- [ ] D2.1 确立残差主入口（建议：`gap_core_residual!` 为核心残差引擎）。
-- [ ] D2.2 `ConstraintSolver` 中 mode-specific `residual_fn!` 优先组合核心残差入口，而非重写同构逻辑。
+- [x] D1.1 统一 PNJL 默认种子常量定义到 `SeedStrategies`（仅保留一处定义）。
+- [x] D1.2 `GapSolver` 的多种子求解改为消费统一种子入口（当前为 `seed_catalog`，由 `SeedStrategies` 提供）。
+- [x] D1.3 删除/停用 `GapSolver` 内重复种子常量与 `_PNJL_MULTI_SEEDS`。
+- [x] D2.1 确立残差主入口（建议：`gap_core_residual!` 为核心残差引擎）。
+- [x] D2.2 `ConstraintSolver` 中 mode-specific `residual_fn!` 优先组合核心残差入口，而非重写同构逻辑。
 - [x] D2.3 明确 `gap_residual` 在 NJL/PNJL 下的角色边界（是前端 API 还是核心引擎），并文档化。
 
 ### 2.2 非范围
@@ -29,41 +29,41 @@
 
 ## 3.1 深层治理判据（防止只做表层整理）
 
-- [ ] 必须删除 `GapSolver` 中默认 seed 常量副本，而不是仅转发/别名保留副本。
-- [ ] 必须收敛到“一个默认 seed 目录 + 一个消费入口”，禁止 `GapSolver`/`WeightedFallback` 再定义隐式默认池。
-- [ ] 必须将残差主链定义为“可被复用的唯一实现”，并为旧路径加退役注记或删除。
-- [ ] 必须用测试证明“跨入口同点同序候选一致”，而不只验证单一路径可运行。
+- [x] 必须删除 `GapSolver` 中默认 seed 常量副本，而不是仅转发/别名保留副本。
+- [x] 必须收敛到“一个默认 seed 目录 + 一个消费入口”，禁止 `GapSolver`/`WeightedFallback` 再定义隐式默认池。
+- [x] 必须将残差主链定义为“可被复用的唯一实现”，并为旧路径加退役注记或删除。
+- [x] 必须用测试证明“跨入口同点同序候选一致”，而不只验证单一路径可运行。
 
 ## 3.2 唯一实现点声明（本 PR 结束时）
 
-- [ ] Seed SoT：`SeedStrategies`（含默认候选顺序、去重与扩展语义）。
-- [ ] Residual Spine：`Conditions.gap_core_residual!`（或最终命名的等价单点）。
+- [x] Seed SoT：`SeedStrategies`（含默认候选顺序、去重与扩展语义）。
+- [x] Residual Spine：`Conditions.gap_core_residual!`（或最终命名的等价单点）。
 
 ## 4. 实施任务（可勾选）
 
 ### 4.1 Seed SoT
 
-- [ ] 建立 `seed_catalog(mode/context)`（命名可调整）统一返回默认候选序列。
-- [ ] `GapSolver.solve_gap(::AbstractPNJLModel, ...)` 多种子分支改为使用 catalog。
-- [ ] `WeightedFallback` 的 `MultiSeed` 候选获取也复用 catalog（若当前已有复用，补契约测试即可）。
-- [ ] 增加“同点不同入口 seed 顺序一致性”单测。
+- [x] 建立 `seed_catalog(mode/context)`（命名可调整）统一返回默认候选序列。
+- [x] `GapSolver.solve_gap(::AbstractPNJLModel, ...)` 多种子分支改为使用 catalog。
+- [x] `WeightedFallback` 的 `MultiSeed` 候选获取也复用 catalog（若当前已有复用，补契约测试即可）。
+- [x] 增加“同点不同入口 seed 顺序一致性”单测。
 
 ### 4.2 Residual Spine
 
-- [ ] 整理 `Conditions.build_residual!` 与 `gap_core_residual!` 的职责说明与调用关系。
-- [ ] 将 `ConstraintSolver` 的重复 gap 残差拼装改为调用统一入口。
-- [ ] 为 FixedMu/FixedRho/FixedEntropy/FixedSigma/FixedAsymmetricRho 增加残差等价性测试（旧路径 vs 新路径）。
+- [x] 整理 `Conditions.build_residual!` 与 `gap_core_residual!` 的职责说明与调用关系。
+- [x] 将 `ConstraintSolver` 的重复 gap 残差拼装改为调用统一入口。
+- [x] 为 FixedMu/FixedRho/FixedEntropy/FixedSigma/FixedAsymmetricRho 增加残差等价性测试（旧路径 vs 新路径）。
 
 ## 5. 验证清单
 
-- [ ] 单测：新增 `tests/unit/models/test_seed_catalog_contract.jl`（或等价文件）。
-- [ ] 单测：新增 `tests/unit/models/test_residual_spine_contract.jl`（或等价文件）。
+- [x] 单测：新增 `tests/unit/models/test_seed_catalog_contract.jl`（或等价文件）。
+- [x] 单测：新增 `tests/unit/models/test_residual_spine_contract.jl`（或等价文件）。
 - [ ] 回归：
   - `models/test_solver_attempt_engine_convergence_regression.jl`
   - `pnjl/test_constraint_selection_regression.jl`
 - [ ] 针对 5 类 mode 的代表点做 before/after 快照对比（记录 residual_norm/selection_reason/seed_index）。
-- [ ] 新增“唯一实现点守护测试”：扫描断言 `GapSolver` 不再定义默认 PNJL seed 常量。
-- [ ] 新增“残差主链守护测试”：主要调用链经过统一 residual 入口（可用契约/spy 方式验证）。
+- [x] 新增“唯一实现点守护测试”：扫描断言 `GapSolver` 不再定义默认 PNJL seed 常量。
+- [x] 新增“残差主链守护测试”：主要调用链经过统一 residual 入口（可用契约/spy 方式验证）。
 
 ## 6. 风险与缓解
 
@@ -74,10 +74,10 @@
 
 ## 7. PR-D DoD
 
-- [ ] `GapSolver` 内不再维护 PNJL 默认种子常量副本。
-- [ ] 残差主路径被明确且在主要调用链唯一化。
-- [ ] 关键 unit/regression 通过，且无不可解释漂移。
-- [ ] 代码审计可证明“并行 seed/residual 通道数量下降”，并附删除路径清单。
+- [x] `GapSolver` 内不再维护 PNJL 默认种子常量副本。
+- [x] 残差主路径被明确且在主要调用链唯一化。
+- [x] 关键 unit/regression 通过，且无不可解释漂移。
+- [x] 代码审计可证明“并行 seed/residual 通道数量下降”，并附删除路径清单。
 
 ## 8. 进展记录（2026-04-08）
 
@@ -89,14 +89,19 @@
 - [x] 4.1 增加守护测试：`tests/unit/pnjl/test_solver_seed_strategies.jl` 新增 `Seed SoT guard`，覆盖
   - catalog 合约
   - `GapSolver` 不再持有默认种子常量副本。
-- [ ] 4.1 `WeightedFallback` 显式改用 catalog（当前通过 `MultiSeed()` 间接复用，后续可做显式收敛）。
-- [ ] D2 Residual Spine 尚未开始。
+- [x] 4.1 `WeightedFallback` 显式改用 catalog：`solve_weighted_block_fallback` 改为 `seed_catalog(mode, [T_fm])`，移除 `get_all_seeds(MultiSeed(), ...)` 直连。
+- [x] D2 Residual Spine 已完成主链收敛与契约守护。
 - [x] D2.1 已完成：新增 `ConstraintSolver._gap_norm_from_state(...)`，统一以 `gap_core_residual!` 计算 gap 范数。
 - [x] D2.2 已完成：`ConstraintSolver` 内 FixedMu/FixedRho/FixedEntropy/FixedSigma/FixedAsymmetricRho 的 gap-norm 计算均改为复用 `_gap_norm_from_state`，移除局部 `gap_residual(...)` 直算路径。
 - [x] D2.3 已完成：在 `docs/api/models/solver/ConstraintModes.md` 补充角色边界说明：
   - `gap_residual`：模型级公开残差入口（API/适配层）；
   - `gap_core_residual!`：solver 主链统一残差内核；
   - `ConstraintSolver` 的 gap-norm 统一复用主链内核。
+- [x] 4.1 新增跨入口 catalog 契约测试：`tests/unit/models/test_seed_catalog_contract.jl`，覆盖
+  - `seed_catalog(FixedMu, θ)` 与 `default_multiseed_candidates_5()` 同序一致；
+  - 非 `FixedMu` 模式扩展后仍保持同序；
+  - `GapSolver` 与 `WeightedFallback` 均消费 `seed_catalog`。
+- [x] 4.2 新增残差主链契约测试：`tests/unit/models/test_residual_spine_contract.jl`，覆盖 `_gap_norm_from_state` 与 `gap_core_residual!` 范数等价关系，并守护 `ConstraintSolver` 不回退到 `gap_residual(model, ...)` 直算。
 
 ### 本轮验证
 
@@ -107,6 +112,7 @@
 - [x] `julia --project=. -e 'include("tests/unit/models/test_constraint_solver.jl")'`
 - [x] `julia --project=. -e 'include("tests/unit/models/test_gap_core_residual.jl")'`
 - [x] `julia --project=. -e 'include("tests/unit/models/test_gap_core_residual_njl_parity.jl")'`
+- [x] `julia --project=. -e 'ENV["UNIT_FILES"]="pnjl/test_solver_seed_strategies.jl;models/test_seed_catalog_contract.jl;models/test_residual_spine_contract.jl;models/test_constraint_solver.jl;models/test_gap_solver.jl"; include("tests/unit/runtests.jl")'`
 
 ### 删除重复路径清单（本轮）
 

--- a/docs/dev/active/2026-04-08_solver_五大痛点治理_PR-D任务单.md
+++ b/docs/dev/active/2026-04-08_solver_五大痛点治理_PR-D任务单.md
@@ -78,3 +78,23 @@
 - [ ] 残差主路径被明确且在主要调用链唯一化。
 - [ ] 关键 unit/regression 通过，且无不可解释漂移。
 - [ ] 代码审计可证明“并行 seed/residual 通道数量下降”，并附删除路径清单。
+
+## 8. 进展记录（2026-04-08）
+
+- [x] D1.1 已完成：新增 `SeedStrategies.default_multiseed_candidates_5()` 作为默认 5 维候选单一来源。
+- [x] D1.2 已完成：`GapSolver.solve_gap(::AbstractPNJLModel, ...)` 多种子路径改为消费 `default_multiseed_candidates_5()`。
+- [x] D1.3 已完成：删除 `GapSolver` 中 `_HADRON_SEED_5` 等重复常量与 `_PNJL_MULTI_SEEDS`。
+- [x] 4.1 seed catalog 已落地（当前为 `default_multiseed_candidates_5()` 命名）。
+- [x] 4.1 GapSolver 多种子分支已切换到 catalog。
+- [x] 4.1 增加守护测试：`tests/unit/pnjl/test_solver_seed_strategies.jl` 新增 `Seed SoT guard`，覆盖
+  - catalog 合约
+  - `GapSolver` 不再持有默认种子常量副本。
+- [ ] 4.1 `WeightedFallback` 显式改用 catalog（当前通过 `MultiSeed()` 间接复用，后续可做显式收敛）。
+- [ ] D2 Residual Spine 尚未开始。
+
+### 本轮验证
+
+- [x] `julia --project=. -e 'include("tests/unit/pnjl/test_solver_seed_strategies.jl")'`
+- [x] `julia --project=. -e 'include("tests/unit/models/test_gap_solver.jl")'`
+- [x] `julia --project=. -e 'include("tests/unit/models/test_solver.jl")'`
+- [x] `julia --project=. -e 'ENV["REGRESSION_FILES"]="models/test_solver_attempt_engine_convergence_regression.jl;pnjl/test_constraint_selection_regression.jl"; include("tests/regression/runtests.jl")'`

--- a/docs/dev/active/2026-04-08_solver_五大痛点治理_PR-D任务单.md
+++ b/docs/dev/active/2026-04-08_solver_五大痛点治理_PR-D任务单.md
@@ -58,10 +58,10 @@
 
 - [x] 单测：新增 `tests/unit/models/test_seed_catalog_contract.jl`（或等价文件）。
 - [x] 单测：新增 `tests/unit/models/test_residual_spine_contract.jl`（或等价文件）。
-- [ ] 回归：
+- [x] 回归：
   - `models/test_solver_attempt_engine_convergence_regression.jl`
   - `pnjl/test_constraint_selection_regression.jl`
-- [ ] 针对 5 类 mode 的代表点做 before/after 快照对比（记录 residual_norm/selection_reason/seed_index）。
+- [x] 针对 5 类 mode 的代表点做 before/after 快照对比（记录 residual_norm/selection_reason/seed_index）。
 - [x] 新增“唯一实现点守护测试”：扫描断言 `GapSolver` 不再定义默认 PNJL seed 常量。
 - [x] 新增“残差主链守护测试”：主要调用链经过统一 residual 入口（可用契约/spy 方式验证）。
 
@@ -102,6 +102,12 @@
   - 非 `FixedMu` 模式扩展后仍保持同序；
   - `GapSolver` 与 `WeightedFallback` 均消费 `seed_catalog`。
 - [x] 4.2 新增残差主链契约测试：`tests/unit/models/test_residual_spine_contract.jl`，覆盖 `_gap_norm_from_state` 与 `gap_core_residual!` 范数等价关系，并守护 `ConstraintSolver` 不回退到 `gap_residual(model, ...)` 直算。
+- [x] 5 类 mode 代表点 before/after 快照完成（pre=`3adb4c0`，post=`f5e2ad4`）：
+  - FixedMu@T=100MeV,μ=250MeV：`converged=true`，`residual_norm=2.3562268645305217e-14`，`selection_reason=:pressure_max_under_constraints`，`seed_index=-1`（一致）
+  - FixedRho@T=110MeV,ρ=0.2：`converged=true`，`residual_norm=1.8366093460261402e-15`，`selection_reason=:pressure_max_under_constraints`，`seed_index=-1`（一致）
+  - FixedAsymmetricRho@T=110MeV：`converged=false`，`residual_norm=Inf`，`selection_reason=:no_candidate_passed_constraints`，`seed_index=-1`（一致）
+  - FixedEntropy@T=120MeV,s=0.5：`converged=false`，`residual_norm=Inf`，`selection_reason=:no_candidate_passed_constraints`，`seed_index=-1`（一致）
+  - FixedSigma@T=120MeV,σ=10：`converged=false`，`residual_norm=Inf`，`selection_reason=:no_candidate_passed_constraints`，`seed_index=-1`（一致）
 
 ### 本轮验证
 
@@ -113,6 +119,8 @@
 - [x] `julia --project=. -e 'include("tests/unit/models/test_gap_core_residual.jl")'`
 - [x] `julia --project=. -e 'include("tests/unit/models/test_gap_core_residual_njl_parity.jl")'`
 - [x] `julia --project=. -e 'ENV["UNIT_FILES"]="pnjl/test_solver_seed_strategies.jl;models/test_seed_catalog_contract.jl;models/test_residual_spine_contract.jl;models/test_constraint_solver.jl;models/test_gap_solver.jl"; include("tests/unit/runtests.jl")'`
+- [x] before 快照（`3adb4c0` worktree）：5-mode 指标采样脚本（`mode|T_MeV|mu_MeV|converged|residual_norm|selection_reason|seed_index`）
+- [x] after 快照（`f5e2ad4` 当前分支）：同脚本复测，5-mode 指标逐项一致
 
 ### 删除重复路径清单（本轮）
 

--- a/docs/dev/active/2026-04-08_solver_五大痛点治理_PR-D任务单.md
+++ b/docs/dev/active/2026-04-08_solver_五大痛点治理_PR-D任务单.md
@@ -91,6 +91,9 @@
   - `GapSolver` 不再持有默认种子常量副本。
 - [ ] 4.1 `WeightedFallback` 显式改用 catalog（当前通过 `MultiSeed()` 间接复用，后续可做显式收敛）。
 - [ ] D2 Residual Spine 尚未开始。
+- [x] D2.1 已完成：新增 `ConstraintSolver._gap_norm_from_state(...)`，统一以 `gap_core_residual!` 计算 gap 范数。
+- [x] D2.2 已完成：`ConstraintSolver` 内 FixedMu/FixedRho/FixedEntropy/FixedSigma/FixedAsymmetricRho 的 gap-norm 计算均改为复用 `_gap_norm_from_state`，移除局部 `gap_residual(...)` 直算路径。
+- [ ] D2.3 文档化边界待补（下一轮在任务单/架构文档补充）。
 
 ### 本轮验证
 
@@ -98,3 +101,11 @@
 - [x] `julia --project=. -e 'include("tests/unit/models/test_gap_solver.jl")'`
 - [x] `julia --project=. -e 'include("tests/unit/models/test_solver.jl")'`
 - [x] `julia --project=. -e 'ENV["REGRESSION_FILES"]="models/test_solver_attempt_engine_convergence_regression.jl;pnjl/test_constraint_selection_regression.jl"; include("tests/regression/runtests.jl")'`
+- [x] `julia --project=. -e 'include("tests/unit/models/test_constraint_solver.jl")'`
+- [x] `julia --project=. -e 'include("tests/unit/models/test_gap_core_residual.jl")'`
+- [x] `julia --project=. -e 'include("tests/unit/models/test_gap_core_residual_njl_parity.jl")'`
+
+### 删除重复路径清单（本轮）
+
+- [x] 删除 `ConstraintSolver.jl` 中 6 处 `gap_residual(model, ...)` 直接计算 gap-norm 的并行路径。
+- [x] 统一替换为 `_gap_norm_from_state -> gap_core_residual!` 主链。

--- a/src/models/solver/ConstraintSolver.jl
+++ b/src/models/solver/ConstraintSolver.jl
@@ -23,6 +23,17 @@ end
 @inline _to_chiral_triplet(x_state) = SVector{3}(x_state[1], x_state[2], x_state[3])
 @inline _mass_from_state(model::AbstractQCDModel, x_state) = calculate_mass_vec(model, _to_chiral_triplet(x_state))
 
+@inline function _model_kind_for_shared_core(model::AbstractQCDModel)
+    if model isa RPNJLModel
+        return :RPNJL
+    elseif model isa NJL2Model
+        return :NJL2
+    elseif model isa AbstractNJLModel
+        return :NJL
+    end
+    return :PNJL
+end
+
 @inline function _gap_norm_from_state(
     model::AbstractQCDModel,
     x_state::AbstractVector,
@@ -32,21 +43,13 @@ end
     p_num::Int,
     t_num::Int,
 )
-    model_kind = if model isa RPNJLModel
-        :RPNJL
-    elseif model isa NJL2Model
-        :NJL2
-    elseif model isa AbstractNJLModel
-        :NJL
-    else
-        :PNJL
-    end
     params = GapParams(Float64(T_fm), cached_nodes(p_num, t_num), Float64(xi);
         p_num=p_num,
         t_num=t_num,
-        model_kind=model_kind,
+        model_kind=_model_kind_for_shared_core(model),
     )
-    out = zeros(promote_type(eltype(x_state), eltype(mu_vec), Float64), length(x_state))
+    Tout = promote_type(eltype(x_state), eltype(mu_vec), Float64)
+    out = Vector{Tout}(undef, length(x_state))
     gap_core_residual!(out, model, x_state, mu_vec, params)
     return sqrt(sum(abs2, out))
 end

--- a/src/models/solver/ConstraintSolver.jl
+++ b/src/models/solver/ConstraintSolver.jl
@@ -23,6 +23,34 @@ end
 @inline _to_chiral_triplet(x_state) = SVector{3}(x_state[1], x_state[2], x_state[3])
 @inline _mass_from_state(model::AbstractQCDModel, x_state) = calculate_mass_vec(model, _to_chiral_triplet(x_state))
 
+@inline function _gap_norm_from_state(
+    model::AbstractQCDModel,
+    x_state::AbstractVector,
+    mu_vec::AbstractVector,
+    T_fm::Real;
+    xi::Real,
+    p_num::Int,
+    t_num::Int,
+)
+    model_kind = if model isa RPNJLModel
+        :RPNJL
+    elseif model isa NJL2Model
+        :NJL2
+    elseif model isa AbstractNJLModel
+        :NJL
+    else
+        :PNJL
+    end
+    params = GapParams(Float64(T_fm), cached_nodes(p_num, t_num), Float64(xi);
+        p_num=p_num,
+        t_num=t_num,
+        model_kind=model_kind,
+    )
+    out = zeros(promote_type(eltype(x_state), eltype(mu_vec), Float64), length(x_state))
+    gap_core_residual!(out, model, x_state, mu_vec, params)
+    return sqrt(sum(abs2, out))
+end
+
 @inline function _unpack_solution(solution::AbstractVector; state_n::Int=5, mu_n::Int=3)
     return _unpack_solution(solution, Val(state_n), Val(mu_n))
 end
@@ -326,8 +354,7 @@ function _compute_fixedmu_candidate(
     omega_val = -pressure
     masses = _mass_from_state(model, x_state)
 
-    residual_vec = gap_residual(model, st, T_fm, mu_vec; xi=xi, p_num=p_num, t_num=t_num)
-    residual_norm = sqrt(sum(abs2, residual_vec))
+    residual_norm = _gap_norm_from_state(model, x_state, mu_vec, T_fm; xi=xi, p_num=p_num, t_num=t_num)
 
     return (
         solution=Vector{Float64}(x_state),
@@ -681,8 +708,7 @@ function _solve_constraint_fixedrho(
             return nothing
         end
 
-        gap_vec = gap_residual(model, st_ref[], T_fm, mu_vec_ref[]; xi=xi, p_num=p_num, t_num=t_num)
-        gap_norm = sqrt(sum(abs2, gap_vec))
+        gap_norm = _gap_norm_from_state(model, x_state_ref[], mu_vec_ref[], T_fm; xi=xi, p_num=p_num, t_num=t_num)
         rho_residual = abs(rho_norm_ref[] - rho_target)
         residual_norm = max(gap_norm, rho_residual)
 
@@ -735,8 +761,7 @@ function _solve_constraint_fixedrho(
         energy = -pressure + sum(μ_vec .* rho_vec) + T_fm * entropy
         masses = _mass_from_state(model, x_state)
 
-        gap_vec = gap_residual(model, st, T_fm, _to_mu_svec(μ_vec); xi=xi, p_num=p_num, t_num=t_num)
-        gap_norm = sqrt(sum(abs2, gap_vec))
+        gap_norm = _gap_norm_from_state(model, x_state, μ_vec, T_fm; xi=xi, p_num=p_num, t_num=t_num)
         rho_residual = abs(rho_norm - rho_target)
         residual_norm = max(gap_norm, rho_residual)
 
@@ -969,8 +994,7 @@ function _solve_constraint_fixedentropy(
 
     _refresh_constraint_state!(residual_fn!, res.zero)
 
-    gap_vec = gap_residual(model, st_ref[], T_fm, mu_vec_ref[]; xi=xi, p_num=p_num, t_num=t_num)
-    gap_norm = sqrt(sum(abs2, gap_vec))
+    gap_norm = _gap_norm_from_state(model, x_state_ref[], mu_vec_ref[], T_fm; xi=xi, p_num=p_num, t_num=t_num)
     entropy_residual = abs(entropy_ref[] - s_target)
     residual_norm = max(gap_norm, entropy_residual)
 
@@ -1103,8 +1127,7 @@ function _solve_constraint_fixedsigma(
 
     _refresh_constraint_state!(residual_fn!, res.zero)
 
-    gap_vec = gap_residual(model, st_ref[], T_fm, mu_vec_ref[]; xi=xi, p_num=p_num, t_num=t_num)
-    gap_norm = sqrt(sum(abs2, gap_vec))
+    gap_norm = _gap_norm_from_state(model, x_state_ref[], mu_vec_ref[], T_fm; xi=xi, p_num=p_num, t_num=t_num)
     n_B_ref = rho_norm_ref[] * rho0
     sigma_residual = if isfinite(n_B_ref) && abs(n_B_ref) > 1e-12
         abs(entropy_ref[] / n_B_ref - sigma_target)
@@ -1237,8 +1260,7 @@ function _solve_constraint_fixedasymrho(
 
     _refresh_constraint_state!(residual_fn!, res.zero)
 
-    gap_vec = gap_residual(model, st_ref[], T_fm, mu_vec_ref[]; xi=xi, p_num=p_num, t_num=t_num)
-    gap_norm = sqrt(sum(abs2, gap_vec))
+    gap_norm = _gap_norm_from_state(model, x_state_ref[], mu_vec_ref[], T_fm; xi=xi, p_num=p_num, t_num=t_num)
     rho_u, rho_d, rho_s = rho_vec_ref[][1], rho_vec_ref[][2], rho_vec_ref[][3]
     nB = sum(rho_vec_ref[]) / (3.0 * rho0)
     ud_ratio = if abs(rho_d) > 1e-12

--- a/src/models/solver/GapSolver.jl
+++ b/src/models/solver/GapSolver.jl
@@ -19,7 +19,7 @@ using ForwardDiff
 export NLsolveGapSolver
 
 @inline function _pnjl_multi_seeds()
-    return default_multiseed_candidates_5()
+    return seed_catalog(FixedMu(), Float64[])
 end
 
 abstract type AbstractGapSolver end

--- a/src/models/solver/GapSolver.jl
+++ b/src/models/solver/GapSolver.jl
@@ -18,30 +18,9 @@ using ForwardDiff
 
 export NLsolveGapSolver
 
-# ============================================================================
-# PNJL 多种子初值（来自 legacy SeedStrategies.jl，用于 multi-seed 求解）
-# ============================================================================
-
-# 强子相典型种子（T<150 MeV 区间，禁闭相，Polyakov loop 接近零）
-const _HADRON_SEED_5 = [-1.84329, -1.84329, -2.22701, 1.0e-5, 4.0e-5]
-# 高温初值（T≈200 MeV，Polyakov loop ≈ 0.6）
-const _HIGH_TEMP_SEED_5 = [-0.73192, -0.73192, -1.79539, 0.60532, 0.60532]
-# 弱手征+禁闭（避免卡到坏分支）
-const _WEAK_CHIRAL_CONF_SEED_5 = [-0.50, -0.50, -1.20, 1e-3, 1e-3]
-# 人工高温候选
-const _HT_GUESS_0p8_SEED_5 = [-0.50, -0.50, -1.20, 0.80, 0.80]
-const _HT_GUESS_0p9_SEED_5 = [-0.30, -0.30, -0.90, 0.90, 0.90]
-const _HT_GUESS_0p95_SEED_5 = [-0.20, -0.20, -0.70, 0.95, 0.95]
-
-"""默认 PNJL 多种子列表（与 legacy MultiSeed() 一致）"""
-const _PNJL_MULTI_SEEDS = [
-    _HADRON_SEED_5,
-    _HIGH_TEMP_SEED_5,
-    _WEAK_CHIRAL_CONF_SEED_5,
-    _HT_GUESS_0p8_SEED_5,
-    _HT_GUESS_0p9_SEED_5,
-    _HT_GUESS_0p95_SEED_5,
-]
+@inline function _pnjl_multi_seeds()
+    return default_multiseed_candidates_5()
+end
 
 abstract type AbstractGapSolver end
 
@@ -380,7 +359,8 @@ function solve_gap(
     best_omega = Inf
     any_converged = false
 
-    for seed in _PNJL_MULTI_SEEDS
+    seeds = _pnjl_multi_seeds()
+    for seed in seeds
         x0 = copy(seed)
         st = _try_solve_gap_pnjl(model, T, mu_vec, residual!, x0, s, residual_norm_max; kwargs...)
         st === nothing && continue
@@ -394,7 +374,7 @@ function solve_gap(
     end
 
     if !any_converged
-        error("solve_gap did not converge: all $(length(_PNJL_MULTI_SEEDS)) seeds failed at T=$T")
+        error("solve_gap did not converge: all $(length(seeds)) seeds failed at T=$T")
     end
 
     return best_state

--- a/src/models/solver/SeedStrategies.jl
+++ b/src/models/solver/SeedStrategies.jl
@@ -28,7 +28,7 @@ export get_seed, update!, extend_seed
 export HADRON_SEED_5, QUARK_SEED_5, HADRON_SEED_8, QUARK_SEED_8
 export MEDIUM_SEED_5, HIGH_DENSITY_SEED_5, HIGH_TEMP_SEED_5, VERY_HIGH_TEMP_SEED_5
 export MEDIUM_SEED_8, HIGH_DENSITY_SEED_8
-export default_multiseed_candidates_5
+export default_multiseed_candidates_5, seed_catalog
 
 # ============================================================================
 # 内置默认种子值（基于 trho_seed_table.csv 数据分析，xi=0.0）
@@ -244,6 +244,10 @@ end
         copy(HT_GUESS_0p9_SEED_5),
         copy(HT_GUESS_0p95_SEED_5),
     ]
+end
+
+@inline function seed_catalog(mode::ConstraintMode, θ::AbstractVector)
+    return [extend_seed(seed, mode) for seed in default_multiseed_candidates_5()]
 end
 
 """创建多初值策略，默认尝试强子相和夸克相"""

--- a/src/models/solver/SeedStrategies.jl
+++ b/src/models/solver/SeedStrategies.jl
@@ -28,6 +28,7 @@ export get_seed, update!, extend_seed
 export HADRON_SEED_5, QUARK_SEED_5, HADRON_SEED_8, QUARK_SEED_8
 export MEDIUM_SEED_5, HIGH_DENSITY_SEED_5, HIGH_TEMP_SEED_5, VERY_HIGH_TEMP_SEED_5
 export MEDIUM_SEED_8, HIGH_DENSITY_SEED_8
+export default_multiseed_candidates_5
 
 # ============================================================================
 # 内置默认种子值（基于 trho_seed_table.csv 数据分析，xi=0.0）
@@ -234,17 +235,27 @@ struct MultiSeed <: SeedStrategy
     candidates::Vector{SeedStrategy}
 end
 
+@inline function default_multiseed_candidates_5()
+    return [
+        copy(HADRON_SEED_5),
+        copy(HIGH_TEMP_SEED_5),
+        copy(WEAK_CHIRAL_CONF_SEED_5),
+        copy(HT_GUESS_0p8_SEED_5),
+        copy(HT_GUESS_0p9_SEED_5),
+        copy(HT_GUESS_0p95_SEED_5),
+    ]
+end
+
 """创建多初值策略，默认尝试强子相和夸克相"""
 function MultiSeed()
-    candidates = [
-        DefaultSeed(phase_hint=:hadron),
-        DefaultSeed(phase_hint=:quark),
-        # 更偏禁闭：Φ 很小，但凝聚较弱（用于避免卡到坏分支）
-        DefaultSeed(copy(WEAK_CHIRAL_CONF_SEED_5), copy(WEAK_CHIRAL_CONF_SEED_5), :hadron),
-        # 人工高温候选：凝聚幅度更小、Polyakov loop 更高
-        DefaultSeed(copy(HT_GUESS_0p8_SEED_5), copy(HT_GUESS_0p8_SEED_5), :hadron),
-        DefaultSeed(copy(HT_GUESS_0p9_SEED_5), copy(HT_GUESS_0p9_SEED_5), :hadron),
-        DefaultSeed(copy(HT_GUESS_0p95_SEED_5), copy(HT_GUESS_0p95_SEED_5), :hadron),
+    default_candidates = default_multiseed_candidates_5()
+    candidates = SeedStrategy[
+        DefaultSeed(default_candidates[1], default_candidates[1], :hadron),
+        DefaultSeed(default_candidates[2], default_candidates[2], :hadron),
+        DefaultSeed(default_candidates[3], default_candidates[3], :hadron),
+        DefaultSeed(default_candidates[4], default_candidates[4], :hadron),
+        DefaultSeed(default_candidates[5], default_candidates[5], :hadron),
+        DefaultSeed(default_candidates[6], default_candidates[6], :hadron),
     ]
     return MultiSeed(candidates)
 end
@@ -313,4 +324,3 @@ Base.show(io::IO, s::MultiSeed) = print(io, "MultiSeed($(length(s.candidates)) c
 Base.show(io::IO, s::HybridContinuitySeed) = print(io, "HybridContinuitySeed(prev=$(s.previous_solution !== nothing))")
 
 end # module SeedStrategies
-

--- a/src/models/solver/SeedStrategies.jl
+++ b/src/models/solver/SeedStrategies.jl
@@ -246,21 +246,18 @@ end
     ]
 end
 
+@inline function seed_catalog(::FixedMu, θ::AbstractVector)
+    return default_multiseed_candidates_5()
+end
+
 @inline function seed_catalog(mode::ConstraintMode, θ::AbstractVector)
     return [extend_seed(seed, mode) for seed in default_multiseed_candidates_5()]
 end
 
-"""创建多初值策略，默认尝试强子相和夸克相"""
+"""创建多初值策略，默认尝试 catalog 中定义的候选序列"""
 function MultiSeed()
     default_candidates = default_multiseed_candidates_5()
-    candidates = SeedStrategy[
-        DefaultSeed(default_candidates[1], default_candidates[1], :hadron),
-        DefaultSeed(default_candidates[2], default_candidates[2], :hadron),
-        DefaultSeed(default_candidates[3], default_candidates[3], :hadron),
-        DefaultSeed(default_candidates[4], default_candidates[4], :hadron),
-        DefaultSeed(default_candidates[5], default_candidates[5], :hadron),
-        DefaultSeed(default_candidates[6], default_candidates[6], :hadron),
-    ]
+    candidates = SeedStrategy[DefaultSeed(seed, seed, :hadron) for seed in default_candidates]
     return MultiSeed(candidates)
 end
 

--- a/src/models/solver/WeightedFallback.jl
+++ b/src/models/solver/WeightedFallback.jl
@@ -66,7 +66,7 @@ function solve_weighted_block_fallback(mode::FixedAsymmetricRho, T_fm::Real;
     seed_candidates = Vector{Vector{Float64}}()
     push!(seed_candidates, copy(base_seed))
     extra = max(max_seed_candidates - 1, 0)
-    for seed in Iterators.take(get_all_seeds(MultiSeed(), [T_fm], mode), extra)
+    for seed in Iterators.take(seed_catalog(mode, [T_fm]), extra)
         s8 = length(seed) >= 8 ? Float64.(seed[1:8]) : extend_seed(Float64.(seed), mode)
         push!(seed_candidates, s8)
     end

--- a/tests/unit/models/test_constraint_solver.jl
+++ b/tests/unit/models/test_constraint_solver.jl
@@ -158,4 +158,11 @@ Models.pnjl_module()
         @test selected.selected_index == 2
         @test !selected.selected_candidate.hard_constraint_ok
     end
+
+    @testset "residual spine guard" begin
+        solver_path = joinpath(PROJECT_ROOT, "src", "models", "solver", "ConstraintSolver.jl")
+        source = read(solver_path, String)
+        @test occursin("_gap_norm_from_state", source)
+        @test !occursin("gap_residual(model", source)
+    end
 end

--- a/tests/unit/models/test_residual_spine_contract.jl
+++ b/tests/unit/models/test_residual_spine_contract.jl
@@ -1,0 +1,33 @@
+using Test
+using StaticArrays
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+@testset "residual spine contract" begin
+    model = Models.create_model(:PNJL)
+    x_state = SVector{5}(-1.84, -1.84, -2.23, 0.5, 0.5)
+    mu_vec = SVector{3}(0.0, 0.0, 0.0)
+    T_fm = 0.5
+    xi = 0.0
+    p_num = 8
+    t_num = 4
+
+    gap_norm = Models._gap_norm_from_state(model, x_state, mu_vec, T_fm; xi=xi, p_num=p_num, t_num=t_num)
+
+    thermal_nodes = Models.cached_nodes(p_num, t_num)
+    params = Models.GapParams(T_fm, thermal_nodes, xi; p_num=p_num, t_num=t_num, model_kind=:PNJL)
+    F_core = zeros(5)
+    Models.gap_core_residual!(F_core, model, x_state, mu_vec, params)
+    expected_norm = sqrt(sum(abs2, F_core))
+
+    @test isapprox(gap_norm, expected_norm; rtol=1e-9, atol=1e-9)
+
+    solver_path = joinpath(PROJECT_ROOT, "src", "models", "solver", "ConstraintSolver.jl")
+    source = read(solver_path, String)
+    @test occursin("_gap_norm_from_state", source)
+    @test !occursin("gap_residual(model", source)
+end

--- a/tests/unit/models/test_seed_catalog_contract.jl
+++ b/tests/unit/models/test_seed_catalog_contract.jl
@@ -1,0 +1,47 @@
+using Test
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+if !isdefined(Main, :Models)
+    include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+end
+
+@testset "seed catalog contract" begin
+    @testset "FixedMu catalog order matches default source" begin
+        θ = [0.5, 0.0]
+        from_catalog = Models.seed_catalog(Models.FixedMu(), θ)
+        from_default = Models.default_multiseed_candidates_5()
+
+        @test length(from_catalog) == length(from_default)
+        @test all(length.(from_catalog) .== 5)
+        @test all(length.(from_default) .== 5)
+        for i in eachindex(from_default)
+            @test from_catalog[i] == from_default[i]
+        end
+    end
+
+    @testset "non-FixedMu catalog keeps order and extends" begin
+        mode = Models.FixedAsymmetricRho(0.2, 1.0, 0.0)
+        θ = [0.5]
+        from_catalog = Models.seed_catalog(mode, θ)
+        base = Models.default_multiseed_candidates_5()
+
+        @test length(from_catalog) == length(base)
+        @test all(length.(from_catalog) .== 8)
+        for i in eachindex(base)
+            @test from_catalog[i][1:5] == base[i]
+        end
+    end
+
+    @testset "single-source consumption guards" begin
+        gap_solver_path = joinpath(PROJECT_ROOT, "src", "models", "solver", "GapSolver.jl")
+        weighted_path = joinpath(PROJECT_ROOT, "src", "models", "solver", "WeightedFallback.jl")
+
+        gap_source = read(gap_solver_path, String)
+        weighted_source = read(weighted_path, String)
+
+        @test occursin("seed_catalog(", gap_source)
+        @test occursin("seed_catalog(", weighted_source)
+        @test !occursin("get_all_seeds(MultiSeed(), [T_fm], mode)", weighted_source)
+    end
+end

--- a/tests/unit/pnjl/test_solver_seed_strategies.jl
+++ b/tests/unit/pnjl/test_solver_seed_strategies.jl
@@ -152,6 +152,22 @@ end
     end
 end
 
+@testset "Seed SoT guard" begin
+    @testset "default_multiseed_candidates_5 contract" begin
+        seeds = P.default_multiseed_candidates_5()
+        @test seeds isa Vector{Vector{Float64}}
+        @test length(seeds) >= 2
+        @test all(length.(seeds) .== 5)
+    end
+
+    @testset "GapSolver does not own default seed constants" begin
+        gap_solver_path = joinpath(PROJECT_ROOT, "src", "models", "solver", "GapSolver.jl")
+        source = read(gap_solver_path, String)
+        @test !occursin("const _HADRON_SEED_5", source)
+        @test !occursin("const _PNJL_MULTI_SEEDS", source)
+    end
+end
+
 # ============================================================================
 # extend_seed 测试
 # ============================================================================


### PR DESCRIPTION
## Summary
- Complete PR-D seed SoT convergence by introducing `seed_catalog` in `SeedStrategies` and routing both `GapSolver` and `WeightedFallback` to consume the same default candidate source.
- Complete residual spine convergence in `ConstraintSolver` by normalizing gap-norm evaluation through `_gap_norm_from_state -> gap_core_residual!`, and clarify API-vs-core responsibility boundaries in solver docs.
- Add contract guards for both governance axes (`test_seed_catalog_contract.jl`, `test_residual_spine_contract.jl`, plus strengthened existing guards) and update the active PR-D task sheet with before/after five-mode snapshot evidence.

## Verification
- `julia --project=. -e 'ENV["UNIT_FILES"]="pnjl/test_solver_seed_strategies.jl;models/test_seed_catalog_contract.jl;models/test_residual_spine_contract.jl;models/test_constraint_solver.jl;models/test_gap_solver.jl"; include("tests/unit/runtests.jl")'`
- `julia --project=. -e 'ENV["REGRESSION_FILES"]="models/test_solver_attempt_engine_convergence_regression.jl;pnjl/test_constraint_selection_regression.jl"; include("tests/regression/runtests.jl")'`