### PR TITLE
refactor(relaxtime): add unified run provenance sidecars for scan outputs

### DIFF
--- a/scripts/relaxtime/provenance_metadata.jl
+++ b/scripts/relaxtime/provenance_metadata.jl
@@ -15,32 +15,17 @@ Base.@kwdef struct RunContext
     argv::Vector{String}
 end
 
-@inline function _json_escape(s::AbstractString)
-    out = IOBuffer()
-    for c in s
-        if c == '"'
-            print(out, "\\\"")
-        elseif c == '\\'
-            print(out, "\\\\")
-        elseif c == '\n'
-            print(out, "\\n")
-        elseif c == '\r'
-            print(out, "\\r")
-        elseif c == '\t'
-            print(out, "\\t")
-        else
-            print(out, c)
-        end
-    end
-    return String(take!(out))
-end
+@inline _json_escape(s::AbstractString) = Base.escape_string(s)
 
 function _to_json(x)
     if x === nothing
         return "null"
     elseif x isa Bool
         return x ? "true" : "false"
-    elseif x isa Integer || x isa AbstractFloat
+    elseif x isa Integer
+        return string(x)
+    elseif x isa AbstractFloat
+        isfinite(x) || throw(ArgumentError("non-finite float cannot be serialized to JSON: $(x)"))
         return string(x)
     elseif x isa AbstractString
         return "\"$(_json_escape(x))\""
@@ -91,7 +76,14 @@ end
 
 function _sha256_file(path::String)
     open(path, "r") do io
-        return bytes2hex(sha256(read(io)))
+        ctx = SHA.SHA2_256_CTX()
+        buffer = Vector{UInt8}(undef, 1024 * 1024)
+        while !eof(io)
+            n = readbytes!(io, buffer)
+            n == 0 && break
+            SHA.update!(ctx, @view buffer[1:n])
+        end
+        return bytes2hex(SHA.digest!(ctx))
     end
 end
 
@@ -123,8 +115,9 @@ function _artifact_entry(path::String, project_root::String)
 end
 
 function new_run_context(script::String, argv::Vector{String}=copy(ARGS))::RunContext
-    run_id = string(Dates.format(now(UTC), dateformat"yyyymmddTHHMMSS"), "_", bytes2hex(rand(UInt8, 4)))
-    timestamp_utc = Dates.format(now(UTC), dateformat"yyyy-mm-ddTHH:MM:SSZ")
+    t = now(UTC)
+    run_id = string(Dates.format(t, dateformat"yyyymmddTHHMMSS"), "_", bytes2hex(rand(UInt8, 4)))
+    timestamp_utc = Dates.format(t, dateformat"yyyy-mm-ddTHH:MM:SSZ")
     return RunContext(run_id=run_id, timestamp_utc=timestamp_utc, script=script, argv=copy(argv))
 end
 
@@ -180,14 +173,15 @@ function write_run_sidecars(outdir::String;
     project_toml = joinpath(project_root, "Project.toml")
     manifest_toml = joinpath(project_root, "Manifest.toml")
 
+    cwd_rel = relpath(pwd(), project_root)
     manifest = Dict{String,Any}(
         "schema_version" => "v1",
         "run_id" => ctx.run_id,
         "timestamp_utc" => ctx.timestamp_utc,
         "script" => ctx.script,
         "argv" => ctx.argv,
-        "cwd" => pwd(),
-        "project_path" => project_root,
+        "cwd" => cwd_rel,
+        "project_path" => ".",
         "julia_version" => string(VERSION),
         "threads" => Threads.nthreads(),
         "git_commit" => _current_git_commit(project_root),

--- a/scripts/relaxtime/provenance_metadata.jl
+++ b/scripts/relaxtime/provenance_metadata.jl
@@ -1,0 +1,207 @@
+module ProvenanceMetadata
+
+using Dates
+using SHA
+
+export RunContext
+export new_run_context
+export write_run_sidecars
+export csv_stats
+
+Base.@kwdef struct RunContext
+    run_id::String
+    timestamp_utc::String
+    script::String
+    argv::Vector{String}
+end
+
+@inline function _json_escape(s::AbstractString)
+    out = IOBuffer()
+    for c in s
+        if c == '"'
+            print(out, "\\\"")
+        elseif c == '\\'
+            print(out, "\\\\")
+        elseif c == '\n'
+            print(out, "\\n")
+        elseif c == '\r'
+            print(out, "\\r")
+        elseif c == '\t'
+            print(out, "\\t")
+        else
+            print(out, c)
+        end
+    end
+    return String(take!(out))
+end
+
+function _to_json(x)
+    if x === nothing
+        return "null"
+    elseif x isa Bool
+        return x ? "true" : "false"
+    elseif x isa Integer || x isa AbstractFloat
+        return string(x)
+    elseif x isa AbstractString
+        return "\"$(_json_escape(x))\""
+    elseif x isa AbstractVector
+        return "[" * join((_to_json(v) for v in x), ",") * "]"
+    elseif x isa AbstractDict
+        pairs_sorted = sort(collect(pairs(x)); by=kv -> String(kv.first))
+        parts = String[]
+        for (k, v) in pairs_sorted
+            push!(parts, "\"$(_json_escape(String(k)))\":" * _to_json(v))
+        end
+        return "{" * join(parts, ",") * "}"
+    else
+        return "\"$(_json_escape(string(x)))\""
+    end
+end
+
+function _write_json(path::String, x)
+    mkpath(dirname(path))
+    open(path, "w") do io
+        write(io, _to_json(x))
+    end
+end
+
+function _current_git_commit(project_root::String)
+    try
+        return readchomp(`git -C $(project_root) rev-parse HEAD`)
+    catch
+        return "unknown"
+    end
+end
+
+function _current_git_branch(project_root::String)
+    try
+        return readchomp(`git -C $(project_root) rev-parse --abbrev-ref HEAD`)
+    catch
+        return "unknown"
+    end
+end
+
+function _git_dirty(project_root::String)
+    try
+        return !isempty(readchomp(`git -C $(project_root) status --porcelain`))
+    catch
+        return false
+    end
+end
+
+function _sha256_file(path::String)
+    open(path, "r") do io
+        return bytes2hex(sha256(read(io)))
+    end
+end
+
+function _count_csv_rows(path::String)
+    rows = 0
+    seen_header = false
+    open(path, "r") do io
+        for line in eachline(io)
+            s = strip(line)
+            isempty(s) && continue
+            startswith(s, "#") && continue
+            if !seen_header
+                seen_header = true
+                continue
+            end
+            rows += 1
+        end
+    end
+    return rows
+end
+
+function _artifact_entry(path::String, project_root::String)
+    abs_path = abspath(path)
+    return Dict{String,Any}(
+        "path" => relpath(abs_path, project_root),
+        "sha256" => _sha256_file(abs_path),
+        "rows" => endswith(lowercase(path), ".csv") ? _count_csv_rows(abs_path) : nothing,
+    )
+end
+
+function new_run_context(script::String, argv::Vector{String}=copy(ARGS))::RunContext
+    run_id = string(Dates.format(now(UTC), dateformat"yyyymmddTHHMMSS"), "_", bytes2hex(rand(UInt8, 4)))
+    timestamp_utc = Dates.format(now(UTC), dateformat"yyyy-mm-ddTHH:MM:SSZ")
+    return RunContext(run_id=run_id, timestamp_utc=timestamp_utc, script=script, argv=copy(argv))
+end
+
+function csv_stats(path::String; converged_col::String="converged")
+    header = String[]
+    idx_conv = 0
+    total = 0
+    success = 0
+    errors = 0
+    open(path, "r") do io
+        for line in eachline(io)
+            s = strip(line)
+            isempty(s) && continue
+            startswith(s, "#") && continue
+            if isempty(header)
+                header = [strip(x) for x in split(s, ',')]
+                idx_conv = something(findfirst(==(converged_col), header), 0)
+                continue
+            end
+            total += 1
+            if idx_conv > 0
+                parts = split(s, ',')
+                if idx_conv <= length(parts)
+                    v = lowercase(strip(parts[idx_conv]))
+                    if v == "true"
+                        success += 1
+                    else
+                        errors += 1
+                    end
+                end
+            end
+        end
+    end
+    return (points_total=total, success_count=success, error_count=errors)
+end
+
+function write_run_sidecars(outdir::String;
+    ctx::RunContext,
+    effective_config::Dict{String,Any},
+    artifacts::Vector{String},
+    summary::Dict{String,Any}=Dict{String,Any}(),
+)
+    project_root = normpath(joinpath(@__DIR__, "..", ".."))
+    effective = Dict{String,Any}(
+        "schema_version" => "v1",
+        "run_id" => ctx.run_id,
+        "script" => ctx.script,
+        "options" => effective_config,
+    )
+    effective_json = _to_json(effective)
+    config_hash = bytes2hex(sha256(effective_json))
+
+    project_toml = joinpath(project_root, "Project.toml")
+    manifest_toml = joinpath(project_root, "Manifest.toml")
+
+    manifest = Dict{String,Any}(
+        "schema_version" => "v1",
+        "run_id" => ctx.run_id,
+        "timestamp_utc" => ctx.timestamp_utc,
+        "script" => ctx.script,
+        "argv" => ctx.argv,
+        "cwd" => pwd(),
+        "project_path" => project_root,
+        "julia_version" => string(VERSION),
+        "threads" => Threads.nthreads(),
+        "git_commit" => _current_git_commit(project_root),
+        "git_branch" => _current_git_branch(project_root),
+        "git_dirty" => _git_dirty(project_root),
+        "project_toml_hash" => isfile(project_toml) ? _sha256_file(project_toml) : "",
+        "manifest_toml_hash" => isfile(manifest_toml) ? _sha256_file(manifest_toml) : "",
+        "config_hash" => config_hash,
+        "artifacts" => [_artifact_entry(p, project_root) for p in artifacts],
+        "summary" => summary,
+    )
+
+    _write_json(joinpath(outdir, "effective_config.json"), effective)
+    _write_json(joinpath(outdir, "run_manifest.json"), manifest)
+end
+
+end # module ProvenanceMetadata

--- a/scripts/relaxtime/run_gap_transport_scan.jl
+++ b/scripts/relaxtime/run_gap_transport_scan.jl
@@ -526,6 +526,7 @@ function ensure_output_header_compatible(path::AbstractString)
         "quality_flag",
         "quality_reason",
         "quality_metric",
+        "run_id",
         "equilibrium_backend",
         "seed_source",
         "phase_prev",
@@ -1087,7 +1088,7 @@ function run_scan(opts::ScanOptions, ctx::ProvenanceMetadata.RunContext)
         ensure_parent_dir(opts.failed_points_output)
     end
     provenance_dir = isnothing(opts.provenance_dir) ? dirname(opts.output) : opts.provenance_dir
-    ensure_parent_dir(joinpath(provenance_dir, "dummy.txt"))
+    mkpath(provenance_dir)
 
     if opts.resume && isfile(opts.output) && !opts.overwrite
         ensure_output_header_compatible(opts.output)
@@ -1363,6 +1364,7 @@ function run_scan(opts::ScanOptions, ctx::ProvenanceMetadata.RunContext)
                     stats_success += 1
                 catch point_err
                     @warn "SCAN POINT FAILED — skipped" T_mev=T_mev muB_mev=muB_mev xi=xi err=point_err
+                    stats_error += 1
                     if failed_io !== nothing
                         diag_or_hint = (seed_source="unknown", phase_prev=previous_phase, phase_curr=:unknown)
                         write_failed_point_row!(failed_io, T_mev, muB_mev, xi, diag_or_hint, point_err)

--- a/scripts/relaxtime/run_gap_transport_scan.jl
+++ b/scripts/relaxtime/run_gap_transport_scan.jl
@@ -18,6 +18,7 @@ const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", ".."))
 
 include(joinpath(PROJECT_ROOT, "scripts", "utils", "scan_csv.jl"))
 include(joinpath(PROJECT_ROOT, "scripts", "relaxtime", "scan_quality.jl"))
+include(joinpath(PROJECT_ROOT, "scripts", "relaxtime", "provenance_metadata.jl"))
 
 include(joinpath(PROJECT_ROOT, "src", "constants", "Constants_PNJL.jl"))
 include(joinpath(PROJECT_ROOT, "src", "integration", "GaussLegendre.jl"))
@@ -32,6 +33,7 @@ using StaticArrays
 using Dates
 using .ScanCSV: ScanCSV
 using .ScanQuality: assess_point_quality
+using .ProvenanceMetadata: ProvenanceMetadata
 
 const PNJL_MODEL = Models.create_model(:PNJL)
 const TransportWorkflow = Models.transport_workflow_module()
@@ -58,6 +60,7 @@ struct ScanOptions
     output::String
     channel_diagnostics_output::Union{Nothing, String}
     failed_points_output::Union{Nothing, String}
+    provenance_dir::Union{Nothing, String}
     xi_values::Vector{Float64}
     tmin_mev::Float64
     tmax_mev::Float64
@@ -95,6 +98,7 @@ function print_usage()
     println("  --output <path>             输出 CSV (default data/outputs/results/relaxtime/scan/gap_transport_scan.csv)")
     println("  --channel-diagnostics-output <path>  可选：输出每点每通道的 τ^-1 贡献明细 CSV")
     println("  --failed-points-output <path>        可选：输出跳过失败点 sidecar CSV")
+    println("  --provenance-dir <path>              可选：写入 run_manifest/effective_config 的目录（默认 output 同目录）")
     println("  --xi <value>                追加一个 ξ 值（可多次传入）")
     println("  --xi-list v1,v2,...         用逗号分隔的 ξ 列表替换")
     println("  --tmin/--tmax/--tstep <MeV> 温度范围与步长")
@@ -128,6 +132,7 @@ function parse_args(args::Vector{String})
         :output => joinpath("data", "outputs", "results", "relaxtime", "scan", "gap_transport_scan.csv"),
         :channel_diagnostics_output => nothing,
         :failed_points_output => nothing,
+        :provenance_dir => nothing,
         :xi_values => Float64[0.0],
         :tmin => 50.0,
         :tmax => 200.0,
@@ -172,6 +177,8 @@ function parse_args(args::Vector{String})
             opts[:channel_diagnostics_output] = require_value()
         elseif arg == "--failed-points-output"
             opts[:failed_points_output] = require_value()
+        elseif arg == "--provenance-dir"
+            opts[:provenance_dir] = require_value()
         elseif arg == "--xi"
             val = parse(Float64, require_value())
             if opts[:xi_values] == Float64[0.0]
@@ -267,6 +274,7 @@ function parse_args(args::Vector{String})
         String(opts[:output]),
         isnothing(opts[:channel_diagnostics_output]) ? nothing : String(opts[:channel_diagnostics_output]),
         isnothing(opts[:failed_points_output]) ? nothing : String(opts[:failed_points_output]),
+        isnothing(opts[:provenance_dir]) ? nothing : String(opts[:provenance_dir]),
         xi_vals,
         Float64(opts[:tmin]),
         Float64(opts[:tmax]),
@@ -546,7 +554,7 @@ function write_header_if_needed(io)
         "tauinv_u", "tauinv_d", "tauinv_s", "tauinv_ubar", "tauinv_dbar", "tauinv_sbar",
         "eta", "sigma", "zeta", "eta_over_s", "zeta_over_s",
         "sigma_over_T", "sigma_over_T_over_eta_over_s", "zeta_over_s_over_eta_over_s",
-        "quality_flag", "quality_reason", "quality_metric",
+        "quality_flag", "quality_reason", "quality_metric", "run_id",
     ], ',')
     println(io, header)
 end
@@ -1070,7 +1078,7 @@ function build_sigma_caches(processes::Tuple, quark_params::NamedTuple, thermo_p
     return caches
 end
 
-function run_scan(opts::ScanOptions)
+function run_scan(opts::ScanOptions, ctx::ProvenanceMetadata.RunContext)
     ensure_parent_dir(opts.output)
     if opts.channel_diagnostics_output !== nothing
         ensure_parent_dir(opts.channel_diagnostics_output)
@@ -1078,6 +1086,8 @@ function run_scan(opts::ScanOptions)
     if opts.failed_points_output !== nothing
         ensure_parent_dir(opts.failed_points_output)
     end
+    provenance_dir = isnothing(opts.provenance_dir) ? dirname(opts.output) : opts.provenance_dir
+    ensure_parent_dir(joinpath(provenance_dir, "dummy.txt"))
 
     if opts.resume && isfile(opts.output) && !opts.overwrite
         ensure_output_header_compatible(opts.output)
@@ -1103,6 +1113,9 @@ function run_scan(opts::ScanOptions)
     io = open(opts.output, "a")
     channel_io = opts.channel_diagnostics_output === nothing ? nothing : open(opts.channel_diagnostics_output, "a")
     failed_io = opts.failed_points_output === nothing ? nothing : open(opts.failed_points_output, "a")
+    stats_success = 0
+    stats_error = 0
+    stats_skipped = 0
     try
         if new_file
             ScanCSV.write_metadata(io, Dict(
@@ -1181,6 +1194,7 @@ function run_scan(opts::ScanOptions)
                 done += 1
                 key = (T_mev, muB_mev, xi)
                 if opts.resume && (key in existing)
+                    stats_skipped += 1
                     continue
                 end
 
@@ -1337,7 +1351,7 @@ function run_scan(opts::ScanOptions)
                         string(tauinv.u), string(tauinv.d), string(tauinv.s), string(tauinv.ubar), string(tauinv.dbar), string(tauinv.sbar),
                         string(tr.eta), string(tr.sigma), string(tr.zeta), string(eta_over_s), string(zeta_over_s),
                         string(sigma_over_T), string(sigma_over_T_over_eta_over_s), string(zeta_over_s_over_eta_over_s),
-                        csv_bool(quality_flag), quality_reason, string(quality_metric),
+                        csv_bool(quality_flag), quality_reason, string(quality_metric), string(ctx.run_id),
                     ], ',')
                     println(io, row)
                     flush(io)
@@ -1346,6 +1360,7 @@ function run_scan(opts::ScanOptions)
                         write_channel_diagnostics_rows!(channel_io, T_mev, muq_mev, muB_mev, xi,
                             dens, rates, tauinv, eq.solver_backend, diag)
                     end
+                    stats_success += 1
                 catch point_err
                     @warn "SCAN POINT FAILED — skipped" T_mev=T_mev muB_mev=muB_mev xi=xi err=point_err
                     if failed_io !== nothing
@@ -1371,6 +1386,7 @@ function run_scan(opts::ScanOptions)
                     done += 1
                     key = (T_mev, muB_mev, xi)
                     if opts.resume && (key in existing)
+                        stats_skipped += 1
                         continue
                     end
 
@@ -1544,7 +1560,7 @@ function run_scan(opts::ScanOptions)
                         string(tauinv.u), string(tauinv.d), string(tauinv.s), string(tauinv.ubar), string(tauinv.dbar), string(tauinv.sbar),
                         string(tr.eta), string(tr.sigma), string(tr.zeta), string(eta_over_s), string(zeta_over_s),
                         string(sigma_over_T), string(sigma_over_T_over_eta_over_s), string(zeta_over_s_over_eta_over_s),
-                        csv_bool(quality_flag), quality_reason, string(quality_metric),
+                        csv_bool(quality_flag), quality_reason, string(quality_metric), string(ctx.run_id),
                     ], ',')
                     println(io, row)
                     flush(io)
@@ -1553,6 +1569,7 @@ function run_scan(opts::ScanOptions)
                         write_channel_diagnostics_rows!(channel_io, T_mev, muq_mev, muB_mev, xi,
                             dens, rates, tauinv, eq.solver_backend, diag)
                     end
+                    stats_success += 1
 
                     catch point_err
                         @warn "SCAN POINT FAILED — skipped" T_mev=T_mev muB_mev=muB_mev xi=xi err=point_err
@@ -1560,6 +1577,7 @@ function run_scan(opts::ScanOptions)
                             diag_or_hint = (seed_source="unknown", phase_prev=previous_phase, phase_curr=:unknown)
                             write_failed_point_row!(failed_io, T_mev, muB_mev, xi, diag_or_hint, point_err)
                         end
+                        stats_error += 1
                     end  # try 单点容错
 
                     if opts.gc_every_n > 0 && done % opts.gc_every_n == 0
@@ -1583,12 +1601,69 @@ function run_scan(opts::ScanOptions)
         end
     end
 
+    effective_config = Dict{String,Any}(
+        "output" => opts.output,
+        "channel_diagnostics_output" => opts.channel_diagnostics_output,
+        "failed_points_output" => opts.failed_points_output,
+        "xi_values" => opts.xi_values,
+        "tmin_mev" => opts.tmin_mev,
+        "tmax_mev" => opts.tmax_mev,
+        "tstep_mev" => opts.tstep_mev,
+        "mubmin_mev" => opts.mubmin_mev,
+        "mubmax_mev" => opts.mubmax_mev,
+        "mubstep_mev" => opts.mubstep_mev,
+        "overwrite" => opts.overwrite,
+        "resume" => opts.resume,
+        "compute_bulk" => opts.compute_bulk,
+        "p_num" => opts.p_num,
+        "t_num" => opts.t_num,
+        "max_iter" => opts.max_iter,
+        "tau_p_nodes" => opts.tau_p_nodes,
+        "tau_angle_nodes" => opts.tau_angle_nodes,
+        "tau_phi_nodes" => opts.tau_phi_nodes,
+        "tau_n_sigma_points" => opts.tau_n_sigma_points,
+        "tau_threshold_subtraction" => opts.tau_threshold_subtraction,
+        "tau_asym_window" => opts.tau_asym_window,
+        "tau_asym_fit_min_points" => opts.tau_asym_fit_min_points,
+        "tau_asym_extra_points" => opts.tau_asym_extra_points,
+        "tau_interpolation_mode" => String(opts.tau_interpolation_mode),
+        "sigma_grid_n" => opts.sigma_grid_n,
+        "integration_mode" => String(opts.integration_mode),
+        "gc_every_n" => opts.gc_every_n,
+        "tr_p_nodes" => opts.tr_p_nodes,
+        "tr_p_max_fm" => opts.tr_p_max_fm,
+    )
+
+    summary = Dict{String,Any}(
+        "points_total" => stats_success + stats_error,
+        "success_count" => stats_success,
+        "error_count" => stats_error,
+        "skipped_count" => stats_skipped,
+    )
+
+    artifacts = String[opts.output]
+    if opts.channel_diagnostics_output !== nothing
+        push!(artifacts, opts.channel_diagnostics_output)
+    end
+    if opts.failed_points_output !== nothing
+        push!(artifacts, opts.failed_points_output)
+    end
+
+    ProvenanceMetadata.write_run_sidecars(
+        provenance_dir;
+        ctx=ctx,
+        effective_config=effective_config,
+        artifacts=artifacts,
+        summary=summary,
+    )
+
     println("Scan finished. Output: $(opts.output)")
 end
 
 function main()
     opts = parse_args(copy(ARGS))
-    run_scan(opts)
+    ctx = ProvenanceMetadata.new_run_context("scripts/relaxtime/run_gap_transport_scan.jl", copy(ARGS))
+    run_scan(opts, ctx)
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__

--- a/scripts/relaxtime/scan_relaxation_times_vs_T.jl
+++ b/scripts/relaxtime/scan_relaxation_times_vs_T.jl
@@ -284,7 +284,10 @@ end
 function run_scan(opts::Options, ctx::ProvenanceMetadata.RunContext)
     ensure_parent_dir(opts.out)
     provenance_dir = isnothing(opts.provenance_dir) ? dirname(opts.out) : opts.provenance_dir
-    ensure_parent_dir(joinpath(provenance_dir, "dummy.txt"))
+    mkpath(provenance_dir)
+    if opts.resume && isfile(opts.out) && !opts.overwrite
+        ScanCSV.assert_required_columns(opts.out, ["run_id"])
+    end
     existing = opts.resume && isfile(opts.out) && !opts.overwrite ? 
         ScanCSV.read_existing_keys(opts.out, ["T_MeV", "muB_MeV", "xi"]) : Set{Tuple{Float64,Float64,Float64}}()
     opts.overwrite && isfile(opts.out) && rm(opts.out)

--- a/scripts/relaxtime/scan_relaxation_times_vs_T.jl
+++ b/scripts/relaxtime/scan_relaxation_times_vs_T.jl
@@ -32,6 +32,7 @@
 const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", ".."))
 
 include(joinpath(PROJECT_ROOT, "scripts", "utils", "scan_csv.jl"))
+include(joinpath(PROJECT_ROOT, "scripts", "relaxtime", "provenance_metadata.jl"))
 include(joinpath(PROJECT_ROOT, "src", "constants", "Constants_PNJL.jl"))
 include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
 include(joinpath(PROJECT_ROOT, "src", "integration", "GaussLegendre.jl"))
@@ -49,6 +50,7 @@ const DEFAULT_MOMENTUM_WEIGHTS = getproperty(Integrals, :DEFAULT_MOMENTUM_WEIGHT
 using .OneLoopIntegrals: A
 using .EffectiveCouplings: calculate_G_from_A, calculate_effective_couplings
 using .ScanCSV: ScanCSV
+using .ProvenanceMetadata: ProvenanceMetadata
 using .GaussLegendre: gauleg
 
 const TransportWorkflow = Models.transport_workflow_module()
@@ -66,6 +68,7 @@ const MODULE_DEFAULT_SIGMA_GRID_N = RT_ASR.DEFAULT_SIGMA_GRID_N # 60
 struct Options
     out::String
     diagnostics_out::Union{Nothing,String}
+    provenance_dir::Union{Nothing, String}
     overwrite::Bool
     resume::Bool
     xi::Float64
@@ -90,6 +93,7 @@ function print_usage()
     println("Options:")
     println("  --out <path>                 输出 CSV (default data/outputs/results/relaxtime/scan/relaxation_times_vs_T.csv)")
     println("  --diagnostics-out <path>     过程级诊断 CSV（按 species/channel 导出贡献）")
+    println("  --provenance-dir <path>      可选：写入 run_manifest/effective_config 的目录（默认 out 同目录）")
     println("  --overwrite                  覆盖输出文件")
     println("  --no-resume                  禁用跳过逻辑，强制重算")
     println("  --xi <value>                 各向异性参数 ξ (default 0.0)")
@@ -116,6 +120,7 @@ function parse_args(args::Vector{String})
     opts = Dict{Symbol,Any}(
         :out => joinpath("data", "outputs", "results", "relaxtime", "scan", "relaxation_times_vs_T.csv"),
         :diagnostics_out => nothing,
+        :provenance_dir => nothing,
         :overwrite => false,
         :resume => true,
         :xi => 0.0,
@@ -149,6 +154,8 @@ function parse_args(args::Vector{String})
             opts[:out] = require_value()
         elseif arg == "--diagnostics-out"
             opts[:diagnostics_out] = require_value()
+        elseif arg == "--provenance-dir"
+            opts[:provenance_dir] = require_value()
         elseif arg == "--overwrite"
             opts[:overwrite] = true
         elseif arg == "--no-resume"
@@ -199,7 +206,10 @@ function parse_args(args::Vector{String})
 
     tstep = Float64(opts[:tstep]); tstep > 0 || error("tstep must be positive")
     return Options(
-        String(opts[:out]), opts[:diagnostics_out] === nothing ? nothing : String(opts[:diagnostics_out]), Bool(opts[:overwrite]), Bool(opts[:resume]),
+        String(opts[:out]),
+        opts[:diagnostics_out] === nothing ? nothing : String(opts[:diagnostics_out]),
+        opts[:provenance_dir] === nothing ? nothing : String(opts[:provenance_dir]),
+        Bool(opts[:overwrite]), Bool(opts[:resume]),
         Float64(opts[:xi]), Float64(opts[:tmin]), Float64(opts[:tmax]), Float64(opts[:tstep]),
         Float64.(opts[:mub_list]), Int(opts[:p_num]), Int(opts[:t_num]), Int(opts[:max_iter]),
         Int(opts[:tau_p_nodes]), Int(opts[:tau_angle_nodes]), Int(opts[:tau_phi_nodes]),
@@ -233,7 +243,7 @@ function write_header(io, opts::Options)
         "tauinv_u", "tauinv_s", "tauinv_ubar", "tauinv_sbar",
         "tau_p_nodes", "tau_angle_nodes", "tau_phi_nodes", "tau_n_sigma_points",
         "sigma_grid_n", "integration_mode",
-        "gc_every_n",
+        "gc_every_n", "run_id",
     ]
     println(io, join(cols, ','))
 end
@@ -271,8 +281,10 @@ function build_K_coeffs(T_fm::Float64, muq_fm::Float64, masses::NamedTuple, Φ::
     return (K_coeffs=calculate_effective_couplings(G_fm2, K_fm5, G_u, G_s), A_vals=(u=A_u, d=A_u, s=A_s))
 end
 
-function run_scan(opts::Options)
+function run_scan(opts::Options, ctx::ProvenanceMetadata.RunContext)
     ensure_parent_dir(opts.out)
+    provenance_dir = isnothing(opts.provenance_dir) ? dirname(opts.out) : opts.provenance_dir
+    ensure_parent_dir(joinpath(provenance_dir, "dummy.txt"))
     existing = opts.resume && isfile(opts.out) && !opts.overwrite ? 
         ScanCSV.read_existing_keys(opts.out, ["T_MeV", "muB_MeV", "xi"]) : Set{Tuple{Float64,Float64,Float64}}()
     opts.overwrite && isfile(opts.out) && rm(opts.out)
@@ -284,6 +296,9 @@ function run_scan(opts::Options)
     new_file = !isfile(opts.out) || filesize(opts.out) == 0
     io = open(opts.out, "a")
     diag_io = nothing
+    stats_success = 0
+    stats_error = 0
+    stats_skipped = 0
     try
         if opts.diagnostics_out !== nothing
             new_diag_file = !isfile(opts.diagnostics_out) || filesize(opts.diagnostics_out) == 0
@@ -356,7 +371,10 @@ function run_scan(opts::Options)
             seed_state = nothing
 
             for T_mev in T_vals
-                opts.resume && !opts.overwrite && (T_mev, muB_mev, opts.xi) in existing && continue
+                if opts.resume && !opts.overwrite && (T_mev, muB_mev, opts.xi) in existing
+                    stats_skipped += 1
+                    continue
+                end
                 T_fm = T_mev / ħc_MeV_fm
 
                 tau = (u=NaN, s=NaN, ubar=NaN, sbar=NaN)
@@ -422,8 +440,10 @@ function run_scan(opts::Options)
                     tau, tauinv = res.tau, res.tau_inv
                     rates = res.rates
                     seed_state = res.equilibrium.x_state
+                    stats_success += 1
                 catch point_err
                     @warn "tau scan point failed; writing NaN row" T_mev=T_mev muB_mev=muB_mev xi=opts.xi err=point_err
+                    stats_error += 1
                 end
 
                 row = Any[
@@ -435,7 +455,7 @@ function run_scan(opts::Options)
                     tauinv.u, tauinv.s, tauinv.ubar, tauinv.sbar,
                     opts.tau_p_nodes, opts.tau_angle_nodes, opts.tau_phi_nodes, opts.tau_n_sigma_points,
                     opts.sigma_grid_n, string(opts.integration_mode),
-                    opts.gc_every_n,
+                    opts.gc_every_n, ctx.run_id,
                 ]
                 println(io, join(row, ',')); flush(io)
 
@@ -466,10 +486,53 @@ function run_scan(opts::Options)
         close(io)
         diag_io === nothing || close(diag_io)
     end
+
+    effective_config = Dict{String,Any}(
+        "out" => opts.out,
+        "diagnostics_out" => opts.diagnostics_out,
+        "xi" => opts.xi,
+        "tmin_mev" => opts.tmin_mev,
+        "tmax_mev" => opts.tmax_mev,
+        "tstep_mev" => opts.tstep_mev,
+        "mub_list_mev" => opts.mub_list_mev,
+        "overwrite" => opts.overwrite,
+        "resume" => opts.resume,
+        "p_num" => opts.p_num,
+        "t_num" => opts.t_num,
+        "max_iter" => opts.max_iter,
+        "tau_p_nodes" => opts.tau_p_nodes,
+        "tau_angle_nodes" => opts.tau_angle_nodes,
+        "tau_phi_nodes" => opts.tau_phi_nodes,
+        "tau_n_sigma_points" => opts.tau_n_sigma_points,
+        "sigma_grid_n" => opts.sigma_grid_n,
+        "integration_mode" => String(opts.integration_mode),
+        "gc_every_n" => opts.gc_every_n,
+    )
+
+    summary = Dict{String,Any}(
+        "points_total" => stats_success + stats_error,
+        "success_count" => stats_success,
+        "error_count" => stats_error,
+        "skipped_count" => stats_skipped,
+    )
+
+    artifacts = String[opts.out]
+    if opts.diagnostics_out !== nothing
+        push!(artifacts, opts.diagnostics_out)
+    end
+    ProvenanceMetadata.write_run_sidecars(
+        provenance_dir;
+        ctx=ctx,
+        effective_config=effective_config,
+        artifacts=artifacts,
+        summary=summary,
+    )
+
     @printf("Done. Wrote %s\n", opts.out)
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__
     opts = parse_args(ARGS)
-    run_scan(opts)
+    ctx = ProvenanceMetadata.new_run_context("scripts/relaxtime/scan_relaxation_times_vs_T.jl", copy(ARGS))
+    run_scan(opts, ctx)
 end

--- a/scripts/utils/scan_csv.jl
+++ b/scripts/utils/scan_csv.jl
@@ -12,7 +12,7 @@ fields without embedded commas.
 
 module ScanCSV
 
-export write_metadata, write_header, read_existing_keys
+export write_metadata, write_header, read_existing_keys, assert_required_columns
 
 """Write metadata lines as `# key: value` (one per line)."""
 function write_metadata(io, metadata::AbstractDict{<:AbstractString,<:AbstractString})
@@ -87,6 +87,19 @@ function read_existing_keys(path::AbstractString, key_cols::AbstractVector{<:Abs
     end
 
     return keys
+end
+
+"""Assert that an existing scan CSV header contains all required columns."""
+function assert_required_columns(path::AbstractString, required_cols::AbstractVector{<:AbstractString})
+    isfile(path) || return
+    open(path, "r") do io
+        header = _first_non_comment_line(io)
+        header === nothing && error("existing output CSV has no header: $(path)")
+        colmap = _parse_header_map(header)
+        for c in required_cols
+            haskey(colmap, String(c)) || error("existing output CSV header is incompatible (missing column: $(c)). Please rerun with --overwrite or choose a new output path.")
+        end
+    end
 end
 
 end # module

--- a/tests/integration/relaxtime/test_zero_knowledge_provenance_contract_smoke.jl
+++ b/tests/integration/relaxtime/test_zero_knowledge_provenance_contract_smoke.jl
@@ -1,4 +1,5 @@
 using Test
+using JSON3
 
 const _PROVENANCE_PATH = normpath(joinpath(@__DIR__, "..", "..", "..", "scripts", "relaxtime", "provenance_metadata.jl"))
 if !isdefined(Main, :ProvenanceMetadata)
@@ -42,9 +43,22 @@ using Main.ProvenanceMetadata
     @test isfile(effective_path)
     @test isfile(manifest_path)
 
-    manifest_text = read(manifest_path, String)
-    @test occursin("\"run_id\"", manifest_text)
-    @test occursin("\"artifacts\"", manifest_text)
-    @test occursin("\"sha256\"", manifest_text)
-    @test occursin("\"rows\"", manifest_text)
+    manifest_obj = JSON3.read(read(manifest_path, String))
+    effective_obj = JSON3.read(read(effective_path, String))
+    @test String(manifest_obj["run_id"]) == ctx.run_id
+    @test haskey(manifest_obj, "artifacts")
+    @test length(manifest_obj["artifacts"]) == 1
+    @test haskey(manifest_obj["artifacts"][1], "sha256")
+    @test haskey(manifest_obj["artifacts"][1], "rows")
+    @test String(manifest_obj["project_path"]) == "."
+    @test !isabspath(String(manifest_obj["cwd"]))
+    @test String(effective_obj["run_id"]) == ctx.run_id
+
+    @test_throws ArgumentError ProvenanceMetadata.write_run_sidecars(
+        outdir;
+        ctx=ctx,
+        effective_config=Dict{String,Any}("bad" => NaN),
+        artifacts=[csv_path],
+        summary=Dict{String,Any}("points_total" => 2),
+    )
 end

--- a/tests/integration/relaxtime/test_zero_knowledge_provenance_contract_smoke.jl
+++ b/tests/integration/relaxtime/test_zero_knowledge_provenance_contract_smoke.jl
@@ -1,0 +1,50 @@
+using Test
+
+const _PROVENANCE_PATH = normpath(joinpath(@__DIR__, "..", "..", "..", "scripts", "relaxtime", "provenance_metadata.jl"))
+if !isdefined(Main, :ProvenanceMetadata)
+    Base.include(Main, _PROVENANCE_PATH)
+end
+
+using Main.ProvenanceMetadata
+
+@testset "provenance sidecars minimal contract" begin
+    tmp = mktempdir()
+    outdir = joinpath(tmp, "out")
+    mkpath(outdir)
+    csv_path = joinpath(outdir, "demo.csv")
+
+    open(csv_path, "w") do io
+        println(io, "# schema: scan_csv_v1")
+        println(io, "A,converged")
+        println(io, "1,true")
+        println(io, "2,false")
+    end
+
+    stats = ProvenanceMetadata.csv_stats(csv_path; converged_col="converged")
+    @test stats.points_total == 2
+    @test stats.success_count == 1
+    @test stats.error_count == 1
+
+    ctx = ProvenanceMetadata.new_run_context("scripts/relaxtime/run_gap_transport_scan.jl", ["--tmin", "120"])
+    @test !isempty(ctx.run_id)
+    @test !isempty(ctx.timestamp_utc)
+
+    ProvenanceMetadata.write_run_sidecars(
+        outdir;
+        ctx=ctx,
+        effective_config=Dict{String,Any}("demo" => true),
+        artifacts=[csv_path],
+        summary=Dict{String,Any}("points_total" => 2),
+    )
+
+    effective_path = joinpath(outdir, "effective_config.json")
+    manifest_path = joinpath(outdir, "run_manifest.json")
+    @test isfile(effective_path)
+    @test isfile(manifest_path)
+
+    manifest_text = read(manifest_path, String)
+    @test occursin("\"run_id\"", manifest_text)
+    @test occursin("\"artifacts\"", manifest_text)
+    @test occursin("\"sha256\"", manifest_text)
+    @test occursin("\"rows\"", manifest_text)
+end


### PR DESCRIPTION
## Summary
- Introduce a shared provenance helper for relaxtime scan scripts that writes run sidecars (`effective_config.json` and `run_manifest.json`) with artifact hashing and runtime metadata.
- Integrate the provenance contract into `run_gap_transport_scan.jl` and `scan_relaxation_times_vs_T.jl`, including a stable `run_id` column in CSV outputs for traceability.
- Add an integration smoke test that asserts the minimal provenance sidecar contract to prevent regressions.

## Validation
- `julia --project=. -e ''include("tests/integration/relaxtime/test_zero_knowledge_provenance_contract_smoke.jl'')'` (11/11 pass)