### PR TITLE
refactor(docs): align AGENTS and README guidance after PR76

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Repository guidance for coding agents working in `Julia_RelaxTime`.
 - Prefer unified entrypoints exposed through `Models` and `src/models/entrypoints.jl`.
 - `src/pnjl/PNJL.jl` 已从主线移除；若历史文档仍提及该路径，应按“兼容层历史说明”理解，不作为当前实现入口。
 - 统一入口请使用 `Models` 与 `src/models/entrypoints.jl`。
+- Post-PR76 contract alignment: keep mixed-meson governance and non-fixedmu unified joint-solve semantics unchanged unless explicitly required by task scope.
 - Default user-facing communication language is Chinese.
 
 ## Repo Rules From Copilot / Cursor
@@ -43,6 +44,15 @@ Run the standard package test entrypoint:
 
 ```sh
 julia --project=. test/runtests.jl
+```
+
+Run layered wrapper entrypoints (preferred for focused local loops):
+
+```sh
+julia --project=. test/unit.jl
+julia --project=. test/integration.jl
+julia --project=. test/regression.jl
+julia --project=. test/validation.jl
 ```
 
 Alternative package test command:
@@ -232,6 +242,10 @@ Preserve local style and use the governance scripts as the nearest equivalent to
 julia --project=. scripts/dev/check_unit_skip_policy.jl
 julia --project=. scripts/dev/check_docs_consistency.jl
 julia --project=. scripts/dev/check_active_docs_governance.jl
+julia --project=. scripts/dev/check_script_entrypoints.jl
+julia --project=. scripts/dev/check_models_entry_contract.jl
+julia --project=. scripts/dev/check_solver_contract_leakage.jl
+julia --project=. scripts/dev/check_relaxtime_script_governance.jl
 julia --project=. scripts/dev/check_pnjl_migration_guard.jl
 julia --project=. scripts/dev/analyze_deps.jl
 julia --project=. scripts/dev/check_precompile_profile_coverage.jl

--- a/README.md
+++ b/README.md
@@ -65,19 +65,23 @@ Remove-Item -Recurse -Force "data/outputs/results/phase_smoke"
 1. 先读取仓库协作约束：`AGENTS.md`、`.github/copilot-instructions.md`。
 2. 统一入口优先：`Models` 与 `src/models/entrypoints.jl`。
 3. non-fixedmu 求解模式按“展平联合求解”治理，不要引入新的分层默认路径。
-4. 目录治理：
+4. PR76 后契约对齐：mixed-meson 治理与 non-fixedmu 联合求解语义默认保持不变；若需变更必须在任务范围内显式声明并补回归证据。
+5. 目录治理：
    - 分析脚本放 `scripts/analysis/`
    - 性能探针放 `scripts/perf/`
    - 非测试脚本不要放入 `tests/`
-5. 测试执行顺序优先 smoke profile；测试分层保持 `unit/integration/regression/validation`。
-6. 稳定公共入口变更需同步更新 `docs/api/`；新增核心模块必须补 unit tests。
-7. 若工作区有用户已有改动：不要覆盖/回滚无关改动；仅提交本任务相关文件。
+6. 测试执行顺序优先 smoke profile；测试分层保持 `unit/integration/regression/validation`。
+7. 可优先使用分层 wrapper 入口：`test/unit.jl`、`test/integration.jl`、`test/regression.jl`、`test/validation.jl`。
+8. 稳定公共入口变更需同步更新 `docs/api/`；新增核心模块必须补 unit tests。
+9. 若工作区有用户已有改动：不要覆盖/回滚无关改动；仅提交本任务相关文件。
 
 建议最小验证命令（agent 默认基线）：
 
 ```powershell
 julia --project=. -e 'ENV["UNIT_PROFILE"]="smoke"; include("tests/unit/runtests.jl")'
 julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'
+julia --project=. scripts/dev/check_docs_consistency.jl
+julia --project=. scripts/dev/check_models_entry_contract.jl
 ```
 
 </details>

--- a/docs/guides/scripts/README.md
+++ b/docs/guides/scripts/README.md
@@ -21,8 +21,8 @@
 
 - [scripts/pnjl/run_conserved_charge_susceptibilities.jl](../../../scripts/pnjl/run_conserved_charge_susceptibilities.jl)
   - 守恒荷广义磁化率、累积量、`Ssigma`、`kappa_sigma2` 的统一单点/小范围扫描入口
-- [scripts/pnjl/run_tmu_scan.jl](../../../scripts/pnjl/run_tmu_scan.jl)
-  - T-μ 单入口（`--mode=scan|point`），覆盖网格扫描与单点求解
+- [scripts/models/run_unified_scan.jl](../../../scripts/models/run_unified_scan.jl)
+  - 统一扫描入口（`scan tmu|trho`），覆盖 T-μ / T-ρ 网格扫描
 - [scripts/pnjl/calculate_phase_structure.jl](../../../scripts/pnjl/calculate_phase_structure.jl)
   - 相图自动化产线入口（扫描 -> 判据 -> 报告），支持模板配置 + CLI 覆盖
 

--- a/docs/guides/scripts/README.md
+++ b/docs/guides/scripts/README.md
@@ -19,11 +19,11 @@
 
 ### PNJL
 
-- [scripts/pnjl/run_conserved_charge_susceptibilities.jl](scripts/pnjl/run_conserved_charge_susceptibilities.jl)
+- [scripts/pnjl/run_conserved_charge_susceptibilities.jl](../../../scripts/pnjl/run_conserved_charge_susceptibilities.jl)
   - 守恒荷广义磁化率、累积量、`Ssigma`、`kappa_sigma2` 的统一单点/小范围扫描入口
-- [scripts/pnjl/run_tmu_scan.jl](scripts/pnjl/run_tmu_scan.jl)
+- [scripts/pnjl/run_tmu_scan.jl](../../../scripts/pnjl/run_tmu_scan.jl)
   - T-μ 单入口（`--mode=scan|point`），覆盖网格扫描与单点求解
-- [scripts/pnjl/calculate_phase_structure.jl](scripts/pnjl/calculate_phase_structure.jl)
+- [scripts/pnjl/calculate_phase_structure.jl](../../../scripts/pnjl/calculate_phase_structure.jl)
   - 相图自动化产线入口（扫描 -> 判据 -> 报告），支持模板配置 + CLI 覆盖
 
 #### 相图最小单命令产线（PNJL）
@@ -58,14 +58,14 @@ julia --project=. scripts/pnjl/calculate_phase_structure.jl --model_kind=PNJL --
 
 ### Server
 
-- [scripts/server/server_full.jl](scripts/server/server_full.jl)
+- [scripts/server/server_full.jl](../../../scripts/server/server_full.jl)
   - Web + API 联调用完整入口
-- [scripts/server/server.jl](scripts/server/server.jl)
+- [scripts/server/server.jl](../../../scripts/server/server.jl)
   - 仅 API 入口
 
 ### RelaxTime
 
-- [scripts/relaxtime/run_manual_relaxation_scan_workflow.jl](scripts/relaxtime/run_manual_relaxation_scan_workflow.jl)
+- [scripts/relaxtime/run_manual_relaxation_scan_workflow.jl](../../../scripts/relaxtime/run_manual_relaxation_scan_workflow.jl)
   - 手动组合产物入口（`cross_section` / `plan_a` / `plan_b`）
   - 支持 `--base-output-dir` 将结果写到隔离目录（默认 `data/outputs`）
 


### PR DESCRIPTION
## Summary
- align `AGENTS.md` with post-PR76 contract guidance, including mixed-meson and non-fixedmu joint-solve invariants plus layered wrapper test entrypoints
- strengthen root `README.md` LLM/operator guidance with explicit post-PR76 boundary and baseline governance checks
- fix script entry links in `docs/guides/scripts/README.md` to use repository-correct relative paths

## Validation
- `julia --project=. scripts/dev/check_docs_consistency.jl`
- `julia --project=. scripts/dev/check_active_docs_governance.jl`
- `julia --project=. scripts/dev/check_script_entrypoints.jl`
- `julia --project=. scripts/dev/check_models_entry_contract.jl`

## Issue Closure
Closes #77
Closes #78