### PR TITLE
refactor(models/solver): implement phase-1 thermo jacobian targets

### DIFF
--- a/src/models/solver/diff/JacobianEngine.jl
+++ b/src/models/solver/diff/JacobianEngine.jl
@@ -1,8 +1,5 @@
-@inline function _fd_step(value::Float64, key::Symbol)
+@inline function _fd_step(value::Float64)
     base = max(abs(value), 1.0)
-    if key === :xi
-        return max(1e-5, sqrt(eps(Float64)) * base)
-    end
     return max(1e-5, sqrt(eps(Float64)) * base)
 end
 
@@ -53,12 +50,25 @@ end
     return out
 end
 
+@inline function _evaluate_targets_at_theta(ctx::ThermoDiffContext, targets::AbstractVector{<:DiffTarget}, theta::NamedTuple)
+    solved = _solve_result_at_theta(ctx, theta)
+    local_ctx = ThermoDiffContext(solved, ctx.mode, ctx.model, theta, ctx.spec_override, ctx.jacobian_backend)
+    out = Vector{Float64}(undef, length(targets))
+    for i in eachindex(targets)
+        value = targets[i].evaluator(local_ctx)
+        value isa Real || throw(ArgumentError("target $(targets[i].name) evaluator must return Real, got $(typeof(value))"))
+        out[i] = Float64(value)
+        isfinite(out[i]) || throw(ArgumentError("target $(targets[i].name) evaluator returned non-finite value"))
+    end
+    return out
+end
+
 @inline function _default_numeric_jacobian(ctx::ThermoDiffContext, target::DiffTarget, params::ParamSpec)
     n_params = length(params.names)
     if n_params == 1
         key = params.names[1]
         center = _resolve_theta_value(ctx.theta, key)
-        h = _fd_step(center, key)
+        h = _fd_step(center)
         f_p = _evaluate_target_at_theta(ctx, target, _theta_with_perturb(ctx.theta, key, h))
         f_m = _evaluate_target_at_theta(ctx, target, _theta_with_perturb(ctx.theta, key, -h))
         return (f_p - f_m) / (2h)
@@ -67,7 +77,7 @@ end
     out = Matrix{Float64}(undef, 1, n_params)
     for (j, key) in enumerate(params.names)
         center = _resolve_theta_value(ctx.theta, key)
-        h = _fd_step(center, key)
+        h = _fd_step(center)
         f_p = _evaluate_target_at_theta(ctx, target, _theta_with_perturb(ctx.theta, key, h))
         f_m = _evaluate_target_at_theta(ctx, target, _theta_with_perturb(ctx.theta, key, -h))
         out[1, j] = (f_p - f_m) / (2h)
@@ -83,14 +93,14 @@ end
     if n_params == 1
         key = params.names[1]
         center = _resolve_theta_value(ctx.theta, key)
-        h = _fd_step(center, key)
+        h = _fd_step(center)
         out = Vector{Float64}(undef, n_targets)
         theta_p = _theta_with_perturb(ctx.theta, key, h)
         theta_m = _theta_with_perturb(ctx.theta, key, -h)
-        for i in eachindex(targets)
-            f_p = _evaluate_target_at_theta(ctx, targets[i], theta_p)
-            f_m = _evaluate_target_at_theta(ctx, targets[i], theta_m)
-            out[i] = (f_p - f_m) / (2h)
+        values_p = _evaluate_targets_at_theta(ctx, targets, theta_p)
+        values_m = _evaluate_targets_at_theta(ctx, targets, theta_m)
+        @inbounds for i in eachindex(targets)
+            out[i] = (values_p[i] - values_m[i]) / (2h)
         end
         return out
     end
@@ -98,13 +108,13 @@ end
     out = Matrix{Float64}(undef, n_targets, n_params)
     for (j, key) in enumerate(params.names)
         center = _resolve_theta_value(ctx.theta, key)
-        h = _fd_step(center, key)
+        h = _fd_step(center)
         theta_p = _theta_with_perturb(ctx.theta, key, h)
         theta_m = _theta_with_perturb(ctx.theta, key, -h)
-        for i in eachindex(targets)
-            f_p = _evaluate_target_at_theta(ctx, targets[i], theta_p)
-            f_m = _evaluate_target_at_theta(ctx, targets[i], theta_m)
-            out[i, j] = (f_p - f_m) / (2h)
+        values_p = _evaluate_targets_at_theta(ctx, targets, theta_p)
+        values_m = _evaluate_targets_at_theta(ctx, targets, theta_m)
+        @inbounds for i in eachindex(targets)
+            out[i, j] = (values_p[i] - values_m[i]) / (2h)
         end
     end
     return out

--- a/src/models/solver/diff/JacobianEngine.jl
+++ b/src/models/solver/diff/JacobianEngine.jl
@@ -1,3 +1,115 @@
+@inline function _fd_step(value::Float64, key::Symbol)
+    base = max(abs(value), 1.0)
+    if key === :xi
+        return max(1e-5, sqrt(eps(Float64)) * base)
+    end
+    return max(1e-5, sqrt(eps(Float64)) * base)
+end
+
+@inline function _resolve_theta_value(theta::NamedTuple, key::Symbol)
+    hasproperty(theta, key) || throw(ArgumentError("theta is missing required key $(key)"))
+    value = getproperty(theta, key)
+    value isa Real || throw(ArgumentError("theta.$(key) must be Real, got $(typeof(value))"))
+    return Float64(value)
+end
+
+@inline function _theta_with_perturb(theta::NamedTuple, key::Symbol, delta::Float64)
+    value = _resolve_theta_value(theta, key)
+    return merge(theta, (key => value + delta,))
+end
+
+@inline function _runtime_option(ctx::ThermoDiffContext, key::Symbol, default)
+    if ctx.spec_override === nothing
+        return default
+    end
+    return get(ctx.spec_override, key, default)
+end
+
+@inline function _solve_result_at_theta(ctx::ThermoDiffContext, theta::NamedTuple)
+    if ctx.mode isa FixedMu
+        T_fm = _resolve_theta_value(theta, :T_fm)
+        mu_fm = _resolve_theta_value(theta, :mu_fm)
+        xi = hasproperty(theta, :xi) ? Float64(getproperty(theta, :xi)) : Float64(_runtime_option(ctx, :xi, ctx.result.xi))
+        p_num = Int(_runtime_option(ctx, :p_num, Main.Models.default_momentum_count()))
+        t_num = Int(_runtime_option(ctx, :t_num, Main.Models.default_theta_count()))
+        residual_norm_max = Float64(_runtime_option(ctx, :residual_norm_max, 1e-6))
+        return Main.Models.solve(ctx.model, ctx.mode, T_fm, mu_fm;
+            xi=xi,
+            p_num=p_num,
+            t_num=t_num,
+            residual_norm_max=residual_norm_max,
+        )
+    end
+    throw(ArgumentError("default jacobian backend currently supports FixedMu mode only, got $(typeof(ctx.mode))"))
+end
+
+@inline function _evaluate_target_at_theta(ctx::ThermoDiffContext, target::DiffTarget, theta::NamedTuple)
+    solved = _solve_result_at_theta(ctx, theta)
+    local_ctx = ThermoDiffContext(solved, ctx.mode, ctx.model, theta, ctx.spec_override, ctx.jacobian_backend)
+    value = target.evaluator(local_ctx)
+    value isa Real || throw(ArgumentError("target $(target.name) evaluator must return Real, got $(typeof(value))"))
+    out = Float64(value)
+    isfinite(out) || throw(ArgumentError("target $(target.name) evaluator returned non-finite value"))
+    return out
+end
+
+@inline function _default_numeric_jacobian(ctx::ThermoDiffContext, target::DiffTarget, params::ParamSpec)
+    n_params = length(params.names)
+    if n_params == 1
+        key = params.names[1]
+        center = _resolve_theta_value(ctx.theta, key)
+        h = _fd_step(center, key)
+        f_p = _evaluate_target_at_theta(ctx, target, _theta_with_perturb(ctx.theta, key, h))
+        f_m = _evaluate_target_at_theta(ctx, target, _theta_with_perturb(ctx.theta, key, -h))
+        return (f_p - f_m) / (2h)
+    end
+
+    out = Matrix{Float64}(undef, 1, n_params)
+    for (j, key) in enumerate(params.names)
+        center = _resolve_theta_value(ctx.theta, key)
+        h = _fd_step(center, key)
+        f_p = _evaluate_target_at_theta(ctx, target, _theta_with_perturb(ctx.theta, key, h))
+        f_m = _evaluate_target_at_theta(ctx, target, _theta_with_perturb(ctx.theta, key, -h))
+        out[1, j] = (f_p - f_m) / (2h)
+    end
+    return out
+end
+
+@inline function _default_numeric_jacobian(ctx::ThermoDiffContext, targets::AbstractVector{<:DiffTarget}, params::ParamSpec)
+    n_targets = length(targets)
+    n_targets > 0 || throw(ArgumentError("targets must be non-empty"))
+    n_params = length(params.names)
+
+    if n_params == 1
+        key = params.names[1]
+        center = _resolve_theta_value(ctx.theta, key)
+        h = _fd_step(center, key)
+        out = Vector{Float64}(undef, n_targets)
+        theta_p = _theta_with_perturb(ctx.theta, key, h)
+        theta_m = _theta_with_perturb(ctx.theta, key, -h)
+        for i in eachindex(targets)
+            f_p = _evaluate_target_at_theta(ctx, targets[i], theta_p)
+            f_m = _evaluate_target_at_theta(ctx, targets[i], theta_m)
+            out[i] = (f_p - f_m) / (2h)
+        end
+        return out
+    end
+
+    out = Matrix{Float64}(undef, n_targets, n_params)
+    for (j, key) in enumerate(params.names)
+        center = _resolve_theta_value(ctx.theta, key)
+        h = _fd_step(center, key)
+        theta_p = _theta_with_perturb(ctx.theta, key, h)
+        theta_m = _theta_with_perturb(ctx.theta, key, -h)
+        for i in eachindex(targets)
+            f_p = _evaluate_target_at_theta(ctx, targets[i], theta_p)
+            f_m = _evaluate_target_at_theta(ctx, targets[i], theta_m)
+            out[i, j] = (f_p - f_m) / (2h)
+        end
+    end
+    return out
+end
+
 @inline function _coerce_jacobian_scalar(raw)
     raw isa Real || throw(ArgumentError("jacobian backend for single target must return Real, got $(typeof(raw))"))
     value = Float64(raw)
@@ -23,7 +135,11 @@ end
 
 @inline function jacobian(ctx::ThermoDiffContext, target::DiffTarget, params::ParamSpec)
     n_params = length(params.names)
-    raw = ctx.jacobian_backend(ctx, target, params)
+    raw = if ctx.jacobian_backend === _default_jacobian_backend
+        _default_numeric_jacobian(ctx, target, params)
+    else
+        ctx.jacobian_backend(ctx, target, params)
+    end
     if n_params == 1
         value = _coerce_jacobian_scalar(raw)
         return reshape([value], 1, 1)
@@ -34,7 +150,11 @@ end
 @inline function jacobian(ctx::ThermoDiffContext, targets::AbstractVector{<:DiffTarget}, params::ParamSpec)
     isempty(targets) && throw(ArgumentError("targets must be non-empty"))
     n_params = length(params.names)
-    raw = ctx.jacobian_backend(ctx, targets, params)
+    raw = if ctx.jacobian_backend === _default_jacobian_backend
+        _default_numeric_jacobian(ctx, targets, params)
+    else
+        ctx.jacobian_backend(ctx, targets, params)
+    end
     if n_params == 1
         vec = _coerce_jacobian_vector(raw, length(targets))
         return reshape(vec, length(targets), 1)

--- a/src/models/solver/diff/Targets.jl
+++ b/src/models/solver/diff/Targets.jl
@@ -5,11 +5,54 @@ end
 
 @inline DiffTarget(name::Symbol) = DiffTarget(name, _ctx -> throw(ErrorException("DiffTarget $(name) evaluator is not implemented")))
 
+@inline function _theta_value(theta::NamedTuple, key::Symbol)
+    hasproperty(theta, key) || throw(ArgumentError("theta is missing required key $(key)"))
+    value = getproperty(theta, key)
+    value isa Real || throw(ArgumentError("theta.$(key) must be Real, got $(typeof(value))"))
+    return Float64(value)
+end
+
+@inline function _finite_target_value(name::Symbol, value)
+    value isa Real || throw(ArgumentError("target $(name) must evaluate to Real, got $(typeof(value))"))
+    out = Float64(value)
+    isfinite(out) || throw(ArgumentError("target $(name) evaluated to non-finite value: $(value)"))
+    return out
+end
+
+@inline _eval_pressure(ctx::ThermoDiffContext) = _finite_target_value(:pressure, ctx.result.pressure)
+@inline _eval_entropy(ctx::ThermoDiffContext) = _finite_target_value(:entropy, ctx.result.entropy)
+@inline _eval_rho_norm(ctx::ThermoDiffContext) = _finite_target_value(:rho_norm, ctx.result.rho_norm)
+@inline _eval_energy(ctx::ThermoDiffContext) = _finite_target_value(:energy, ctx.result.energy)
+
+@inline function _eval_dP_dT(ctx::ThermoDiffContext)
+    deriv = Main.Models.ThermoDerivatives
+    T_fm = _theta_value(ctx.theta, :T_fm)
+    mu_fm = _theta_value(ctx.theta, :mu_fm)
+    xi = hasproperty(ctx.theta, :xi) ? Float64(getproperty(ctx.theta, :xi)) : 0.0
+    p_num = ctx.spec_override === nothing ? Main.Models.default_momentum_count() : Int(get(ctx.spec_override, :p_num, Main.Models.default_momentum_count()))
+    t_num = ctx.spec_override === nothing ? Main.Models.default_theta_count() : Int(get(ctx.spec_override, :t_num, Main.Models.default_theta_count()))
+    value = deriv.dP_dT(T_fm, mu_fm; xi=xi, p_num=p_num, t_num=t_num, model=ctx.model)
+    return _finite_target_value(:dP_dT, value)
+end
+
+@inline function _eval_dP_dmu(ctx::ThermoDiffContext)
+    deriv = Main.Models.ThermoDerivatives
+    T_fm = _theta_value(ctx.theta, :T_fm)
+    mu_fm = _theta_value(ctx.theta, :mu_fm)
+    xi = hasproperty(ctx.theta, :xi) ? Float64(getproperty(ctx.theta, :xi)) : 0.0
+    p_num = ctx.spec_override === nothing ? Main.Models.default_momentum_count() : Int(get(ctx.spec_override, :p_num, Main.Models.default_momentum_count()))
+    t_num = ctx.spec_override === nothing ? Main.Models.default_theta_count() : Int(get(ctx.spec_override, :t_num, Main.Models.default_theta_count()))
+    value = deriv.dP_dmu(T_fm, mu_fm; xi=xi, p_num=p_num, t_num=t_num, model=ctx.model)
+    return _finite_target_value(:dP_dmu, value)
+end
+
 const _DIFF_TARGET_REGISTRY = Dict{Symbol, DiffTarget}(
-    :pressure => DiffTarget(:pressure),
-    :entropy => DiffTarget(:entropy),
-    :rho_norm => DiffTarget(:rho_norm),
-    :energy => DiffTarget(:energy),
+    :pressure => DiffTarget(:pressure, _eval_pressure),
+    :entropy => DiffTarget(:entropy, _eval_entropy),
+    :rho_norm => DiffTarget(:rho_norm, _eval_rho_norm),
+    :energy => DiffTarget(:energy, _eval_energy),
+    :dP_dT => DiffTarget(:dP_dT, _eval_dP_dT),
+    :dP_dmu => DiffTarget(:dP_dmu, _eval_dP_dmu),
 )
 
 @inline function diff_target(name::Symbol)

--- a/src/models/solver/diff/Targets.jl
+++ b/src/models/solver/diff/Targets.jl
@@ -19,6 +19,20 @@ end
     return out
 end
 
+@inline function _resolve_target_xi(ctx::ThermoDiffContext)
+    if hasproperty(ctx.theta, :xi)
+        return _theta_value(ctx.theta, :xi)
+    end
+    if ctx.spec_override !== nothing && haskey(ctx.spec_override, :xi)
+        xi = Float64(get(ctx.spec_override, :xi, 0.0))
+        isfinite(xi) || throw(ArgumentError("spec_override.xi must be finite, got $(xi)"))
+        return xi
+    end
+    xi = Float64(ctx.result.xi)
+    isfinite(xi) || throw(ArgumentError("context result xi must be finite, got $(xi)"))
+    return xi
+end
+
 @inline _eval_pressure(ctx::ThermoDiffContext) = _finite_target_value(:pressure, ctx.result.pressure)
 @inline _eval_entropy(ctx::ThermoDiffContext) = _finite_target_value(:entropy, ctx.result.entropy)
 @inline _eval_rho_norm(ctx::ThermoDiffContext) = _finite_target_value(:rho_norm, ctx.result.rho_norm)
@@ -28,7 +42,7 @@ end
     deriv = Main.Models.ThermoDerivatives
     T_fm = _theta_value(ctx.theta, :T_fm)
     mu_fm = _theta_value(ctx.theta, :mu_fm)
-    xi = hasproperty(ctx.theta, :xi) ? Float64(getproperty(ctx.theta, :xi)) : 0.0
+    xi = _resolve_target_xi(ctx)
     p_num = ctx.spec_override === nothing ? Main.Models.default_momentum_count() : Int(get(ctx.spec_override, :p_num, Main.Models.default_momentum_count()))
     t_num = ctx.spec_override === nothing ? Main.Models.default_theta_count() : Int(get(ctx.spec_override, :t_num, Main.Models.default_theta_count()))
     value = deriv.dP_dT(T_fm, mu_fm; xi=xi, p_num=p_num, t_num=t_num, model=ctx.model)
@@ -39,7 +53,7 @@ end
     deriv = Main.Models.ThermoDerivatives
     T_fm = _theta_value(ctx.theta, :T_fm)
     mu_fm = _theta_value(ctx.theta, :mu_fm)
-    xi = hasproperty(ctx.theta, :xi) ? Float64(getproperty(ctx.theta, :xi)) : 0.0
+    xi = _resolve_target_xi(ctx)
     p_num = ctx.spec_override === nothing ? Main.Models.default_momentum_count() : Int(get(ctx.spec_override, :p_num, Main.Models.default_momentum_count()))
     t_num = ctx.spec_override === nothing ? Main.Models.default_theta_count() : Int(get(ctx.spec_override, :t_num, Main.Models.default_theta_count()))
     value = deriv.dP_dmu(T_fm, mu_fm; xi=xi, p_num=p_num, t_num=t_num, model=ctx.model)

--- a/tests/unit/models/solver/test_solver_diff_contract.jl
+++ b/tests/unit/models/solver/test_solver_diff_contract.jl
@@ -6,6 +6,55 @@ if !isdefined(Main, :Models)
     include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
 end
 
+@testset "solver diff jacobian numeric targets" begin
+    T_fm = 100.0 / 197.327
+    mu_fm = 0.0
+    model = Models.create_model(:PNJL)
+    mode = Models.FixedMu()
+    result = Models.solve(model, mode, T_fm, mu_fm; p_num=8, t_num=4, residual_norm_max=1e-6)
+
+    ctx = Models.build_thermo_diff_context(
+        result;
+        mode=mode,
+        model=model,
+        theta=(T_fm=T_fm, mu_fm=mu_fm, xi=0.0),
+        spec_override=(p_num=8, t_num=4, residual_norm_max=1e-6),
+    )
+
+    @testset "core targets become callable" begin
+        params = Models.ParamSpec([:T_fm])
+        for name in (:pressure, :entropy, :rho_norm, :energy)
+            target = Models.diff_target(name)
+            J = Models.jacobian(ctx, target, params)
+            @test size(J) == (1, 1)
+            @test isfinite(J[1, 1])
+        end
+    end
+
+    @testset "selected high-order response targets" begin
+        params = Models.ParamSpec([:T_fm])
+        for name in (:dP_dT, :dP_dmu)
+            target = Models.diff_target(name)
+            J = Models.jacobian(ctx, target, params)
+            @test size(J) == (1, 1)
+            @test isfinite(J[1, 1])
+        end
+    end
+
+    @testset "finite-difference check for pressure wrt T" begin
+        params = Models.ParamSpec([:T_fm])
+        target = Models.diff_target(:pressure)
+        J = Models.jacobian(ctx, target, params)
+
+        h = 1e-4
+        p_p = Models.solve(model, mode, T_fm + h, mu_fm; p_num=8, t_num=4, residual_norm_max=1e-6).pressure
+        p_m = Models.solve(model, mode, T_fm - h, mu_fm; p_num=8, t_num=4, residual_norm_max=1e-6).pressure
+        fd = (p_p - p_m) / (2h)
+
+        @test isapprox(J[1, 1], fd; rtol=1e-2, atol=1e-3)
+    end
+end
+
 @testset "solver diff contract scaffold" begin
     T_fm = 100.0 / 197.327
     mu_fm = 0.0
@@ -61,8 +110,9 @@ end
             theta=(T_fm=T_fm, mu_fm=mu_fm, xi=0.0),
         )
         params = Models.ParamSpec([:T_fm])
-
-        @test_throws ErrorException Models.jacobian(ctx, target, params)
+        J = Models.jacobian(ctx, target, params)
+        @test size(J) == (1, 1)
+        @test isfinite(J[1, 1])
     end
 
     @testset "jacobian shape convention" begin
@@ -115,12 +165,8 @@ end
             model=model,
             theta=(T_fm=T_fm, mu_fm=mu_fm, xi=0.0),
         )
-        err_msg = try
-            Models.jacobian(ctx_default, [target, target], params)
-            ""
-        catch err
-            sprint(showerror, err)
-        end
-        @test occursin("targets", err_msg)
+        Jd = Models.jacobian(ctx_default, [target, target], params)
+        @test size(Jd) == (2, 1)
+        @test all(isfinite, Jd)
     end
 end


### PR DESCRIPTION
## Summary
- implement Phase-1 numeric Jacobian path in `solver/diff` using finite-difference backend for `FixedMu` contexts with shape-safe `N×P` behavior
- wire callable evaluators for thermo core targets (`pressure`, `entropy`, `rho_norm`, `energy`) and selected high-order responses (`dP_dT`, `dP_dmu`)
- extend contract tests with executable numeric target checks, 1x1 guarantee, multi-parameter matrix shape checks, and finite-difference consistency for pressure-vs-temperature

## Validation
- `julia --project=. -e '"'"'ENV["'"'"'UNIT_FILES"'"'"']="'"'"'models/solver/test_solver_diff_contract.jl"'"'"'; include("'"'"'tests/unit/runtests.jl"'"'"')'`
- `julia --project=. -e '"'"'ENV["'"'"'UNIT_PROFILE"'"'"']="'"'"'smoke"'"'"'; include("'"'"'tests/unit/runtests.jl"'"'"')'`
- `julia --project=. -e '"'"'ENV["'"'"'UNIT_FILES"'"'"']="'"'"'models/workflow/test_manifest_extensions_234.jl"'"'"'; include("'"'"'tests/unit/runtests.jl"'"'"')'`
- `julia --project=. -e '"'"'ENV["'"'"'INTEGRATION_PROFILE"'"'"']="'"'"'smoke"'"'"'; include("'"'"'tests/integration/runtests.jl"'"'"')'`
- `julia --project=. scripts/dev/check_docs_consistency.jl`
- `julia --project=. scripts/dev/check_models_entry_contract.jl`

## Issue Closure
Closes #80