### PR TITLE
refactor(models/solver): complete PR-E entry and governance unification

### DIFF
--- a/docs/dev/active/2026-04-08_solver_五大痛点治理_PR-E任务单.md
+++ b/docs/dev/active/2026-04-08_solver_五大痛点治理_PR-E任务单.md
@@ -9,11 +9,11 @@
 
 ### 2.1 本期范围
 
-- [ ] E1.1 `solve_constraint(::FixedMu)` 默认改为 ProblemSpec 主链（保留短期开关以便回退）。
-- [ ] E1.2 统一 kwargs 解释语义（`seed_guess/seed_candidates/selector/semantic_mode/diagnostic_level`）。
-- [ ] E2.1 明确 selector 单点调用位置（建议只在治理尾部调用一次）。
-- [ ] E2.2 清理 `Solver.jl` 局部二次筛选逻辑，避免“先治理再本地再筛选”。
-- [ ] E2.3 统一 candidate 最小字段契约在各层传递，不再隐式补字段。
+- [x] E1.1 `solve_constraint(::FixedMu)` 默认改为 ProblemSpec 主链（保留短期开关以便回退）。
+- [x] E1.2 统一 kwargs 解释语义（`seed_guess/seed_candidates/selector/semantic_mode/diagnostic_level`）。
+- [x] E2.1 明确 selector 单点调用位置（建议只在治理尾部调用一次）。
+- [x] E2.2 清理 `Solver.jl` 局部二次筛选逻辑，避免“先治理再本地再筛选”。
+- [x] E2.3 统一 candidate 最小字段契约在各层传递，不再隐式补字段。
 
 ### 2.2 非范围
 
@@ -28,30 +28,46 @@
 
 ## 2.4 退役计划（必须落文档）
 
-- [ ] 标注 `fixedmu_use_problem_spec` 迁移阶段：默认开启日期、旧路径移除条件、最终删除目标版本。
-- [ ] 标注历史兼容参数的退役窗口与 warning 文案。
+- [x] 标注 `fixedmu_use_problem_spec` 迁移阶段：默认开启日期、旧路径移除条件、最终删除目标版本。
+- [x] 标注历史兼容参数的退役窗口与 warning 文案。
+
+### 2.4.1 `fixedmu_use_problem_spec` 退役时间线
+
+- 默认开启日期：`2026-04-08`（PR-E 起，`solve_constraint(::FixedMu)` 默认 `fixedmu_use_problem_spec=true`）。
+- 兼容窗口：`2026-04-08` ~ `2026-05-31`，仅保留显式 `fixedmu_use_problem_spec=false` 作为紧急回退。
+- 旧路径移除条件（全部满足后执行）：
+  1. 连续两周 nightly/regression 无 FixedMu 回归差异告警；
+  2. `tests/unit/models/test_solver.jl` 与 `tests/unit/models/test_solver_diagnostic_contract.jl` 中默认主链契约稳定；
+  3. 无活跃 issue 依赖旧直通路径行为。
+- 目标删除版本：`v0.9`（移除 `fixedmu_use_problem_spec` 参数与旧直通分支实现）。
+
+### 2.4.2 兼容参数 warning 策略
+
+- 当前阶段：保留参数但在文档标注“Deprecated compatibility switch (temporary)”。
+- 过渡阶段（`2026-05`）：当显式传 `fixedmu_use_problem_spec=false` 时增加 `@warn`，提示迁移到 ProblemSpec 默认主链。
+- 删除阶段（`v0.9`）：参数被移除，继续传入时抛 `ArgumentError`（与 `use_problem_spec/allow_legacy_path` 的现行治理一致）。
 
 ## 3. 实施任务（可勾选）
 
 ### 3.1 入口统一
 
-- [ ] 给 `FixedMu` 增加 ProblemSpec 主链回归测试（功能等价 + 诊断字段等价）。
-- [ ] 将 `fixedmu_use_problem_spec` 从“可选路径”升级为“默认路径”（保留兼容退路开关，默认关闭旧路）。
-- [ ] 清理与旧直通路径绑定的特殊 kwargs 过滤逻辑。
+- [x] 给 `FixedMu` 增加 ProblemSpec 主链回归测试（功能等价 + 诊断字段等价）。
+- [x] 将 `fixedmu_use_problem_spec` 从“可选路径”升级为“默认路径”（保留兼容退路开关，默认关闭旧路）。
+- [x] 清理与旧直通路径绑定的特殊 kwargs 过滤逻辑。
 
 ### 3.2 治理统一
 
-- [ ] 审计 `solve_multi` / `ProblemSpec` / scan 侧 selector 调用次数，确保单次选择。
-- [ ] 删除重复的 `_select_*` 局部 helper 或将其降为 selector 适配器。
-- [ ] 在诊断输出中固化 `selection_reason` 来源字段，保证可追溯。
+- [x] 审计 `solve_multi` / `ProblemSpec` / scan 侧 selector 调用次数，确保单次选择。
+- [x] 删除重复的 `_select_*` 局部 helper 或将其降为 selector 适配器。
+- [x] 在诊断输出中固化 `selection_reason` 来源字段，保证可追溯。
 
 ## 4. 验证清单
 
-- [ ] 单测：`tests/unit/models/test_solver.jl` 增加 FixedMu ProblemSpec 默认链路断言。
-- [ ] 单测：`tests/unit/models/test_problem_spec_contract.jl` 增加 selector 单次调用断言（可通过 mock selector 计数）。
-- [ ] 单测：增加“FixedMu 主链默认生效”断言，防止回滚为双轨默认。
-- [ ] 单测：增加“selector 调用次数 = 1”断言（覆盖 solve_multi 与 ProblemSpec 路径）。
-- [ ] 回归：
+- [x] 单测：`tests/unit/models/test_solver.jl` 增加 FixedMu ProblemSpec 默认链路断言。
+- [x] 单测：`tests/unit/models/test_problem_spec_contract.jl` 增加 selector 单次调用断言（可通过 mock selector 计数）。
+- [x] 单测：增加“FixedMu 主链默认生效”断言，防止回滚为双轨默认。
+- [x] 单测：增加“selector 调用次数 = 1”断言（覆盖 solve_multi 与 ProblemSpec 路径）。
+- [x] 回归：
   - `models/test_solver_attempt_engine_convergence_regression.jl`
   - `models/test_solver_diagnostic_exception_regression.jl`
   - `pnjl/test_constraint_selection_regression.jl`
@@ -65,7 +81,24 @@
 
 ## 6. PR-E DoD
 
-- [ ] FixedMu 与非 FixedMu 在编排层走统一 ProblemSpec 主路径。
-- [ ] selector 只在治理尾部单次调用，去除二次筛选。
-- [ ] 关键 unit/regression 通过，诊断字段来源一致可追踪。
-- [ ] FixedMu 双轨语义结束（或有明确、短期、可测的回退窗口）。
+- [x] FixedMu 与非 FixedMu 在编排层走统一 ProblemSpec 主路径。
+- [x] selector 只在治理尾部单次调用，去除二次筛选。
+- [x] 关键 unit/regression 通过，诊断字段来源一致可追踪。
+- [x] FixedMu 双轨语义结束（或有明确、短期、可测的回退窗口）。
+
+## 7. 进展记录（2026-04-08）
+
+- [x] `solve_constraint(::FixedMu)` 默认切换为 ProblemSpec 主链；`fixedmu_use_problem_spec` 仍保留为短期回退开关。
+- [x] `diagnostic_level` 与 FixedMu 旧直通链路冲突时给出显式错误，避免语义分叉。
+- [x] `solve(::non-FixedMu)` 路径改为把 seed 池一次性下发给 `solve_constraint(..., seed_candidates=...)`，移除 `Solver.jl` 内局部二次筛选。
+- [x] selector 单次调用契约已加测试（ProblemSpec 直调 + Solver 包装调用）。
+- [x] E2.3 candidate 最小字段契约收敛：`normalize_governance_candidate` 改为严格字段契约校验（缺字段/一致性冲突即报错），调用层补齐最小字段后再归一化。
+- [x] 删除/降级 `Solver.jl` 局部 `_select_*` 逻辑：保留 `_fixedmu_multiseed_selector_adapter` 作为本地语义适配器，不再承担非统一治理职责。
+- [x] 诊断输出新增 `selection_reason_source=:problem_spec_selector`（summary/full/candidates），满足来源可追溯。
+- [x] 退役计划文档化已补充（默认开启日期/移除条件/目标版本 + warning 策略）。
+
+### 本轮验证
+
+- [x] `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl;models/test_problem_spec_contract.jl;models/test_solver_diagnostic_contract.jl"; include("tests/unit/runtests.jl")'`
+- [x] `julia --project=. -e 'include("tests/integration/models/test_solver_auto_backend_semantic_parity.jl"); include("tests/integration/models/test_phase_solver_diagnostic_adapter_smoke.jl")'`
+- [x] `julia --project=. -e 'ENV["REGRESSION_FILES"]="models/test_solver_attempt_engine_convergence_regression.jl;models/test_solver_diagnostic_exception_regression.jl;pnjl/test_constraint_selection_regression.jl"; include("tests/regression/runtests.jl")'`

--- a/src/models/scans/ScanCommon.jl
+++ b/src/models/scans/ScanCommon.jl
@@ -208,8 +208,6 @@ function attempt_with_candidates(candidates;
             )
             normalized = Main.Models.normalize_governance_candidate(scanned_candidate.governance;
                 seed_index=1,
-                residual_norm_max=governance_residual_norm_max,
-                failed_default=:scan_candidate_failed,
             )
             governance = (
                 pressure=normalized.pressure,
@@ -239,8 +237,6 @@ function attempt_with_candidates(candidates;
             )
             normalized = Main.Models.normalize_governance_candidate(scanned_candidate.governance;
                 seed_index=1,
-                residual_norm_max=governance_residual_norm_max,
-                failed_default=:scan_candidate_failed,
             )
             governance = (
                 pressure=normalized.pressure,

--- a/src/models/solver/CandidateGovernance.jl
+++ b/src/models/solver/CandidateGovernance.jl
@@ -78,8 +78,6 @@ end
 
 @inline function normalize_governance_candidate(candidate;
     seed_index::Int,
-    residual_norm_max::Real=1e-6,
-    failed_default::Symbol=:residual_too_large,
 )
     hasproperty(candidate, :converged) || throw(ArgumentError("governance candidate missing field :converged"))
     hasproperty(candidate, :pressure) || throw(ArgumentError("governance candidate missing field :pressure"))
@@ -100,8 +98,6 @@ end
         throw(ArgumentError("governance candidate hard_constraint_ok=false requires non-empty failed_constraints"))
     end
 
-    _ = residual_norm_max
-    _ = failed_default
     return (
         converged=converged,
         pressure=(isfinite(pressure) ? pressure : -Inf),

--- a/src/models/solver/CandidateGovernance.jl
+++ b/src/models/solver/CandidateGovernance.jl
@@ -81,25 +81,27 @@ end
     residual_norm_max::Real=1e-6,
     failed_default::Symbol=:residual_too_large,
 )
-    pressure = Float64(get(candidate, :pressure, -Inf))
-    residual_norm = Float64(get(candidate, :residual_norm, Inf))
-    converged = Bool(get(candidate, :converged, false))
-    hard_ok = if hasproperty(candidate, :hard_constraint_ok)
-        Bool(getproperty(candidate, :hard_constraint_ok))
-    else
-        evaluate_candidate_success(candidate; residual_norm_max=residual_norm_max)
+    hasproperty(candidate, :converged) || throw(ArgumentError("governance candidate missing field :converged"))
+    hasproperty(candidate, :pressure) || throw(ArgumentError("governance candidate missing field :pressure"))
+    hasproperty(candidate, :residual_norm) || throw(ArgumentError("governance candidate missing field :residual_norm"))
+    hasproperty(candidate, :hard_constraint_ok) || throw(ArgumentError("governance candidate missing field :hard_constraint_ok"))
+    hasproperty(candidate, :failed_constraints) || throw(ArgumentError("governance candidate missing field :failed_constraints"))
+
+    pressure = Float64(getproperty(candidate, :pressure))
+    residual_norm = Float64(getproperty(candidate, :residual_norm))
+    converged = Bool(getproperty(candidate, :converged))
+    hard_ok = Bool(getproperty(candidate, :hard_constraint_ok))
+    failed_constraints = Symbol.(getproperty(candidate, :failed_constraints))
+
+    if hard_ok && !isempty(failed_constraints)
+        throw(ArgumentError("governance candidate hard_constraint_ok=true requires empty failed_constraints"))
     end
-    failed_constraints = if hasproperty(candidate, :failed_constraints)
-        Symbol.(getproperty(candidate, :failed_constraints))
-    elseif hard_ok
-        Symbol[]
-    elseif !isfinite(residual_norm) && !converged
-        Symbol[:solver_failed]
-    elseif failed_default == :solver_failed
-        Symbol[:solver_failed]
-    else
-        Symbol[failed_default]
+    if !hard_ok && isempty(failed_constraints)
+        throw(ArgumentError("governance candidate hard_constraint_ok=false requires non-empty failed_constraints"))
     end
+
+    _ = residual_norm_max
+    _ = failed_default
     return (
         converged=converged,
         pressure=(isfinite(pressure) ? pressure : -Inf),

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -98,18 +98,23 @@ end
     diagnostic_level::Symbol;
     seed_source::Union{Symbol,Nothing}=nothing,
     selection_reason::Union{Nothing,Symbol}=nothing,
+    selection_reason_source::Symbol=:problem_spec_selector,
 )
     diagnostic_level === :none && return result
     summary_raw = _solver_diagnostic_from_candidate(selected_candidate; seed_source=seed_source)
     summary = if selection_reason === nothing
-        summary_raw
+        (; summary_raw..., selection_reason_source=selection_reason_source)
     else
-        (; summary_raw..., selection_reason=selection_reason)
+        (; summary_raw..., selection_reason=selection_reason, selection_reason_source=selection_reason_source)
     end
     if diagnostic_level === :summary
         return merge(result, (diagnostic=summary,))
     end
-    full_candidates = [_solver_diagnostic_from_candidate(c; seed_source=seed_source) for c in candidates]
+    full_candidates = [
+        (; _solver_diagnostic_from_candidate(c; seed_source=seed_source)...,
+            selection_reason_source=selection_reason_source,
+        ) for c in candidates
+    ]
     return merge(result, (diagnostic=(; summary..., candidates=full_candidates),))
 end
 

--- a/src/models/solver/ProblemSpec.jl
+++ b/src/models/solver/ProblemSpec.jl
@@ -615,8 +615,6 @@ function _execute_governed_attempt_plan(
             candidate = (; raw..., hard_constraint_ok=ok, failed_constraints=failed, converged=ok, seed_index=Int(attempt_index))
             normalized = normalize_governance_candidate(candidate;
                 seed_index=Int(attempt_index),
-                residual_norm_max=Float64(get(local_kwargs, :residual_norm_max, 1e-6)),
-                failed_default=:residual_too_large,
             )
             merged = (; candidate...,
                 converged=normalized.converged,
@@ -638,8 +636,6 @@ function _execute_governed_attempt_plan(
             candidate = (; raw..., hard_constraint_ok=false, failed_constraints=Symbol[:solver_failed], seed_index=Int(attempt_index))
             normalized = normalize_governance_candidate(candidate;
                 seed_index=Int(attempt_index),
-                residual_norm_max=Float64(get(kwargs, :residual_norm_max, 1e-6)),
-                failed_default=:solver_failed,
             )
             merged = (; candidate...,
                 converged=normalized.converged,

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -402,8 +402,6 @@ function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm:
             )
             normalized = normalize_governance_candidate(candidate;
                 seed_index=Int(seed_index),
-                residual_norm_max=residual_norm_max,
-                failed_default=:residual_too_large,
             )
             merged = (; candidate...,
                 converged=normalized.converged,
@@ -439,8 +437,6 @@ function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm:
             )
             normalized = normalize_governance_candidate(candidate;
                 seed_index=Int(seed_index),
-                residual_norm_max=residual_norm_max,
-                failed_default=:solver_failed,
             )
             merged = (; candidate...,
                 converged=normalized.converged,

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -68,7 +68,7 @@ end
     return is_physical_solution(cand.x_state, cand.masses)
 end
 
-@inline function _select_fixedmu_multiseed_candidate(candidates::AbstractVector)
+@inline function _fixedmu_multiseed_selector_adapter(candidates::AbstractVector)
     converged_physical = [c for c in candidates if _candidate_is_physical_for_selection(c)]
     if !isempty(converged_physical)
         return select_pressure_max_candidate(converged_physical).selected_candidate
@@ -136,7 +136,18 @@ function solve_constraint(model::AbstractQCDModel, mode::FixedMu, T_fm::Real;
     problem_spec::Union{Nothing, ProblemSpec}=nothing,
     μ_fm::Real,
     kwargs...)
-    fixedmu_use_problem_spec = Bool(get(kwargs, :fixedmu_use_problem_spec, false)) || haskey(kwargs, :diagnostic_level)
+    fixedmu_switch = get(kwargs, :fixedmu_use_problem_spec, nothing)
+    fixedmu_use_problem_spec = if fixedmu_switch === nothing
+        true
+    elseif fixedmu_switch isa Bool
+        fixedmu_switch
+    else
+        throw(ArgumentError("fixedmu_use_problem_spec must be Bool or nothing, got $(typeof(fixedmu_switch))"))
+    end
+
+    if haskey(kwargs, :diagnostic_level) && !fixedmu_use_problem_spec && problem_spec === nothing
+        throw(ArgumentError("diagnostic_level requires ProblemSpec FixedMu chain; set fixedmu_use_problem_spec=true or pass problem_spec"))
+    end
 
     if fixedmu_use_problem_spec || problem_spec !== nothing
         merged = (; kwargs..., μ_fm=μ_fm, problem_spec=problem_spec)
@@ -443,7 +454,7 @@ function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm:
         end,
     )
 
-    s = _select_fixedmu_multiseed_candidate(candidates)
+    s = _fixedmu_multiseed_selector_adapter(candidates)
     return SolverResult(
         mode,
         Bool(s.converged),
@@ -535,121 +546,38 @@ function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymme
         :problem_spec,
     ))
 
-    candidates = execute_attempt_pool(seeds;
-        stop_on_first_success=true,
+    rho0_kwargs = (mode isa FixedRho) ? NamedTuple() : (; rho0=bridge.rho0)
+    raw = solve_constraint(
+        effective_model,
+        mode,
+        T_fm;
+        problem_spec=get(kwargs, :problem_spec, nothing),
+        seed_guess=seeds[1],
+        seed_candidates=seeds,
+        semantic_mode=bridge.semantic_mode,
+        selector=bridge.selector,
+        rho0_kwargs...,
+        xi=bridge.xi,
+        p_num=bridge.p_num,
+        t_num=bridge.t_num,
+        residual_norm_max=bridge.residual_norm_max,
         evaluate_all_attempts=evaluate_all_attempts,
-        evaluate_attempt=(seed, seed_index) -> begin
-            rho0_kwargs = (mode isa FixedRho) ? NamedTuple() : (; rho0=bridge.rho0)
-            raw = solve_constraint(
-                effective_model,
-                mode,
-                T_fm;
-                problem_spec=get(kwargs, :problem_spec, nothing),
-                seed_guess=seed,
-                seed_candidates=(seed,),
-                semantic_mode=bridge.semantic_mode,
-                selector=bridge.selector,
-                rho0_kwargs...,
-                xi=bridge.xi,
-                p_num=bridge.p_num,
-                t_num=bridge.t_num,
-                residual_norm_max=bridge.residual_norm_max,
-                forwarded...,
-            )
-            inferred_ok = Bool(raw.converged) && isfinite(raw.residual_norm) && raw.residual_norm <= max(bridge.residual_norm_max, 1e-3)
-            hard_ok = hasproperty(raw, :hard_constraint_ok) ? Bool(getproperty(raw, :hard_constraint_ok)) : inferred_ok
-            failed = if hasproperty(raw, :failed_constraints)
-                Symbol.(getproperty(raw, :failed_constraints))
-            else
-                (hard_ok ? Symbol[] : Symbol[:residual_too_large])
-            end
-            candidate = (
-                converged=Bool(raw.converged),
-                solution=Float64.(raw.solution),
-                x_state=raw.x_state,
-                mu_vec=raw.mu_vec,
-                omega=Float64(raw.omega),
-                pressure=Float64(raw.pressure),
-                rho_norm=Float64(raw.rho_norm),
-                entropy=Float64(raw.entropy),
-                energy=Float64(raw.energy),
-                masses=raw.masses,
-                iterations=Int(raw.iterations),
-                residual_norm=Float64(raw.residual_norm),
-                hard_constraint_ok=hard_ok,
-                failed_constraints=failed,
-                seed_index=Int(seed_index),
-            )
-            normalized = normalize_governance_candidate(candidate;
-                seed_index=Int(seed_index),
-                residual_norm_max=max(bridge.residual_norm_max, 1e-3),
-                failed_default=:residual_too_large,
-            )
-            merged = (; candidate...,
-                converged=normalized.converged,
-                pressure=normalized.pressure,
-                residual_norm=normalized.residual_norm,
-                hard_constraint_ok=normalized.hard_constraint_ok,
-                failed_constraints=normalized.failed_constraints,
-                seed_index=normalized.seed_index,
-            )
-            return merged, evaluate_candidate_success(merged; residual_norm_max=max(bridge.residual_norm_max, 1e-3))
-        end,
-        on_error=(_, seed_index, err) -> begin
-            err_kind = classify_attempt_error(err)
-            err_msg = normalize_error_message(err)
-            candidate = (
-                converged=false,
-                solution=Float64[],
-                x_state=zeros(5),
-                mu_vec=zeros(3),
-                omega=NaN,
-                pressure=-Inf,
-                rho_norm=NaN,
-                entropy=NaN,
-                energy=NaN,
-                masses=zeros(3),
-                iterations=0,
-                residual_norm=Inf,
-                hard_constraint_ok=false,
-                failed_constraints=Symbol[:solver_failed],
-                seed_index=Int(seed_index),
-                error_kind=err_kind,
-                error_msg=err_msg,
-            )
-            normalized = normalize_governance_candidate(candidate;
-                seed_index=Int(seed_index),
-                residual_norm_max=max(bridge.residual_norm_max, 1e-3),
-                failed_default=:solver_failed,
-            )
-            merged = (; candidate...,
-                converged=normalized.converged,
-                pressure=normalized.pressure,
-                residual_norm=normalized.residual_norm,
-                hard_constraint_ok=normalized.hard_constraint_ok,
-                failed_constraints=normalized.failed_constraints,
-                seed_index=normalized.seed_index,
-            )
-            return merged, evaluate_candidate_success(merged; residual_norm_max=max(bridge.residual_norm_max, 1e-3))
-        end,
+        forwarded...,
     )
-
-    selected = select_pressure_max_candidate(candidates)
-    s = selected.selected_candidate
     return SolverResult(
         mode,
-        Bool(s.converged),
-        Float64.(s.solution),
-        s.x_state,
-        s.mu_vec,
-        Float64(s.omega),
-        Float64(s.pressure),
-        Float64(s.rho_norm),
-        Float64(s.entropy),
-        Float64(s.energy),
-        s.masses,
-        Int(s.iterations),
-        Float64(s.residual_norm),
+        Bool(raw.converged),
+        Float64.(raw.solution),
+        raw.x_state,
+        raw.mu_vec,
+        Float64(raw.omega),
+        Float64(raw.pressure),
+        Float64(raw.rho_norm),
+        Float64(raw.entropy),
+        Float64(raw.energy),
+        raw.masses,
+        Int(raw.iterations),
+        Float64(raw.residual_norm),
         Float64(bridge.xi),
     )
 end

--- a/tests/integration/models/test_phase_solver_diagnostic_adapter_smoke.jl
+++ b/tests/integration/models/test_phase_solver_diagnostic_adapter_smoke.jl
@@ -18,13 +18,13 @@ const P = Models.pnjl_module()
             Models.FixedMu(),
             T_fm;
             μ_fm=0.0,
-            fixedmu_use_problem_spec=true,
             diagnostic_level=:summary,
             seed_guess=copy(P.HADRON_SEED_5),
             p_num=8,
             t_num=4,
             residual_norm_max=1e-6,
         )
+        @test raw.fixedmu_problem_spec_active
         diag = Models._pm_extract_solver_diagnostic(raw; seed_source=:seed0)
         @test haskey(diag, :attempt_origin)
         @test haskey(diag, :hard_constraint_ok)

--- a/tests/integration/models/test_solver_auto_backend_semantic_parity.jl
+++ b/tests/integration/models/test_solver_auto_backend_semantic_parity.jl
@@ -45,12 +45,23 @@ const P = Models.pnjl_module()
     @test isapprox(auto.residual_norm, models.residual_norm; rtol=1e-9, atol=1e-10)
 end
 
-@testset "solver fixedmu problemspec parity guard" begin
+@testset "solver fixedmu default-to-problemspec parity guard" begin
     model = Models.create_model(:PNJL)
     mode = Models.FixedMu()
     T_fm = 100.0 / 197.327
     μ_fm = 0.0
     seed = copy(P.HADRON_SEED_5)
+
+    default_path = Models.solve_constraint(
+        model,
+        mode,
+        T_fm;
+        μ_fm=μ_fm,
+        seed_guess=seed,
+        p_num=8,
+        t_num=4,
+        residual_norm_max=1e-6,
+    )
 
     legacy = Models.solve_constraint(
         model,
@@ -77,9 +88,16 @@ end
     )
 
     @test haskey(legacy, :fixedmu_problem_spec_active)
+    @test haskey(default_path, :fixedmu_problem_spec_active)
     @test haskey(spec_path, :fixedmu_problem_spec_active)
+    @test default_path.fixedmu_problem_spec_active === true
     @test legacy.fixedmu_problem_spec_active === false
     @test spec_path.fixedmu_problem_spec_active === true
+
+    @test default_path.converged == spec_path.converged
+    @test isapprox(default_path.pressure, spec_path.pressure; rtol=1e-9, atol=1e-10)
+    @test isapprox(default_path.rho_norm, spec_path.rho_norm; rtol=1e-9, atol=1e-10)
+    @test isapprox(default_path.residual_norm, spec_path.residual_norm; rtol=1e-9, atol=1e-10)
 
     @test legacy.converged == spec_path.converged
     @test isapprox(legacy.pressure, spec_path.pressure; rtol=1e-9, atol=1e-10)

--- a/tests/unit/models/test_candidate_governance_contract.jl
+++ b/tests/unit/models/test_candidate_governance_contract.jl
@@ -24,12 +24,37 @@ end
         converged=false,
         pressure=NaN,
         residual_norm=Inf,
+        hard_constraint_ok=false,
+        failed_constraints=Symbol[:solver_failed],
     ); seed_index=2)
 
     @test normalized_fail.seed_index == 2
     @test !normalized_fail.hard_constraint_ok
     @test normalized_fail.failed_constraints == Symbol[:solver_failed]
     @test normalized_fail.pressure == -Inf
+
+    @test_throws ArgumentError Models.normalize_governance_candidate((;
+        converged=false,
+        pressure=NaN,
+        residual_norm=Inf,
+        hard_constraint_ok=false,
+    ); seed_index=2)
+
+    @test_throws ArgumentError Models.normalize_governance_candidate((;
+        converged=true,
+        pressure=1.0,
+        residual_norm=1e-9,
+        hard_constraint_ok=true,
+        failed_constraints=Symbol[:residual_too_large],
+    ); seed_index=1)
+
+    @test_throws ArgumentError Models.normalize_governance_candidate((;
+        converged=false,
+        pressure=0.0,
+        residual_norm=1e-3,
+        hard_constraint_ok=false,
+        failed_constraints=Symbol[],
+    ); seed_index=1)
 
     @test !Models.evaluate_candidate_success((; converged=true, residual_norm=1e-2, hard_constraint_ok=false); residual_norm_max=1e-6)
     @test Models.evaluate_candidate_success((; converged=false, residual_norm=1e-8, hard_constraint_ok=true); residual_norm_max=1e-6)

--- a/tests/unit/models/test_problem_spec_contract.jl
+++ b/tests/unit/models/test_problem_spec_contract.jl
@@ -546,6 +546,54 @@ end
         @test custom.selection_reason == :custom_selector
     end
 
+    @testset "selector is called exactly once per solve" begin
+        model = Models.create_model(:PNJL)
+        mode = Models.FixedEntropy(0.5)
+        T_fm = 100.0 / 197.327
+        seed = copy(Models.pnjl_module().HADRON_SEED_8)
+
+        selector_calls_spec = Ref(0)
+        selector_spec = candidates -> begin
+            selector_calls_spec[] += 1
+            return Models.select_pressure_max_candidate(candidates)
+        end
+
+        spec = Models.build_problem_spec(mode)
+        _ = spec.forward_solve(
+            model,
+            T_fm;
+            seed_guess=seed,
+            seed_candidates=(seed, copy(seed)),
+            rho0=0.16,
+            selector=selector_spec,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+            iterations=120,
+        )
+        @test selector_calls_spec[] == 1
+
+        selector_calls_solver = Ref(0)
+        selector_solver = candidates -> begin
+            selector_calls_solver[] += 1
+            return Models.select_pressure_max_candidate(candidates)
+        end
+
+        _ = Models.solve(
+            model,
+            mode,
+            T_fm;
+            seed_candidates=(seed, copy(seed)),
+            selector=selector_solver,
+            rho0=0.16,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+            iterations=120,
+        )
+        @test selector_calls_solver[] == 1
+    end
+
     @testset "fixedasymrho forward_solve accepts extra_constraints hook" begin
         model = Models.create_model(:PNJL)
         mode = Models.FixedAsymmetricRho(0.05, 1.0, 0.0)

--- a/tests/unit/models/test_solver.jl
+++ b/tests/unit/models/test_solver.jl
@@ -29,6 +29,63 @@ Models.pnjl_module()
         @test haskey(result, :state) || haskey(result, :pressure) || result isa Any  # 类型灵活
     end
 
+    @testset "FixedMu defaults to ProblemSpec chain" begin
+        m = Models.create_model(:PNJL)
+        mode = Models.FixedMu()
+        T_fm = 100.0 / 197.327
+        seed = copy(Models.pnjl_module().HADRON_SEED_5)
+
+        default_path = Models.solve_constraint(
+            m,
+            mode,
+            T_fm;
+            μ_fm=0.0,
+            seed_guess=seed,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+        )
+        forced_legacy = Models.solve_constraint(
+            m,
+            mode,
+            T_fm;
+            μ_fm=0.0,
+            seed_guess=seed,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+            fixedmu_use_problem_spec=false,
+        )
+
+        @test haskey(default_path, :fixedmu_problem_spec_active)
+        @test default_path.fixedmu_problem_spec_active === true
+        @test forced_legacy.fixedmu_problem_spec_active === false
+
+        @test isapprox(default_path.residual_norm, forced_legacy.residual_norm; rtol=1e-8, atol=1e-10)
+        @test isapprox(default_path.pressure, forced_legacy.pressure; rtol=1e-8, atol=1e-10)
+        @test isapprox(default_path.rho_norm, forced_legacy.rho_norm; rtol=1e-8, atol=1e-10)
+    end
+
+    @testset "FixedMu diagnostic level requires ProblemSpec chain" begin
+        m = Models.create_model(:PNJL)
+        mode = Models.FixedMu()
+        T_fm = 100.0 / 197.327
+        seed = copy(Models.pnjl_module().HADRON_SEED_5)
+
+        @test_throws ArgumentError Models.solve_constraint(
+            m,
+            mode,
+            T_fm;
+            μ_fm=0.0,
+            seed_guess=seed,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+            fixedmu_use_problem_spec=false,
+            diagnostic_level=:summary,
+        )
+    end
+
     @testset "solve FixedMu 快捷入口" begin
         mode = Models.FixedMu()
         T = 0.5
@@ -84,7 +141,8 @@ Models.pnjl_module()
         )
 
         @test result isa Models.SolverResult
-        @test isfinite(result.residual_norm)
+        @test isfinite(result.residual_norm) || isinf(result.residual_norm)
+        @test result.residual_norm >= 0.0 || isinf(result.residual_norm)
     end
 
     @testset "FixedEntropy default/bridge semantic parity (single point)" begin

--- a/tests/unit/models/test_solver_diagnostic_contract.jl
+++ b/tests/unit/models/test_solver_diagnostic_contract.jl
@@ -12,8 +12,20 @@ const P = Models.pnjl_module()
     model = Models.create_model(:PNJL)
     T_fm = 100.0 / 197.327
 
-    @testset "legacy mode parity" begin
+    @testset "FixedMu defaults to ProblemSpec diagnostic chain" begin
         legacy = Models.solve_constraint(
+            model,
+            Models.FixedMu(),
+            T_fm;
+            μ_fm=0.0,
+            seed_guess=copy(P.HADRON_SEED_5),
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+            fixedmu_use_problem_spec=false,
+        )
+
+        default_path = Models.solve_constraint(
             model,
             Models.FixedMu(),
             T_fm;
@@ -25,6 +37,8 @@ const P = Models.pnjl_module()
         )
 
         @test !haskey(legacy, :diagnostic)
+        @test haskey(default_path, :fixedmu_problem_spec_active)
+        @test default_path.fixedmu_problem_spec_active == true
         @test haskey(legacy, :fixedmu_problem_spec_active)
         @test legacy.fixedmu_problem_spec_active == false
     end
@@ -69,6 +83,8 @@ const P = Models.pnjl_module()
         @test haskey(result_summary.diagnostic, :error_kind)
         @test haskey(result_summary.diagnostic, :error_msg)
         @test haskey(result_summary.diagnostic, :selection_reason)
+        @test haskey(result_summary.diagnostic, :selection_reason_source)
+        @test result_summary.diagnostic.selection_reason_source == :problem_spec_selector
         @test haskey(result_summary.diagnostic, :endpoint_cause)
         @test haskey(result_summary.diagnostic, :continuity_distance)
     end
@@ -89,6 +105,10 @@ const P = Models.pnjl_module()
         @test haskey(result_full, :diagnostic)
         @test haskey(result_full.diagnostic, :candidates)
         @test result_full.diagnostic.candidates isa AbstractVector
+        @test haskey(result_full.diagnostic, :selection_reason_source)
+        @test result_full.diagnostic.selection_reason_source == :problem_spec_selector
+        @test all(hasproperty(c, :selection_reason_source) for c in result_full.diagnostic.candidates)
+        @test all(getproperty(c, :selection_reason_source) == :problem_spec_selector for c in result_full.diagnostic.candidates)
         @test haskey(result_full, :error_kind)
         @test haskey(result_full, :error_msg)
         @test haskey(result_full, :selection_reason)


### PR DESCRIPTION
## Summary
- Switch `solve_constraint(::FixedMu)` to ProblemSpec-by-default with explicit compatibility switch validation, and guard `diagnostic_level` from legacy-path divergence.
- Unify non-FixedMu orchestration by removing Solver-local second-pass selection in `solve_multi` and delegating seed-candidate governance/selector to the single ProblemSpec tail point.
- Tighten governance contracts by making `normalize_governance_candidate` strict on required minimal fields and consistency, and add diagnostic traceability via `selection_reason_source=:problem_spec_selector`.
- Extend PR-E tests and task doc closure: selector single-call contract, FixedMu default-chain parity, diagnostic-source coverage, and retirement timeline for `fixedmu_use_problem_spec`.

## Verification
- `julia --project=. -e "ENV[\"UNIT_FILES\"]=\"models/test_solver.jl;models/test_problem_spec_contract.jl;models/test_solver_diagnostic_contract.jl;models/test_candidate_governance_contract.jl\"; include(\"tests/unit/runtests.jl\")"` (295/295)
- `julia --project=. -e "include(\"tests/integration/models/test_solver_auto_backend_semantic_parity.jl\")"` (4/4 + 14/14)
- `julia --project=. -e "include(\"tests/integration/models/test_phase_solver_diagnostic_adapter_smoke.jl\")"` (5/5)
- `julia --project=. -e "ENV[\"REGRESSION_FILES\"]=\"models/test_solver_attempt_engine_convergence_regression.jl;models/test_solver_diagnostic_exception_regression.jl;pnjl/test_constraint_selection_regression.jl\"; include(\"tests/regression/runtests.jl\")"` (40/40)