### PR TITLE
refactor(models/solver): harden solver runtime option boundaries (PR-1)

### DIFF
--- a/docs/dev/active/2026-04-08_solver_重构解耦_PR-1_边界硬化任务单.md
+++ b/docs/dev/active/2026-04-08_solver_重构解耦_PR-1_边界硬化任务单.md
@@ -36,20 +36,20 @@
 
 ## 2. 任务分解（可勾选）
 
-- [ ] 盘点 `Solver.jl` 中 mode 无关 kwargs 解析点（`xi/p_num/t_num/residual_norm_max/semantic_mode/selector/seed*`）。
-- [ ] 新建运行时选项结构（或等价 NamedTuple helper）并集中校验类型与默认值。
-- [ ] 将 FixedMu 与非 FixedMu 共用参数解析逻辑迁到统一 helper。
-- [ ] 保持 `solve/solve_multi/solve_constraint` 函数签名不变，确保外部调用兼容。
-- [ ] 清理入口层内联判断分支，保证“解析 -> 分发 -> 封装”三段顺序清晰。
-- [ ] 增补/更新 unit 测试：覆盖参数默认值、非法参数类型、旧行为回归。
-- [ ] 补充开发说明：记录 PR-1 完成后入口职责边界。
+- [x] 盘点 `Solver.jl` 中 mode 无关 kwargs 解析点（`xi/p_num/t_num/residual_norm_max/semantic_mode/selector/seed*`）。
+- [x] 新建运行时选项结构（或等价 NamedTuple helper）并集中校验类型与默认值。
+- [x] 将 FixedMu 与非 FixedMu 共用参数解析逻辑迁到统一 helper。
+- [x] 保持 `solve/solve_multi/solve_constraint` 函数签名不变，确保外部调用兼容。
+- [x] 清理入口层内联判断分支，保证“解析 -> 分发 -> 封装”三段顺序清晰。
+- [x] 增补/更新 unit 测试：覆盖参数默认值、非法参数类型、旧行为回归。
+- [x] 补充开发说明：记录 PR-1 完成后入口职责边界。
 
 ## 3. 验证与验收标准
 
-- [ ] `tests/unit/models/test_solver*.jl` 全绿。
-- [ ] 至少一条 integration smoke 覆盖 `solve` 与 `solve_multi` 主路径。
-- [ ] FixedMu 的 `fixedmu_use_problem_spec` 既有行为不变。
-- [ ] 不新增公开导出符号（除非评审明确批准）。
+- [x] `tests/unit/models/test_solver*.jl` 全绿。
+- [x] 至少一条 integration smoke 覆盖 `solve` 与 `solve_multi` 主路径。
+- [x] FixedMu 的 `fixedmu_use_problem_spec` 既有行为不变。
+- [x] 不新增公开导出符号（除非评审明确批准）。
 - [ ] `git diff` 显示无与本 PR 无关的目录污染。
 
 建议最小验证命令（按顺序）：
@@ -79,6 +79,21 @@
 - [ ] PR 已通过评审并采用 `squash + delete` 合并。
 - [ ] 本地执行：`git switch main`，删除本地开发分支。
 - [ ] 本任务单状态已更新（勾选已完成项，补充实际验证命令输出摘要）。
+
+## 8. 开发说明（PR-1 入口边界）
+
+- 入口层新增统一运行时参数解析 helper：`_resolve_common_runtime_options`、`_resolve_fixedmu_runtime_options`、`_resolve_fixedmu_multi_runtime_options`，统一承接 `xi/p_num/t_num/residual_norm_max` 的默认值与类型校验。
+- mode 无关种子参数校验集中到 `_normalize_seed_vector` 与 `_normalize_seed_pool`，在 `solve/solve_multi` 的 FixedMu 与非 FixedMu 路径复用，避免入口处散落的局部 `Float64.(...)` 转换。
+- `solve/solve_multi/solve_constraint` 的对外签名保持不变；入口职责保持为“参数解析 -> 调用 solve_constraint/ProblemSpec 分发 -> SolverResult 封装”。
+
+## 9. 实际验证结果摘要
+
+- 单元测试（目标文件集）
+  - 命令：`julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl,models/test_solver_named_vec_parity.jl,models/test_solver_schema_adapter.jl"; include("tests/unit/runtests.jl")'`
+  - 结果：`Unit | Pass 64 / Total 64`
+- 集成测试（smoke）
+  - 命令：`julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`
+  - 结果：`Integration | Pass 463 / Total 463`
 
 ## 7. 与下一 PR 的衔接检查（PR-1 -> PR-2）
 

--- a/docs/dev/active/2026-04-08_solver_重构解耦_PR-1_边界硬化任务单.md
+++ b/docs/dev/active/2026-04-08_solver_重构解耦_PR-1_边界硬化任务单.md
@@ -50,7 +50,7 @@
 - [x] 至少一条 integration smoke 覆盖 `solve` 与 `solve_multi` 主路径。
 - [x] FixedMu 的 `fixedmu_use_problem_spec` 既有行为不变。
 - [x] 不新增公开导出符号（除非评审明确批准）。
-- [ ] `git diff` 显示无与本 PR 无关的目录污染。
+- [x] `git diff` 显示无与本 PR 无关的目录污染。
 
 建议最小验证命令（按顺序）：
 
@@ -73,12 +73,12 @@
 
 ## 6. 完成信号（Completion Signal）
 
-- [ ] 本任务单条目已全部完成并回写，再创建 PR。
+- [x] 本任务单条目已全部完成并回写，再创建 PR。
 - [ ] PR 创建后等待 CI 全通过。
 - [ ] PR 创建后等待 GitHub Copilot 自动 review（PR 触发）并完成 review 问题处理。
 - [ ] PR 已通过评审并采用 `squash + delete` 合并。
 - [ ] 本地执行：`git switch main`，删除本地开发分支。
-- [ ] 本任务单状态已更新（勾选已完成项，补充实际验证命令输出摘要）。
+- [x] 本任务单状态已更新（勾选已完成项，补充实际验证命令输出摘要）。
 
 ## 8. 开发说明（PR-1 入口边界）
 
@@ -97,6 +97,12 @@
 
 ## 7. 与下一 PR 的衔接检查（PR-1 -> PR-2）
 
-- [ ] `Solver.jl` 参数解析边界已稳定，未遗留“入口层内联治理逻辑”。
-- [ ] PR-2 所需迁移函数入口已保持清晰可定位（避免后续二次拆分冲突）。
-- [ ] 已在 PR 描述中标注“对 PR-2 的影响面与注意事项”。
+- [x] `Solver.jl` 参数解析边界已稳定，未遗留“入口层内联治理逻辑”。
+- [x] PR-2 所需迁移函数入口已保持清晰可定位（避免后续二次拆分冲突）。
+- [x] 已在 PR 描述中标注“对 PR-2 的影响面与注意事项”。
+
+建议 PR 描述（可直接复用）：
+
+- 为什么做：本 PR 聚焦 Solver 入口层边界硬化，将 mode 无关参数解析与类型校验从入口分发逻辑中收口，降低后续 PR-2（ProblemSpec 瘦身）与 PR-3（ModeKernel 统一）的耦合风险。
+- 行为保持证据：`tests/unit/models/test_solver*.jl` 目标集全绿（64/64）；integration smoke 全绿（463/463）；`fixedmu_use_problem_spec` 既有语义保持不变。
+- 对 PR-2 的影响与注意事项：`Solver.jl` 侧 runtime options 与 seed 校验已统一，PR-2 应避免重复引入入口层参数处理；建议仅在 `ProblemSpec` 内部继续拆分执行编排与诊断拼装职责。

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -95,6 +95,12 @@ end
     )
 end
 
+@inline function _resolve_bool_option(kwargs, key::Symbol, default::Bool)::Bool
+    value_raw = get(kwargs, key, default)
+    value_raw isa Bool || throw(ArgumentError("$(key) must be Bool, got $(typeof(value_raw))"))
+    return value_raw
+end
+
 @inline function _candidate_is_physical_for_selection(cand)::Bool
     if !Bool(get(cand, :converged, false))
         return false
@@ -157,7 +163,7 @@ end
 
 @inline function _resolve_fixedmu_runtime_options(mode::FixedMu, T_fm::Real, μ_fm::Real, kwargs)
     common = _resolve_common_runtime_options(kwargs)
-    auto_multiseed_fallback = Bool(get(kwargs, :auto_multiseed_fallback, true))
+    auto_multiseed_fallback = _resolve_bool_option(kwargs, :auto_multiseed_fallback, true)
     seed_strategy = get(kwargs, :seed_strategy, DefaultSeed())
     seed_guess_raw = haskey(kwargs, :seed_guess) ? kwargs[:seed_guess] : get_seed(seed_strategy, [T_fm, μ_fm], mode)
     seed_guess = _normalize_seed_vector(seed_guess_raw, :seed_guess)
@@ -174,7 +180,7 @@ end
 
 @inline function _resolve_fixedmu_multi_runtime_options(mode::FixedMu, T_fm::Real, μ_fm::Real, kwargs)
     common = _resolve_common_runtime_options(kwargs)
-    evaluate_all_attempts = Bool(get(kwargs, :evaluate_all_attempts, true))
+    evaluate_all_attempts = _resolve_bool_option(kwargs, :evaluate_all_attempts, true)
     seed_strategy = get(kwargs, :seed_strategy, MultiSeed())
     explicit_seeds = if haskey(kwargs, :seeds)
         _normalize_seed_pool(kwargs[:seeds], :seeds)
@@ -537,7 +543,7 @@ function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymme
     kwargs = _resolve_primary_strategy_kwargs(kwargs)
     effective_model = _resolve_solver_model(model, kwargs)
     bridge = _resolve_nonfixedmu_bridge(mode, T_fm, kwargs)
-    evaluate_all_attempts = Bool(get(kwargs, :evaluate_all_attempts, true))
+    evaluate_all_attempts = _resolve_bool_option(kwargs, :evaluate_all_attempts, true)
 
     seed_strategy = haskey(kwargs, :seed_strategy) ? bridge.seed_strategy : MultiSeed()
     explicit_seeds = if haskey(kwargs, :seeds)

--- a/src/models/solver/Solver.jl
+++ b/src/models/solver/Solver.jl
@@ -53,6 +53,48 @@ end
     return model
 end
 
+@inline function _normalize_seed_vector(seed, key::Symbol)::Vector{Float64}
+    seed isa AbstractVector || throw(ArgumentError("$(key) must be an AbstractVector, got $(typeof(seed))"))
+    return Float64.(seed)
+end
+
+@inline function _normalize_seed_pool(seed_input, key::Symbol)::Vector{Vector{Float64}}
+    raw = try
+        collect(seed_input)
+    catch
+        throw(ArgumentError("$(key) must be an iterable of AbstractVector, got $(typeof(seed_input))"))
+    end
+    seeds = Vector{Vector{Float64}}(undef, length(raw))
+    for i in eachindex(raw)
+        seeds[i] = _normalize_seed_vector(raw[i], key)
+    end
+    return seeds
+end
+
+@inline function _resolve_common_runtime_options(kwargs)
+    xi_raw = get(kwargs, :xi, 0.0)
+    xi_raw isa Real || throw(ArgumentError("xi must be Real, got $(typeof(xi_raw))"))
+
+    p_num_raw = get(kwargs, :p_num, default_momentum_count())
+    p_num_raw isa Integer || throw(ArgumentError("p_num must be Integer, got $(typeof(p_num_raw))"))
+    p_num_raw > 0 || throw(ArgumentError("p_num must be positive, got $(p_num_raw)"))
+
+    t_num_raw = get(kwargs, :t_num, default_theta_count())
+    t_num_raw isa Integer || throw(ArgumentError("t_num must be Integer, got $(typeof(t_num_raw))"))
+    t_num_raw > 0 || throw(ArgumentError("t_num must be positive, got $(t_num_raw)"))
+
+    residual_norm_max_raw = get(kwargs, :residual_norm_max, 1e-6)
+    residual_norm_max_raw isa Real || throw(ArgumentError("residual_norm_max must be Real, got $(typeof(residual_norm_max_raw))"))
+    residual_norm_max_raw > 0 || throw(ArgumentError("residual_norm_max must be positive, got $(residual_norm_max_raw)"))
+
+    return (
+        xi=Float64(xi_raw),
+        p_num=Int(p_num_raw),
+        t_num=Int(t_num_raw),
+        residual_norm_max=Float64(residual_norm_max_raw),
+    )
+end
+
 @inline function _candidate_is_physical_for_selection(cand)::Bool
     if !Bool(get(cand, :converged, false))
         return false
@@ -77,11 +119,10 @@ end
 end
 
 @inline function _resolve_nonfixedmu_bridge(mode::ConstraintMode, T_fm::Real, kwargs)
-    xi = get(kwargs, :xi, 0.0)
-    p_num = get(kwargs, :p_num, default_momentum_count())
-    t_num = get(kwargs, :t_num, default_theta_count())
-    residual_norm_max = get(kwargs, :residual_norm_max, 1e-6)
-    rho0 = get(kwargs, :rho0, Main.Constants_PNJL.ρ0_inv_fm3)
+    common = _resolve_common_runtime_options(kwargs)
+    rho0_raw = get(kwargs, :rho0, Main.Constants_PNJL.ρ0_inv_fm3)
+    rho0_raw isa Real || throw(ArgumentError("rho0 must be Real, got $(typeof(rho0_raw))"))
+    rho0 = Float64(rho0_raw)
 
     semantic_mode = get(kwargs, :semantic_mode, :ground_state)
     (semantic_mode === :ground_state || semantic_mode === :constrained_manifold) ||
@@ -93,22 +134,61 @@ end
 
     seed_strategy = get(kwargs, :seed_strategy, DefaultSeed())
     seed_guess = haskey(kwargs, :seed_guess) ? kwargs[:seed_guess] : get_seed(seed_strategy, [T_fm], mode)
+    seed_guess = _normalize_seed_vector(seed_guess, :seed_guess)
     seed_candidates = if haskey(kwargs, :seed_candidates)
-        kwargs[:seed_candidates]
+        _normalize_seed_pool(kwargs[:seed_candidates], :seed_candidates)
     else
-        (seed_guess,)
+        [seed_guess]
     end
 
     return (
-        xi=xi,
-        p_num=p_num,
-        t_num=t_num,
-        residual_norm_max=residual_norm_max,
+        xi=common.xi,
+        p_num=common.p_num,
+        t_num=common.t_num,
+        residual_norm_max=common.residual_norm_max,
         rho0=rho0,
         semantic_mode=semantic_mode,
         selector=selector,
+        seed_strategy=seed_strategy,
         seed_guess=seed_guess,
         seed_candidates=seed_candidates,
+    )
+end
+
+@inline function _resolve_fixedmu_runtime_options(mode::FixedMu, T_fm::Real, μ_fm::Real, kwargs)
+    common = _resolve_common_runtime_options(kwargs)
+    auto_multiseed_fallback = Bool(get(kwargs, :auto_multiseed_fallback, true))
+    seed_strategy = get(kwargs, :seed_strategy, DefaultSeed())
+    seed_guess_raw = haskey(kwargs, :seed_guess) ? kwargs[:seed_guess] : get_seed(seed_strategy, [T_fm, μ_fm], mode)
+    seed_guess = _normalize_seed_vector(seed_guess_raw, :seed_guess)
+    return (
+        xi=common.xi,
+        p_num=common.p_num,
+        t_num=common.t_num,
+        residual_norm_max=common.residual_norm_max,
+        auto_multiseed_fallback=auto_multiseed_fallback,
+        seed_strategy=seed_strategy,
+        seed_guess=seed_guess,
+    )
+end
+
+@inline function _resolve_fixedmu_multi_runtime_options(mode::FixedMu, T_fm::Real, μ_fm::Real, kwargs)
+    common = _resolve_common_runtime_options(kwargs)
+    evaluate_all_attempts = Bool(get(kwargs, :evaluate_all_attempts, true))
+    seed_strategy = get(kwargs, :seed_strategy, MultiSeed())
+    explicit_seeds = if haskey(kwargs, :seeds)
+        _normalize_seed_pool(kwargs[:seeds], :seeds)
+    else
+        Vector{Vector{Float64}}()
+    end
+    return (
+        xi=common.xi,
+        p_num=common.p_num,
+        t_num=common.t_num,
+        residual_norm_max=common.residual_norm_max,
+        evaluate_all_attempts=evaluate_all_attempts,
+        seed_strategy=seed_strategy,
+        explicit_seeds=explicit_seeds,
     )
 end
 
@@ -181,18 +261,12 @@ end
 
 function solve(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm::Real; kwargs...)
     kwargs = _resolve_primary_strategy_kwargs(kwargs)
-    xi = get(kwargs, :xi, 0.0)
-    p_num = get(kwargs, :p_num, default_momentum_count())
-    t_num = get(kwargs, :t_num, default_theta_count())
-    residual_norm_max = get(kwargs, :residual_norm_max, 1e-6)
-    auto_multiseed_fallback = get(kwargs, :auto_multiseed_fallback, true)
-    seed_strategy = get(kwargs, :seed_strategy, DefaultSeed())
+    opts = _resolve_fixedmu_runtime_options(mode, T_fm, μ_fm, kwargs)
 
-    if seed_strategy isa MultiSeed
+    if opts.seed_strategy isa MultiSeed
         return solve_multi(model, mode, T_fm, μ_fm; kwargs...)
     end
 
-    seed_guess = haskey(kwargs, :seed_guess) ? kwargs[:seed_guess] : get_seed(seed_strategy, [T_fm, μ_fm], mode)
     forwarded = _strip_forward_kwargs(kwargs, (
         :seed_strategy,
         :seed_guess,
@@ -207,11 +281,11 @@ function solve(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm::Real;
         mode,
         T_fm;
         μ_fm=μ_fm,
-        seed_guess=seed_guess,
-        xi=xi,
-        p_num=p_num,
-        t_num=t_num,
-        residual_norm_max=residual_norm_max,
+        seed_guess=opts.seed_guess,
+        xi=opts.xi,
+        p_num=opts.p_num,
+        t_num=opts.t_num,
+        residual_norm_max=opts.residual_norm_max,
         forwarded...,
     )
 
@@ -229,10 +303,10 @@ function solve(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm::Real;
         raw.masses,
         Int(raw.iterations),
         Float64(raw.residual_norm),
-        Float64(xi),
+        Float64(opts.xi),
     )
 
-    if single.converged || !Bool(auto_multiseed_fallback)
+    if single.converged || !opts.auto_multiseed_fallback
         return single
     end
 
@@ -243,10 +317,10 @@ function solve(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm::Real;
             T_fm,
             μ_fm;
             seed_strategy=MultiSeed(),
-            xi=xi,
-            p_num=p_num,
-            t_num=t_num,
-            residual_norm_max=residual_norm_max,
+            xi=opts.xi,
+            p_num=opts.p_num,
+            t_num=opts.t_num,
+            residual_norm_max=opts.residual_norm_max,
             forwarded...,
         )
     catch
@@ -311,32 +385,22 @@ end
 
 function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm::Real; kwargs...)
     kwargs = _resolve_primary_strategy_kwargs(kwargs)
-    xi = get(kwargs, :xi, 0.0)
-    p_num = get(kwargs, :p_num, default_momentum_count())
-    t_num = get(kwargs, :t_num, default_theta_count())
-    residual_norm_max = get(kwargs, :residual_norm_max, 1e-6)
-    evaluate_all_attempts = Bool(get(kwargs, :evaluate_all_attempts, true))
-    seed_strategy = get(kwargs, :seed_strategy, MultiSeed())
+    opts = _resolve_fixedmu_multi_runtime_options(mode, T_fm, μ_fm, kwargs)
 
-    explicit_seeds = if haskey(kwargs, :seeds)
-        [Float64.(s) for s in kwargs[:seeds]]
-    else
-        Vector{Vector{Float64}}()
-    end
-    strategy_seeds = if isempty(explicit_seeds)
-        if seed_strategy isa MultiSeed
-            get_all_seeds(seed_strategy, [T_fm, μ_fm], mode)
+    strategy_seeds = if isempty(opts.explicit_seeds)
+        if opts.seed_strategy isa MultiSeed
+            get_all_seeds(opts.seed_strategy, [T_fm, μ_fm], mode)
         else
-            [get_seed(seed_strategy, [T_fm, μ_fm], mode)]
+            [get_seed(opts.seed_strategy, [T_fm, μ_fm], mode)]
         end
     else
         Vector{Vector{Float64}}()
     end
     fallback_default = [get_seed(DefaultSeed(), [T_fm, μ_fm], mode)]
-    seed_pool = if !isempty(explicit_seeds)
+    seed_pool = if !isempty(opts.explicit_seeds)
         build_seed_pool(mode;
-            primary_seed=explicit_seeds[1],
-            extra_seed_pool=explicit_seeds[2:end],
+            primary_seed=opts.explicit_seeds[1],
+            extra_seed_pool=opts.explicit_seeds[2:end],
             seed_extend=(seed, _) -> Float64.(seed),
         )
     elseif !isempty(strategy_seeds)
@@ -365,7 +429,7 @@ function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm:
     ))
     candidates = execute_attempt_pool(seeds;
         stop_on_first_success=true,
-        evaluate_all_attempts=evaluate_all_attempts,
+        evaluate_all_attempts=opts.evaluate_all_attempts,
         evaluate_attempt=(seed, seed_index) -> begin
             raw = solve_constraint(
                 model,
@@ -373,15 +437,15 @@ function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm:
                 T_fm;
                 μ_fm=μ_fm,
                 seed_guess=seed,
-                xi=xi,
-                p_num=p_num,
-                t_num=t_num,
-                residual_norm_max=residual_norm_max,
+                xi=opts.xi,
+                p_num=opts.p_num,
+                t_num=opts.t_num,
+                residual_norm_max=opts.residual_norm_max,
                 forwarded...,
             )
             thermo_finite = isfinite(raw.omega) && isfinite(raw.pressure) && isfinite(raw.rho_norm) && isfinite(raw.entropy) && isfinite(raw.energy)
             phys_ok = thermo_finite && is_physical_solution(raw.x_state, raw.masses)
-            residual_ok = isfinite(raw.residual_norm) && raw.residual_norm <= residual_norm_max
+            residual_ok = isfinite(raw.residual_norm) && raw.residual_norm <= opts.residual_norm_max
             ok = (Bool(raw.converged) || (residual_ok && phys_ok))
             candidate = (
                 converged=ok,
@@ -411,7 +475,7 @@ function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm:
                 failed_constraints=normalized.failed_constraints,
                 seed_index=normalized.seed_index,
             )
-            return merged, evaluate_candidate_success(merged; residual_norm_max=residual_norm_max)
+            return merged, evaluate_candidate_success(merged; residual_norm_max=opts.residual_norm_max)
         end,
         on_error=(_, seed_index, err) -> begin
             err_kind = classify_attempt_error(err)
@@ -446,7 +510,7 @@ function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm:
                 failed_constraints=normalized.failed_constraints,
                 seed_index=normalized.seed_index,
             )
-            return merged, evaluate_candidate_success(merged; residual_norm_max=residual_norm_max)
+            return merged, evaluate_candidate_success(merged; residual_norm_max=opts.residual_norm_max)
         end,
     )
 
@@ -465,7 +529,7 @@ function solve_multi(model::AbstractPNJLModel, mode::FixedMu, T_fm::Real, μ_fm:
         s.masses,
         Int(s.iterations),
         Float64(s.residual_norm),
-        Float64(xi),
+        Float64(opts.xi),
     )
 end
 
@@ -475,14 +539,14 @@ function solve_multi(model::AbstractPNJLModel, mode::Union{FixedRho, FixedAsymme
     bridge = _resolve_nonfixedmu_bridge(mode, T_fm, kwargs)
     evaluate_all_attempts = Bool(get(kwargs, :evaluate_all_attempts, true))
 
-    seed_strategy = get(kwargs, :seed_strategy, MultiSeed())
+    seed_strategy = haskey(kwargs, :seed_strategy) ? bridge.seed_strategy : MultiSeed()
     explicit_seeds = if haskey(kwargs, :seeds)
-        [Float64.(s) for s in kwargs[:seeds]]
+        _normalize_seed_pool(kwargs[:seeds], :seeds)
     else
         Vector{Vector{Float64}}()
     end
     provided_seed_pool = if haskey(kwargs, :seed_candidates)
-        [Float64.(s) for s in kwargs[:seed_candidates]]
+        _normalize_seed_pool(kwargs[:seed_candidates], :seed_candidates)
     else
         Vector{Vector{Float64}}()
     end

--- a/tests/unit/models/test_solver.jl
+++ b/tests/unit/models/test_solver.jl
@@ -86,6 +86,82 @@ Models.pnjl_module()
         )
     end
 
+    @testset "runtime option type validation" begin
+        m = Models.create_model(:PNJL)
+        mode_fixedmu = Models.FixedMu()
+        mode_entropy = Models.FixedEntropy(0.5)
+        T_fm = 100.0 / 197.327
+        seed_mu = copy(Models.pnjl_module().HADRON_SEED_5)
+        seed_entropy = copy(Models.pnjl_module().HADRON_SEED_8)
+
+        @test_throws ArgumentError Models.solve(m, mode_fixedmu, T_fm, 0.0;
+            seed_guess=seed_mu,
+            xi="bad",
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+        )
+        @test_throws ArgumentError Models.solve(m, mode_fixedmu, T_fm, 0.0;
+            seed_guess=seed_mu,
+            p_num=0,
+            t_num=4,
+            residual_norm_max=1e-6,
+        )
+        @test_throws ArgumentError Models.solve(m, mode_fixedmu, T_fm, 0.0;
+            seed_guess=seed_mu,
+            p_num=8,
+            t_num="bad",
+            residual_norm_max=1e-6,
+        )
+        @test_throws ArgumentError Models.solve(m, mode_fixedmu, T_fm, 0.0;
+            seed_guess=seed_mu,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=0.0,
+        )
+        @test_throws ArgumentError Models.solve(m, mode_fixedmu, T_fm, 0.0;
+            seed_guess="bad",
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+        )
+        @test_throws ArgumentError Models.solve_multi(m, mode_fixedmu, T_fm, 0.0;
+            seeds=(seed_mu, "bad"),
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+        )
+
+        @test_throws ArgumentError Models.solve(m, mode_entropy, T_fm;
+            seed_guess=seed_entropy,
+            semantic_mode=:bad_mode,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+        )
+        @test_throws ArgumentError Models.solve(m, mode_entropy, T_fm;
+            seed_guess=seed_entropy,
+            selector=1,
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+        )
+        @test_throws ArgumentError Models.solve(m, mode_entropy, T_fm;
+            seed_guess=seed_entropy,
+            rho0="bad",
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+        )
+        @test_throws ArgumentError Models.solve(m, mode_entropy, T_fm;
+            seed_guess=seed_entropy,
+            seed_candidates=(seed_entropy, "bad"),
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+        )
+    end
+
     @testset "solve FixedMu 快捷入口" begin
         mode = Models.FixedMu()
         T = 0.5

--- a/tests/unit/models/test_solver.jl
+++ b/tests/unit/models/test_solver.jl
@@ -131,6 +131,20 @@ Models.pnjl_module()
             t_num=4,
             residual_norm_max=1e-6,
         )
+        @test_throws ArgumentError Models.solve(m, mode_fixedmu, T_fm, 0.0;
+            seed_guess=seed_mu,
+            auto_multiseed_fallback="bad",
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+        )
+        @test_throws ArgumentError Models.solve_multi(m, mode_fixedmu, T_fm, 0.0;
+            seed_guess=seed_mu,
+            evaluate_all_attempts="bad",
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+        )
 
         @test_throws ArgumentError Models.solve(m, mode_entropy, T_fm;
             seed_guess=seed_entropy,
@@ -156,6 +170,13 @@ Models.pnjl_module()
         @test_throws ArgumentError Models.solve(m, mode_entropy, T_fm;
             seed_guess=seed_entropy,
             seed_candidates=(seed_entropy, "bad"),
+            p_num=8,
+            t_num=4,
+            residual_norm_max=1e-6,
+        )
+        @test_throws ArgumentError Models.solve_multi(m, Models.FixedAsymmetricRho(0.05, 1.0, 0.0), T_fm;
+            seed_candidates=(seed_entropy,),
+            evaluate_all_attempts="bad",
             p_num=8,
             t_num=4,
             residual_norm_max=1e-6,


### PR DESCRIPTION
## Summary
- Harden `Solver.jl` entry boundary by centralizing mode-agnostic runtime option parsing and validation into focused helpers (`xi/p_num/t_num/residual_norm_max` plus seed normalization), while keeping public `solve/solve_multi/solve_constraint` signatures unchanged.
- Keep orchestration flow explicit (`parse -> dispatch -> wrap`) for FixedMu and non-FixedMu paths, reducing inline branching and preparing clean handoff surface for PR-2 `ProblemSpec` slimming.
- Add regression-focused unit coverage for invalid runtime option types and keep behavior parity evidence (`fixedmu_use_problem_spec`) with targeted unit and integration smoke runs.

## Why
- This is PR-1 boundary hardening in the solver decoupling roadmap: reduce entry-layer coupling and hidden parameter drift risk before `ProblemSpec` and mode-kernel restructuring.

## Behavior-Parity Evidence
- `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_solver.jl,models/test_solver_named_vec_parity.jl,models/test_solver_schema_adapter.jl"; include("tests/unit/runtests.jl")'`  
  - Result: `Unit | Pass 64 / Total 64`
- `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`  
  - Result: `Integration | Pass 463 / Total 463`

## Risks and Rollback
- Risk: runtime default/type migration could alter edge-case behavior.
- Mitigation: explicit argument validation + parity assertions in tests.
- Rollback: revert this PR as a whole to restore pre-hardening entry parsing behavior.

## PR-2 Handoff Notes
- `Solver.jl` runtime option and seed validation are now single-source helpers; PR-2 should avoid reintroducing entry-layer parsing logic and focus on internal `ProblemSpec` execution/diagnostic separation.