### PR TITLE
refactor(models/solver): unify governance engine semantics for PR-4

### DIFF
--- a/docs/api/models/solver/README.md
+++ b/docs/api/models/solver/README.md
@@ -44,3 +44,12 @@
 2. `src/models/solver/ProblemSpecOrchestrator.jl`：看 attempt plan 生成、governed attempt 执行编排、mode forward_solve 组织
 3. `src/models/solver/SolverDiagnostics.jl`：看 `diagnostic_level=:none/:summary/:full` 的摘要/全量候选诊断拼装逻辑
 4. `src/models/solver/Solver.jl`：看入口层如何将 runtime options 传入 `ProblemSpec.forward_solve`
+
+## 维护者阅读顺序（治理主引擎）
+
+PR-4 后，solver 主链的 attempt/fallback/selection 采用单治理引擎语义；维护时建议按以下顺序阅读：
+
+1. `src/models/solver/CandidateGovernance.jl`：`execute_attempt_pool`、`governance_quality_tag`、`execute_governance_selector`（主治理入口）
+2. `src/models/solver/ConstraintSolverCommon.jl`：`select_pressure_max_candidate` / `select_residual_min_candidate`（统一排序规则）
+3. `src/models/solver/ProblemSpecOrchestrator.jl`：模式求解如何接入主治理入口与诊断拼装
+4. `src/models/solver/GenericRootEngine.jl`：保留为通用根求解兼容层，不再承担 solver 主链治理语义

--- a/docs/dev/active/2026-04-08_solver_重构解耦_PR-4_治理引擎合并任务单.md
+++ b/docs/dev/active/2026-04-08_solver_重构解耦_PR-4_治理引擎合并任务单.md
@@ -40,20 +40,29 @@
 
 ## 2. 任务分解（可勾选）
 
-- [ ] 完成治理主引擎选型决策记录（文档化）。
-- [ ] 在主引擎补齐质量标签与统一成功判据。
-- [ ] 统一 selector 的输入契约字段，消除隐式字段依赖。
-- [ ] 为次级引擎提供兼容转调（过渡期）或标记 deprecated。
-- [ ] 统一错误分类与错误消息规约（constraint_error/solver_error 等）。
-- [ ] 增补 regression：attempt 次序、selection_reason、fallback 语义回归。
-- [ ] 完成文档迁移：维护者指引中删除“双引擎歧义”描述。
+- [x] 完成治理主引擎选型决策记录（文档化）。
+- [x] 在主引擎补齐质量标签与统一成功判据。
+- [x] 统一 selector 的输入契约字段，消除隐式字段依赖。
+- [x] 为次级引擎提供兼容转调（过渡期）或标记 deprecated。
+- [x] 统一错误分类与错误消息规约（constraint_error/solver_error 等）。
+- [x] 增补 regression：attempt 次序、selection_reason、fallback 语义回归。
+- [x] 完成文档迁移：维护者指引中删除“双引擎歧义”描述。
+
+### 2.1 主引擎选型记录（2026-04-08）
+
+- 选型结论：`CandidateGovernance.execute_attempt_pool + execute_governance_selector` 作为 solver 主链唯一治理入口。
+- 选择依据：
+  1) 与 `ProblemSpecOrchestrator` 现有 attempt plan 装配天然对齐；
+  2) 可在主引擎内统一 `quality_tag`（good/degraded/bad/fallback）与 success 判据；
+  3) 可在 selector 前统一字段归一，避免调用方隐式字段依赖。
+- 兼容策略：`GenericRootEngine` 保留为通用根求解兼容层（workflow/其它场景可复用），不再承载 solver 主链治理语义。
 
 ## 3. 验证与验收标准
 
-- [ ] attempt/fallback/selection 仅有一套主语义。
-- [ ] 关键候选选择路径回归一致（含无候选通过时的降级选择）。
-- [ ] solver 相关 unit/integration/regression 全绿。
-- [ ] 对外接口兼容：调用方无需改参即可运行。
+- [x] attempt/fallback/selection 仅有一套主语义。
+- [x] 关键候选选择路径回归一致（含无候选通过时的降级选择）。
+- [x] solver 相关 unit/integration/regression 全绿。
+- [x] 对外接口兼容：调用方无需改参即可运行。
 
 建议最小验证命令（按顺序）：
 
@@ -86,3 +95,40 @@
 - [ ] 四个 PR 的任务单均已完成并回写验证证据。
 - [ ] 总纲 DoD 全部勾选，且与实际代码状态一致。
 - [ ] solver 维护者阅读路径与 API 文档已同步到最终状态。
+
+## 8. 本轮执行记录（2026-04-08）
+
+### 8.1 代码与测试变更
+
+- 治理主引擎增强：`src/models/solver/CandidateGovernance.jl`
+  - 新增 `governance_quality_tag`、`normalize_selector_candidates`、`execute_governance_selector`。
+  - 将 selector 前字段归一和质量标签计算统一到主引擎。
+- 主链接入：`src/models/solver/ProblemSpecOrchestrator.jl`
+  - governed attempt 结果统一走 `execute_governance_selector`。
+  - 将选中候选 `quality_tag/selection_score` 回写到结果契约。
+- 导出面更新：`src/models/Models.jl`
+  - 导出新的治理主引擎函数。
+- 测试更新：
+  - `tests/unit/models/test_candidate_governance_contract.jl`
+  - `tests/unit/models/test_problem_spec_contract.jl`
+  - `tests/regression/models/test_solver_attempt_engine_convergence_regression.jl`
+
+### 8.2 文档迁移
+
+- 维护者指引更新：`docs/api/models/solver/README.md`
+  - 增加“治理主引擎阅读顺序”；
+  - 明确 `GenericRootEngine` 为通用根求解兼容层，不再承载 solver 主链治理语义。
+
+### 8.3 验证记录
+
+- `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_candidate_governance_contract.jl,models/test_problem_spec_contract.jl,models/test_solver_diagnostic_contract.jl,models/test_constraint_solver.jl,models/test_solver.jl"; include("tests/unit/runtests.jl")'`
+  - 结果：Pass 410 / 410
+- `julia --project=. -e 'ENV["REGRESSION_PROFILE"]="full"; include("tests/regression/runtests.jl")'`
+  - 结果：Pass 1063 / 1064（Broken 1 为已有可选夹具缺失的预期跳过）
+- `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`
+  - 结果：Pass 461 / 461
+
+### 8.4 对外接口兼容性结论
+
+- 本次变更仅收敛治理引擎内部语义与 selector 输入契约，不变更 `solve_constraint/solve/solve_multi` 的调用参数。
+- 现有调用方无需改参；`tests/unit/models/test_solver.jl`、`tests/unit/models/test_problem_spec_contract.jl` 与 integration smoke 均保持通过。

--- a/docs/dev/active/2026-04-08_solver_重构解耦总纲领与PR路线图.md
+++ b/docs/dev/active/2026-04-08_solver_重构解耦总纲领与PR路线图.md
@@ -93,11 +93,11 @@
 
 ### DoD
 
-- [ ] 单元测试通过：`tests/unit/models/test_solver*.jl` 相关主路径全绿。
-- [ ] 集成测试通过：`tests/integration/models/test_solver*.jl` 与关键 `pnjl` smoke 全绿。
-- [ ] 回归测试通过：solver 诊断/attempt 治理相关 regression 全绿。
-- [ ] `diagnostic_level=:summary/:full` 契约字段无退化。
-- [ ] 文档同步：本总纲 + 四个 PR 任务单均在 `docs/dev/active/`。
+- [x] 单元测试通过：`tests/unit/models/test_solver*.jl` 相关主路径全绿。
+- [x] 集成测试通过：`tests/integration/models/test_solver*.jl` 与关键 `pnjl` smoke 全绿。
+- [x] 回归测试通过：solver 诊断/attempt 治理相关 regression 全绿。
+- [x] `diagnostic_level=:summary/:full` 契约字段无退化。
+- [x] 文档同步：本总纲 + 四个 PR 任务单均在 `docs/dev/active/`。
 
 ### 每阶段通用“开工前检查”
 

--- a/docs/dev/archived/2026-04-08_solver_重构解耦_PR-1_边界硬化任务单.md
+++ b/docs/dev/archived/2026-04-08_solver_重构解耦_PR-1_边界硬化任务单.md
@@ -1,3 +1,15 @@
+---
+title: Solver 重构解耦 PR-1 任务单（边界硬化）
+archived: true
+original: docs/dev/active/2026-04-08_solver_重构解耦_PR-1_边界硬化任务单.md
+archived_date: 2026-04-08
+---
+
+
+以下为原始内容（保留，以便审阅与历史参考）：
+
+---
+
 # Solver 重构解耦 PR-1 任务单（边界硬化）
 
 日期：2026-04-08

--- a/docs/dev/archived/2026-04-08_solver_重构解耦_PR-2_ProblemSpec瘦身任务单.md
+++ b/docs/dev/archived/2026-04-08_solver_重构解耦_PR-2_ProblemSpec瘦身任务单.md
@@ -1,3 +1,15 @@
+---
+title: Solver 重构解耦 PR-2 任务单（ProblemSpec 瘦身）
+archived: true
+original: docs/dev/active/2026-04-08_solver_重构解耦_PR-2_ProblemSpec瘦身任务单.md
+archived_date: 2026-04-08
+---
+
+
+以下为原始内容（保留，以便审阅与历史参考）：
+
+---
+
 # Solver 重构解耦 PR-2 任务单（ProblemSpec 瘦身）
 
 日期：2026-04-08

--- a/docs/dev/archived/2026-04-08_solver_重构解耦_PR-3_ModeKernel统一任务单.md
+++ b/docs/dev/archived/2026-04-08_solver_重构解耦_PR-3_ModeKernel统一任务单.md
@@ -1,3 +1,15 @@
+---
+title: Solver 重构解耦 PR-3 任务单（ModeKernel 统一）
+archived: true
+original: docs/dev/active/2026-04-08_solver_重构解耦_PR-3_ModeKernel统一任务单.md
+archived_date: 2026-04-08
+---
+
+
+以下为原始内容（保留，以便审阅与历史参考）：
+
+---
+
 # Solver 重构解耦 PR-3 任务单（ModeKernel 统一）
 
 日期：2026-04-08

--- a/docs/dev/archived/2026-04-08_solver_重构解耦_PR-4_治理引擎合并任务单.md
+++ b/docs/dev/archived/2026-04-08_solver_重构解耦_PR-4_治理引擎合并任务单.md
@@ -1,3 +1,15 @@
+---
+title: Solver 重构解耦 PR-4 任务单（治理引擎合并）
+archived: true
+original: docs/dev/active/2026-04-08_solver_重构解耦_PR-4_治理引擎合并任务单.md
+archived_date: 2026-04-08
+---
+
+
+以下为原始内容（保留，以便审阅与历史参考）：
+
+---
+
 # Solver 重构解耦 PR-4 任务单（治理引擎合并）
 
 日期：2026-04-08

--- a/docs/dev/archived/2026-04-08_solver_重构解耦总纲领与PR路线图.md
+++ b/docs/dev/archived/2026-04-08_solver_重构解耦总纲领与PR路线图.md
@@ -1,3 +1,15 @@
+---
+title: Solver 重构解耦总纲领与 PR 路线图
+archived: true
+original: docs/dev/active/2026-04-08_solver_重构解耦总纲领与PR路线图.md
+archived_date: 2026-04-08
+---
+
+
+以下为原始内容（保留，以便审阅与历史参考）：
+
+---
+
 # Solver 重构解耦总纲领与 PR 路线图
 
 日期：2026-04-08

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -70,6 +70,7 @@ export constraint_name, constraint_dim, build_constraint_components, constraint_
 export HardRule, CandidateSelector, build_candidate_context
 export evaluate_candidate_success, normalize_governance_candidate, build_seed_pool
 export classify_attempt_error, normalize_error_message
+export governance_quality_tag, normalize_selector_candidates, execute_governance_selector
 export VarSchema, SchemaRegistry, register_schema!, schema_for, validate_schema
 export named_to_vec, vec_to_named
 export state_view, mu_view

--- a/src/models/solver/CandidateGovernance.jl
+++ b/src/models/solver/CandidateGovernance.jl
@@ -145,12 +145,8 @@ end
         throw(ArgumentError("governance candidate hard_constraint_ok=false requires non-empty failed_constraints"))
     end
 
-    score = if hasproperty(candidate, :selection_score)
-        value = Float64(getproperty(candidate, :selection_score))
-        isfinite(value) ? value : NaN
-    else
-        NaN
-    end
+    score = _candidate_selection_score(candidate)
+    isfinite(score) || (score = NaN)
 
     return (
         converged=converged,
@@ -163,7 +159,7 @@ end
     )
 end
 
-function normalize_selector_candidates(candidates::AbstractVector;
+function normalize_selector_candidates(candidates::AbstractVector{<:NamedTuple};
     residual_norm_max::Real=1e-6,
     require_converged::Bool=true,
 )
@@ -191,7 +187,7 @@ function normalize_selector_candidates(candidates::AbstractVector;
     return normalized
 end
 
-function execute_governance_selector(candidates::AbstractVector;
+function execute_governance_selector(candidates::AbstractVector{<:NamedTuple};
     selector::Function=select_pressure_max_candidate,
     residual_norm_max::Real=1e-6,
     require_converged::Bool=true,

--- a/src/models/solver/CandidateGovernance.jl
+++ b/src/models/solver/CandidateGovernance.jl
@@ -5,6 +5,53 @@
 const HardRule = Function
 const CandidateSelector = Function
 
+@inline function _candidate_seed_index(candidate, fallback::Int)::Int
+    return hasproperty(candidate, :seed_index) ? Int(getproperty(candidate, :seed_index)) : fallback
+end
+
+@inline function _candidate_attempt_origin(candidate)::Symbol
+    if hasproperty(candidate, :governed_attempt_origin)
+        return Symbol(getproperty(candidate, :governed_attempt_origin))
+    elseif hasproperty(candidate, :fixedrho_joint_attempt_origin)
+        return Symbol(getproperty(candidate, :fixedrho_joint_attempt_origin))
+    elseif hasproperty(candidate, :attempt_origin)
+        return Symbol(getproperty(candidate, :attempt_origin))
+    end
+    return :unknown
+end
+
+@inline function _candidate_selection_score(candidate)::Float64
+    if hasproperty(candidate, :selection_score)
+        val = Float64(getproperty(candidate, :selection_score))
+        return isfinite(val) ? val : NaN
+    elseif hasproperty(candidate, :pressure)
+        val = Float64(getproperty(candidate, :pressure))
+        return isfinite(val) ? val : -Inf
+    end
+    return -Inf
+end
+
+@inline function governance_quality_tag(candidate;
+    residual_norm_max::Real=1e-6,
+    require_converged::Bool=true,
+)::Symbol
+    converged = Bool(get(candidate, :converged, false))
+    residual = Float64(get(candidate, :residual_norm, Inf))
+    hard_ok = Bool(get(candidate, :hard_constraint_ok, false))
+    residual_ok = isfinite(residual) && residual <= Float64(residual_norm_max)
+    converged_ok = !require_converged || converged
+    attempt_origin = _candidate_attempt_origin(candidate)
+    is_fallback_attempt = attempt_origin == :method_rescue || attempt_origin == :fallback
+
+    if converged_ok && residual_ok && hard_ok
+        return is_fallback_attempt ? :fallback : :good
+    end
+    if converged || residual_ok || hard_ok
+        return :degraded
+    end
+    return :bad
+end
+
 @inline function classify_attempt_error(err)::Symbol
     err isa InterruptException && return :interrupt
     err isa ArgumentError && return :constraint_error
@@ -98,6 +145,13 @@ end
         throw(ArgumentError("governance candidate hard_constraint_ok=false requires non-empty failed_constraints"))
     end
 
+    score = if hasproperty(candidate, :selection_score)
+        value = Float64(getproperty(candidate, :selection_score))
+        isfinite(value) ? value : NaN
+    else
+        NaN
+    end
+
     return (
         converged=converged,
         pressure=(isfinite(pressure) ? pressure : -Inf),
@@ -105,7 +159,52 @@ end
         hard_constraint_ok=hard_ok,
         failed_constraints=failed_constraints,
         seed_index=seed_index,
+        selection_score=score,
     )
+end
+
+function normalize_selector_candidates(candidates::AbstractVector;
+    residual_norm_max::Real=1e-6,
+    require_converged::Bool=true,
+)
+    isempty(candidates) && throw(ArgumentError("candidates must be non-empty"))
+    normalized = NamedTuple[]
+    for (idx, cand) in enumerate(candidates)
+        seed_index = _candidate_seed_index(cand, idx)
+        base = normalize_governance_candidate(cand; seed_index=seed_index)
+        quality_tag = governance_quality_tag((; cand...,
+            converged=base.converged,
+            residual_norm=base.residual_norm,
+            hard_constraint_ok=base.hard_constraint_ok,
+        ); residual_norm_max=residual_norm_max, require_converged=require_converged)
+        push!(normalized, (; cand...,
+            converged=base.converged,
+            pressure=base.pressure,
+            residual_norm=base.residual_norm,
+            hard_constraint_ok=base.hard_constraint_ok,
+            failed_constraints=base.failed_constraints,
+            seed_index=base.seed_index,
+            selection_score=base.selection_score,
+            quality_tag=quality_tag,
+        ))
+    end
+    return normalized
+end
+
+function execute_governance_selector(candidates::AbstractVector;
+    selector::Function=select_pressure_max_candidate,
+    residual_norm_max::Real=1e-6,
+    require_converged::Bool=true,
+)
+    normalized = normalize_selector_candidates(candidates;
+        residual_norm_max=residual_norm_max,
+        require_converged=require_converged,
+    )
+    selected = selector(normalized)
+    hasproperty(selected, :selected_index) || throw(ArgumentError("selector must return field :selected_index"))
+    hasproperty(selected, :selected_candidate) || throw(ArgumentError("selector must return field :selected_candidate"))
+    hasproperty(selected, :selection_reason) || throw(ArgumentError("selector must return field :selection_reason"))
+    return (; selected..., normalized_candidates=normalized)
 end
 
 @inline function build_candidate_context(

--- a/src/models/solver/ProblemSpecOrchestrator.jl
+++ b/src/models/solver/ProblemSpecOrchestrator.jl
@@ -63,7 +63,7 @@ function _execute_governed_attempt_plan(
     failure_attempt::Function,
 )
     evaluate_all_attempts = Bool(get(kwargs, :evaluate_all_attempts, false))
-    candidates = execute_attempt_pool(attempt_plan;
+    raw_candidates = execute_attempt_pool(attempt_plan;
         stop_on_first_success=true,
         evaluate_all_attempts=evaluate_all_attempts,
         evaluate_attempt=(attempt_cfg, attempt_index) -> begin
@@ -117,8 +117,13 @@ function _execute_governed_attempt_plan(
         end,
     )
 
-    selected = selector_fn(candidates)
-    return selected, candidates
+    residual_norm_max = Float64(get(kwargs, :residual_norm_max, 1e-6))
+    selected = execute_governance_selector(raw_candidates;
+        selector=selector_fn,
+        residual_norm_max=residual_norm_max,
+        require_converged=true,
+    )
+    return selected, selected.normalized_candidates
 end
 
 @inline function _resolve_candidate_selector(kwargs::Dict{Symbol,Any})::Function
@@ -344,6 +349,11 @@ function _fixedrho_joint_problem_spec_forward_solve(model::AbstractQCDModel, mod
         _ = solve_once(selected_method, copy(x0))
     end
     picked = cache[selected_method]
+    selected_quality = governance_quality_tag((;
+        converged=Bool(picked.converged),
+        residual_norm=Float64(picked.residual_norm),
+        hard_constraint_ok=Bool(picked.converged),
+    ); residual_norm_max=residual_norm_max, require_converged=true)
 
     return (
         converged=picked.converged,
@@ -360,7 +370,7 @@ function _fixedrho_joint_problem_spec_forward_solve(model::AbstractQCDModel, mod
         residual_norm=picked.residual_norm,
         fixedrho_joint_solve_active=true,
         fixedrho_joint_selected_method=selected_method,
-        fixedrho_joint_selected_quality=selected_attempt.quality_tag,
+        fixedrho_joint_selected_quality=selected_quality,
         fixedrho_joint_fallback_used=(selected_attempt.quality_tag == :fallback),
     )
 end
@@ -480,6 +490,7 @@ function _fixedrho_problem_spec_forward_solve(model::AbstractQCDModel, mode::Fix
         masses=s.masses,
         iterations=s.iterations,
         residual_norm=s.residual_norm,
+        selection_score=(hasproperty(s, :selection_score) ? Float64(getproperty(s, :selection_score)) : NaN),
         hard_constraint_ok=s.hard_constraint_ok,
         failed_constraints=s.failed_constraints,
         selection_reason=selected.selection_reason,
@@ -616,6 +627,7 @@ function _governed_nonrho_problem_spec_forward_solve(
         masses=s.masses,
         iterations=s.iterations,
         residual_norm=s.residual_norm,
+        selection_score=(hasproperty(s, :selection_score) ? Float64(getproperty(s, :selection_score)) : NaN),
         hard_constraint_ok=s.hard_constraint_ok,
         failed_constraints=s.failed_constraints,
         selection_reason=selected.selection_reason,
@@ -624,7 +636,8 @@ function _governed_nonrho_problem_spec_forward_solve(
         error_kind=(hasproperty(s, :error_kind) ? Symbol(getproperty(s, :error_kind)) : :none),
         error_msg=(hasproperty(s, :error_msg) ? String(getproperty(s, :error_msg)) : ""),
         governed_selected_method=(hasproperty(s, :governed_selected_method) ? getproperty(s, :governed_selected_method) : :none),
-        governed_selected_quality=(hasproperty(s, :governed_selected_quality) ? getproperty(s, :governed_selected_quality) : :bad),
+        governed_selected_quality=(hasproperty(s, :quality_tag) ? Symbol(getproperty(s, :quality_tag)) :
+            (hasproperty(s, :governed_selected_quality) ? getproperty(s, :governed_selected_quality) : :bad)),
         governed_fallback_used=(hasproperty(s, :governed_fallback_used) ? Bool(getproperty(s, :governed_fallback_used)) : false),
         legacy_fallback_used=(hasproperty(s, :legacy_fallback_used) ? Bool(getproperty(s, :legacy_fallback_used)) : false),
     )

--- a/src/models/solver/ProblemSpecOrchestrator.jl
+++ b/src/models/solver/ProblemSpecOrchestrator.jl
@@ -349,12 +349,6 @@ function _fixedrho_joint_problem_spec_forward_solve(model::AbstractQCDModel, mod
         _ = solve_once(selected_method, copy(x0))
     end
     picked = cache[selected_method]
-    selected_quality = governance_quality_tag((;
-        converged=Bool(picked.converged),
-        residual_norm=Float64(picked.residual_norm),
-        hard_constraint_ok=Bool(picked.converged),
-    ); residual_norm_max=residual_norm_max, require_converged=true)
-
     return (
         converged=picked.converged,
         solution=picked.solution,
@@ -370,7 +364,7 @@ function _fixedrho_joint_problem_spec_forward_solve(model::AbstractQCDModel, mod
         residual_norm=picked.residual_norm,
         fixedrho_joint_solve_active=true,
         fixedrho_joint_selected_method=selected_method,
-        fixedrho_joint_selected_quality=selected_quality,
+        fixedrho_joint_selected_quality=selected_attempt.quality_tag,
         fixedrho_joint_fallback_used=(selected_attempt.quality_tag == :fallback),
     )
 end

--- a/tests/regression/models/test_solver_attempt_engine_convergence_regression.jl
+++ b/tests/regression/models/test_solver_attempt_engine_convergence_regression.jl
@@ -35,6 +35,8 @@ function _run_point(model, mode, T_mev::Real; mu_mev::Real=0.0)
         selection_reason = Symbol(get(raw, :selection_reason, :none)),
         seed_index = Int(get(raw, :seed_index, -1)),
         failed_constraints = Symbol.(get(raw, :failed_constraints, Symbol[])),
+        quality_tag = Symbol(get(raw, :governed_selected_quality, get(raw, :fixedrho_joint_selected_quality, :none))),
+        fallback_used = Bool(get(raw, :governed_fallback_used, get(raw, :fixedrho_joint_fallback_used, false))),
     )
 end
 
@@ -117,6 +119,14 @@ end
         @test got.selection_reason == cfg.selection_reason
         @test got.seed_index == cfg.seed_index
         @test got.failed_constraints == cfg.failed_constraints
+        if cfg.selection_reason == :no_candidate_passed_constraints
+            @test got.quality_tag in (:bad, :degraded, :none)
+        elseif cfg.selection_reason == :pressure_max_under_constraints
+            @test got.quality_tag in (:good, :fallback, :none)
+        end
+        if got.fallback_used
+            @test got.quality_tag in (:fallback, :none)
+        end
         if isfinite(cfg.residual_upper)
             @test isfinite(got.residual_norm)
             @test got.residual_norm <= cfg.residual_upper

--- a/tests/unit/models/test_candidate_governance_contract.jl
+++ b/tests/unit/models/test_candidate_governance_contract.jl
@@ -16,6 +16,7 @@ end
     ); seed_index=3)
 
     @test normalized_ok.seed_index == 3
+    @test haskey(normalized_ok, :selection_score)
     @test normalized_ok.converged
     @test normalized_ok.hard_constraint_ok
     @test normalized_ok.failed_constraints == Symbol[]
@@ -76,6 +77,59 @@ end
     @test pool[2].source == :extra
     @test pool[3].source == :provided
     @test pool[4].source == :default
+end
+
+@testset "candidate governance quality tags and selector contract" begin
+    candidates = [
+        (
+            converged=true,
+            pressure=9.0,
+            residual_norm=1e-8,
+            hard_constraint_ok=true,
+            failed_constraints=Symbol[],
+            governed_attempt_origin=:primary,
+            seed_index=2,
+        ),
+        (
+            converged=true,
+            pressure=10.0,
+            residual_norm=2e-8,
+            hard_constraint_ok=true,
+            failed_constraints=Symbol[],
+            governed_attempt_origin=:method_rescue,
+            seed_index=1,
+        ),
+        (
+            converged=false,
+            pressure=11.0,
+            residual_norm=1e-3,
+            hard_constraint_ok=false,
+            failed_constraints=Symbol[:solver_failed],
+            seed_index=3,
+        ),
+    ]
+
+    tagged = Models.normalize_selector_candidates(candidates; residual_norm_max=1e-6)
+    @test length(tagged) == 3
+    @test tagged[1].quality_tag == :good
+    @test tagged[2].quality_tag == :fallback
+    @test tagged[3].quality_tag == :bad
+
+    selected = Models.execute_governance_selector(candidates;
+        selector=Models.select_pressure_max_candidate,
+        residual_norm_max=1e-6,
+    )
+    @test selected.selected_index == 1
+    @test selected.selection_reason == :pressure_max_under_constraints
+    @test haskey(selected, :normalized_candidates)
+    @test selected.selected_candidate.quality_tag == :good
+
+    @test Models.governance_quality_tag((;
+        converged=true,
+        residual_norm=1e-8,
+        hard_constraint_ok=true,
+        governed_attempt_origin=:method_rescue,
+    ); residual_norm_max=1e-6) == :fallback
 end
 
 @testset "candidate governance contract" begin

--- a/tests/unit/models/test_problem_spec_contract.jl
+++ b/tests/unit/models/test_problem_spec_contract.jl
@@ -383,10 +383,12 @@ end
             @test haskey(solved, :governed_selected_method)
             @test haskey(solved, :governed_selected_quality)
             @test haskey(solved, :governed_fallback_used)
+            @test haskey(solved, :selection_score)
             @test solved.legacy_fallback_used isa Bool
             @test solved.governed_selected_method isa Symbol
             @test solved.governed_selected_quality isa Symbol
             @test solved.governed_fallback_used isa Bool
+            @test solved.governed_selected_quality in (:good, :fallback, :degraded, :bad)
             @test solved.selection_reason in (:pressure_max_under_constraints, :residual_min_under_constraints, :no_candidate_passed_constraints)
             @test solved.candidate_count >= 1
         end


### PR DESCRIPTION
## Summary
- unify solver attempt/fallback/selection to a single governance path by adding `governance_quality_tag`, selector-input normalization, and `execute_governance_selector` in `CandidateGovernance`
- route `ProblemSpecOrchestrator` governed execution through the unified governance selector and expose normalized governance metadata (`quality_tag`, `selection_score`) consistently
- update solver maintainer docs and PR-4/roadmap checklists, and add unit/regression coverage for quality tags, fallback semantics, and selector contract

## Verification
- `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_candidate_governance_contract.jl,models/test_problem_spec_contract.jl,models/test_solver_diagnostic_contract.jl,models/test_constraint_solver.jl,models/test_solver.jl"; include("tests/unit/runtests.jl")'` (Pass 410/410)
- `julia --project=. -e 'ENV["REGRESSION_PROFILE"]="full"; include("tests/regression/runtests.jl")'` (Pass 1063/1064, 1 expected optional broken fixture skip)
- `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'` (Pass 461/461)