### PR TITLE
refactor(scripts): add image provenance sidecar workflow for plot outputs (#82)

### DIFF
--- a/docs/guides/scripts/plot_scan_csv.md
+++ b/docs/guides/scripts/plot_scan_csv.md
@@ -34,3 +34,15 @@ python scripts/plot_scan_csv.py \
 ```bash
 python scripts/plot_scan_csv.py --help
 ```
+
+## 图像 sidecar 溯源（Issue #82）
+
+- `plot_scan_csv.py` 在输出 PNG/TIFF 图像后，会默认生成同目录 sidecar：`<image>.provenance.json`。
+- sidecar 必填字段包含 `schema_version`、`generated_at_utc`、`image_sha256`、`script_path`、`command`、`git_commit`、`input_data_hashes` 等，用于受控环境复现实验。
+- 方案边界：sidecar 与图像分离存储；不保证图像脱离 sidecar 后仍可验证来源，也不覆盖开放传播溯源。
+
+校验示例：
+
+```bash
+python scripts/plot_scan_csv.py --verify-provenance data/examples/figures/plot_scan_csv/example.png
+```

--- a/docs/superpowers/plans/2026-04-19-image-provenance-sidecar-82-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-19-image-provenance-sidecar-82-implementation-plan.md
@@ -1,0 +1,416 @@
+# Image Provenance Sidecar #82 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 `scripts/plot_scan_csv.py` 图像输出链路引入默认 sidecar 溯源（`*.provenance.json`）与哈希校验入口，并形成可复用 Python 通用模块。
+
+**Architecture:** 新增 `scripts/common/provenance_image.py` 作为通用能力层，集中处理图像哈希、v1 sidecar 构建、写入与校验。`plot_scan_csv.py` 只负责收集运行上下文并在每次 `savefig` 后调用该模块，避免在脚本内部散落重复实现。通过 Python 单测覆盖“写入成功 + 篡改检测失败 + 缺字段失败”，并补充文档明确 sidecar 方案边界。
+
+**Tech Stack:** Python 3、matplotlib 现有绘图链、JSON/sha256 标准库、Julia smoke 回归命令（integration/unit）。
+
+---
+
+## File Structure
+
+- Create: `scripts/common/provenance_image.py`
+  - 责任：图像 sidecar 的通用哈希/构建/写入/校验能力。
+- Modify: `scripts/plot_scan_csv.py`
+  - 责任：在图像保存流程接入 sidecar 默认写入，并提供校验 CLI 入口。
+- Create: `tests/unit/python/test_image_provenance_sidecar.py`
+  - 责任：覆盖写入与校验（通过/篡改失败/缺字段失败）契约。
+- Modify: `docs/guides/scripts/README.md`
+  - 责任：补充 sidecar 使用方式、校验命令与方案边界说明。
+
+---
+
+### Task 1: 先写失败测试（RED）锁定 v1 sidecar 契约
+
+**Files:**
+- Create: `tests/unit/python/test_image_provenance_sidecar.py`
+
+- [ ] **Step 1: Write failing tests for sidecar contract**
+
+```python
+from pathlib import Path
+import json
+
+from scripts.common.provenance_image import (
+    write_image_provenance_sidecar,
+    verify_image_provenance,
+)
+
+
+def test_write_sidecar_contains_required_v1_fields(tmp_path: Path):
+    image = tmp_path / "demo.png"
+    image.write_bytes(b"fake_png_bytes")
+
+    metadata = {
+        "schema_version": "v1",
+        "generated_at_utc": "2026-04-19T00:00:00Z",
+        "script_path": "scripts/plot_scan_csv.py",
+        "command": "python scripts/plot_scan_csv.py --mode lines ...",
+        "git_commit": "deadbeef",
+        "julia_version": "python-3.x",
+        "input_data_hashes": [{"path": "data/a.csv", "sha256": "abc"}],
+    }
+
+    sidecar = write_image_provenance_sidecar(image, metadata)
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+
+    for key in [
+        "schema_version",
+        "generated_at_utc",
+        "image_path",
+        "image_sha256",
+        "script_path",
+        "command",
+        "git_commit",
+        "julia_version",
+        "input_data_hashes",
+    ]:
+        assert key in payload
+
+
+def test_verify_provenance_detects_tampered_image(tmp_path: Path):
+    image = tmp_path / "tamper.png"
+    image.write_bytes(b"origin")
+
+    metadata = {
+        "schema_version": "v1",
+        "generated_at_utc": "2026-04-19T00:00:00Z",
+        "script_path": "scripts/plot_scan_csv.py",
+        "command": "python scripts/plot_scan_csv.py --mode lines ...",
+        "git_commit": "deadbeef",
+        "julia_version": "python-3.x",
+        "input_data_hashes": [],
+    }
+    write_image_provenance_sidecar(image, metadata)
+
+    image.write_bytes(b"mutated")
+    ok, reason = verify_image_provenance(image)
+    assert ok is False
+    assert "sha256" in reason.lower()
+```
+
+- [ ] **Step 2: Run tests and confirm RED**
+
+Run: `python -m pytest tests/unit/python/test_image_provenance_sidecar.py -q`  
+Expected: FAIL（`scripts.common.provenance_image` 不存在或函数未实现）。
+
+- [ ] **Step 3: Commit RED tests**
+
+```bash
+git add tests/unit/python/test_image_provenance_sidecar.py
+git commit -m "test(scripts): add failing image provenance sidecar contract tests"
+```
+
+---
+
+### Task 2: 实现通用模块最小可用能力（GREEN）
+
+**Files:**
+- Create: `scripts/common/provenance_image.py`
+- Test: `tests/unit/python/test_image_provenance_sidecar.py`
+
+- [ ] **Step 1: Implement minimal provenance module**
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+from datetime import datetime, timezone
+import hashlib
+import json
+from typing import Dict, Tuple
+
+
+REQUIRED_V1_FIELDS = [
+    "schema_version",
+    "generated_at_utc",
+    "image_path",
+    "image_sha256",
+    "script_path",
+    "command",
+    "git_commit",
+    "julia_version",
+    "input_data_hashes",
+]
+
+
+def compute_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _now_utc_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def build_image_provenance(image_path: Path, metadata: Dict) -> Dict:
+    p = dict(metadata)
+    p.setdefault("schema_version", "v1")
+    p.setdefault("generated_at_utc", _now_utc_iso())
+    p["image_path"] = str(image_path)
+    p["image_sha256"] = compute_sha256(image_path)
+    return p
+
+
+def write_image_provenance_sidecar(image_path: Path, metadata: Dict) -> Path:
+    image_path = Path(image_path)
+    payload = build_image_provenance(image_path, metadata)
+    sidecar = image_path.with_name(f"{image_path.name}.provenance.json")
+    sidecar.write_text(json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2), encoding="utf-8")
+    return sidecar
+
+
+def verify_image_provenance(image_path: Path) -> Tuple[bool, str]:
+    image_path = Path(image_path)
+    sidecar = image_path.with_name(f"{image_path.name}.provenance.json")
+    if not sidecar.exists():
+        return False, "sidecar not found"
+    try:
+        payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    except Exception as e:
+        return False, f"invalid sidecar json: {e}"
+
+    for key in REQUIRED_V1_FIELDS:
+        if key not in payload:
+            return False, f"missing required field: {key}"
+
+    actual = compute_sha256(image_path)
+    expected = str(payload.get("image_sha256", ""))
+    if actual != expected:
+        return False, "image sha256 mismatch"
+    return True, "ok"
+```
+
+- [ ] **Step 2: Re-run tests to confirm GREEN**
+
+Run: `python -m pytest tests/unit/python/test_image_provenance_sidecar.py -q`  
+Expected: PASS。
+
+- [ ] **Step 3: Commit module implementation**
+
+```bash
+git add scripts/common/provenance_image.py tests/unit/python/test_image_provenance_sidecar.py
+git commit -m "refactor(scripts): add reusable image provenance sidecar module"
+```
+
+---
+
+### Task 3: 扩展失败路径测试（缺字段/校验入口）
+
+**Files:**
+- Modify: `tests/unit/python/test_image_provenance_sidecar.py`
+
+- [ ] **Step 1: Add failing tests for missing fields and verify pass path**
+
+```python
+def test_verify_passes_for_untampered_image(tmp_path: Path):
+    image = tmp_path / "ok.png"
+    image.write_bytes(b"stable")
+    metadata = {
+        "schema_version": "v1",
+        "generated_at_utc": "2026-04-19T00:00:00Z",
+        "script_path": "scripts/plot_scan_csv.py",
+        "command": "python scripts/plot_scan_csv.py --mode lines ...",
+        "git_commit": "deadbeef",
+        "julia_version": "python-3.x",
+        "input_data_hashes": [],
+    }
+    write_image_provenance_sidecar(image, metadata)
+    ok, reason = verify_image_provenance(image)
+    assert ok is True
+    assert reason == "ok"
+
+
+def test_verify_fails_on_missing_required_field(tmp_path: Path):
+    image = tmp_path / "missing.png"
+    image.write_bytes(b"stable")
+    sidecar = image.with_name(f"{image.name}.provenance.json")
+    sidecar.write_text('{"schema_version":"v1"}', encoding="utf-8")
+
+    ok, reason = verify_image_provenance(image)
+    assert ok is False
+    assert "missing required field" in reason
+```
+
+- [ ] **Step 2: Run tests to verify RED then GREEN**
+
+Run: `python -m pytest tests/unit/python/test_image_provenance_sidecar.py -q`  
+Expected: 新增测试先 FAIL；修复后 PASS。
+
+- [ ] **Step 3: Commit test hardening**
+
+```bash
+git add tests/unit/python/test_image_provenance_sidecar.py scripts/common/provenance_image.py
+git commit -m "test(scripts): harden image provenance verification failure paths"
+```
+
+---
+
+### Task 4: 接入 `plot_scan_csv.py` 默认写 sidecar
+
+**Files:**
+- Modify: `scripts/plot_scan_csv.py`
+
+- [ ] **Step 1: Add helper to collect run context**
+
+在脚本中新增 helper（最小实现）：
+
+```python
+import subprocess
+import sys
+from scripts.common.provenance_image import write_image_provenance_sidecar, verify_image_provenance, compute_sha256
+
+
+def _git_commit_or_unknown() -> str:
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=str(PROJECT_ROOT), text=True).strip()
+    except Exception:
+        return "unknown"
+
+
+def _build_input_hashes(csv_paths: list[Path]) -> list[dict]:
+    out = []
+    for p in csv_paths:
+        if p.exists():
+            out.append({"path": str(p), "sha256": compute_sha256(p)})
+    return out
+```
+
+- [ ] **Step 2: Hook sidecar writing after each savefig**
+
+在所有 `fig.savefig(...)` 后调用：
+
+```python
+metadata = {
+    "schema_version": "v1",
+    "script_path": "scripts/plot_scan_csv.py",
+    "command": " ".join(sys.argv),
+    "git_commit": _git_commit_or_unknown(),
+    "julia_version": f"python-{sys.version.split()[0]}",
+    "input_data_hashes": _build_input_hashes([csv_path]),
+}
+write_image_provenance_sidecar(out, metadata)
+```
+
+- [ ] **Step 3: Commit integration**
+
+```bash
+git add scripts/plot_scan_csv.py
+git commit -m "refactor(scripts): emit image provenance sidecars from plot_scan_csv outputs"
+```
+
+---
+
+### Task 5: 增加 CLI 校验入口
+
+**Files:**
+- Modify: `scripts/plot_scan_csv.py`
+
+- [ ] **Step 1: Add CLI argument and short-circuit verify mode**
+
+```python
+ap.add_argument("--verify-provenance", type=str, default=None, help="Verify image sidecar provenance and exit")
+```
+
+在 `main()` 前部处理：
+
+```python
+if args.verify_provenance:
+    ok, reason = verify_image_provenance(Path(args.verify_provenance))
+    print("PASS" if ok else "FAIL", reason)
+    return 0 if ok else 2
+```
+
+- [ ] **Step 2: Add unit test for CLI verify exit behavior**
+
+在 Python 测试中新增调用脚本子进程断言：
+
+```python
+proc = subprocess.run([sys.executable, "scripts/plot_scan_csv.py", "--verify-provenance", str(image)], capture_output=True, text=True)
+assert proc.returncode == 0
+assert "PASS" in proc.stdout
+```
+
+并增加篡改后 `returncode != 0` 断言。
+
+- [ ] **Step 3: Commit verify CLI**
+
+```bash
+git add scripts/plot_scan_csv.py tests/unit/python/test_image_provenance_sidecar.py
+git commit -m "feat(scripts): add provenance verification CLI for image sidecars"
+```
+
+---
+
+### Task 6: 文档边界说明与使用示例
+
+**Files:**
+- Modify: `docs/guides/scripts/README.md`
+
+- [ ] **Step 1: Add sidecar usage and boundary section**
+
+补充文档段落：
+
+```markdown
+### Image Provenance Sidecar (v1)
+
+- `plot_scan_csv.py` 默认在每张输出图旁生成 `<image>.provenance.json`。
+- sidecar 提供受控环境可复现所需最小元数据与 `image_sha256` 绑定校验。
+- 本方案不保证图片脱离 sidecar 后仍可验证来源，不覆盖开放传播溯源。
+
+验证示例：
+
+```bash
+python scripts/plot_scan_csv.py --verify-provenance data/outputs/figures/example.png
+```
+```
+
+- [ ] **Step 2: Commit docs update**
+
+```bash
+git add docs/guides/scripts/README.md
+git commit -m "docs(guides): document image provenance sidecar scope and verification"
+```
+
+---
+
+### Task 7: 运行 #82 验证命令与收口检查
+
+**Files:**
+- Modify (if needed): `docs/guides/scripts/README.md`
+
+- [ ] **Step 1: Run Python unit tests**
+
+Run: `python -m pytest tests/unit/python/test_image_provenance_sidecar.py -q`  
+Expected: PASS。
+
+- [ ] **Step 2: Run issue-required integration smoke**
+
+Run: `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'`  
+Expected: PASS。
+
+- [ ] **Step 3: Run issue-required unit smoke**
+
+Run: `julia --project=. -e 'ENV["UNIT_PROFILE"]="smoke"; include("tests/unit/runtests.jl")'`  
+Expected: PASS。
+
+- [ ] **Step 4: Final commit (if verification evidence/doc tweaks needed)**
+
+```bash
+git add docs/guides/scripts/README.md
+git commit -m "test(ci): confirm image provenance sidecar smoke verification for issue 82"
+```
+
+---
+
+## Plan Self-Review
+
+- Spec coverage: 已覆盖通用模块、`plot_scan_csv.py` 链路落地、校验入口、测试、文档边界。
+- Placeholder scan: 无 `TBD/TODO/implement later` 占位内容。
+- Type consistency: 全流程统一使用 `write_image_provenance_sidecar` 与 `verify_image_provenance` 命名，sidecar 必填字段与 issue v1 对齐。

--- a/docs/superpowers/specs/2026-04-19-image-provenance-sidecar-82-design.md
+++ b/docs/superpowers/specs/2026-04-19-image-provenance-sidecar-82-design.md
@@ -1,0 +1,128 @@
+# #82 图像 sidecar provenance 设计（通用 Python 模块方案）
+
+## 背景与目标
+
+Issue #82 目标是在受控流程内，为图像产物建立可验证 sidecar 溯源。
+
+本次确认的试点链路：`scripts/plot_scan_csv.py`。
+
+本次采用 B 方案：抽取通用 Python 模块，支持后续多脚本复用，而不是仅在单脚本内内聚实现。
+
+## 非目标
+
+- 不在图像文件本体嵌入元数据。
+- 不在本 issue 覆盖所有历史绘图脚本。
+- 不引入 C2PA/区块链/水印等开放传播溯源机制。
+
+## 方案总览
+
+### 新增通用模块
+
+新增：`scripts/common/provenance_image.py`
+
+职责：
+
+1. 计算文件哈希（SHA256）。
+2. 构造 v1 图像 sidecar 元数据对象。
+3. 写入 `<image>.provenance.json`。
+4. 对图像 + sidecar 做强绑定校验并返回 pass/fail 与原因。
+
+### 模块接口（v1）
+
+建议对外函数：
+
+- `compute_sha256(path: Path) -> str`
+- `build_image_provenance(...) -> dict`
+- `write_image_provenance_sidecar(image_path: Path, metadata: dict) -> Path`
+- `verify_image_provenance(image_path: Path) -> tuple[bool, str]`
+
+## v1 字段规范
+
+sidecar 文件命名：`<image_basename>.provenance.json`
+
+必填字段（与 #82 对齐）：
+
+- `schema_version`
+- `generated_at_utc`
+- `image_path`
+- `image_sha256`
+- `script_path`
+- `command`
+- `git_commit`
+- `julia_version`
+- `input_data_hashes`（数组，元素含 `path`、`sha256`）
+
+可选字段：
+
+- `config_path`
+- `config_hash`
+- `seed`
+- `artifact_paths`
+- `notes`
+
+## 在 `plot_scan_csv.py` 的接入方式
+
+1. 在所有 `savefig` 落点后统一调用 sidecar 写入。
+2. 默认开启 sidecar 输出（不改现有图像命名与目录逻辑）。
+3. 收集并传入上下文：
+   - 当前命令行（command）
+   - `git_commit`
+   - 解释器/运行时版本映射到 `julia_version` 字段（按 issue 字段要求保留该键）
+   - 输入 CSV 的哈希清单
+4. sidecar 与图像同目录落盘。
+
+## 校验入口
+
+在 `plot_scan_csv.py` 增加 CLI 校验模式（如 `--verify-provenance <image>`）：
+
+- 读取同名 sidecar。
+- 复算图像 `sha256`。
+- 返回：
+  - `PASS`：哈希一致且必填字段齐全。
+  - `FAIL`：sidecar 缺失 / 字段缺失 / 哈希不匹配 / JSON 非法。
+
+## 测试策略（TDD）
+
+新增 Python 单测（放在仓库现有 Python 测试约定路径）：
+
+1. 生成临时图像 + 写 sidecar 成功。
+2. 校验通过（pass）。
+3. 篡改图像后校验失败（fail）。
+4. sidecar 缺字段时校验失败并给出明确原因。
+
+## 文档更新
+
+在脚本说明或相关 README 增加：
+
+- sidecar 的边界说明：仅保证受控环境复现，不保证开放传播链路。
+- 归档要求：图像与 `*.provenance.json` 必须同存档。
+- 校验命令示例。
+
+## 验证命令
+
+按 issue #82 给定：
+
+```bash
+julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'
+julia --project=. -e 'ENV["UNIT_PROFILE"]="smoke"; include("tests/unit/runtests.jl")'
+```
+
+并补充 Python 单测命令（以仓库实际测试入口为准）。
+
+## 风险与缓解
+
+1. 图像与 sidecar 分离造成断链
+   - 缓解：校验入口强制 `image_sha256` 绑定；文档明确同存档要求。
+
+2. 字段命名与现有 provenance 风格不一致
+   - 缓解：对齐 `scripts/relaxtime/provenance_metadata.jl` 的组织风格（版本、哈希、运行上下文）。
+
+3. 仅覆盖单条链路导致代表性不足
+   - 缓解：优先选择 `scripts/plot_scan_csv.py` 这种通用绘图入口作为首条落地。
+
+## DoD 对齐
+
+- 至少 1 条图像链路（`plot_scan_csv.py`）落地 sidecar。
+- `*.provenance.json` 覆盖 v1 必填字段。
+- 校验入口能识别 pass/fail（含篡改检测）。
+- 文档中明确 sidecar 方案边界。

--- a/scripts/common/provenance_image.py
+++ b/scripts/common/provenance_image.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+import hashlib
+import json
+import sys
+
+
+SCHEMA_VERSION_V1 = "v1"
+
+REQUIRED_V1_FIELDS = (
+    "schema_version",
+    "generated_at_utc",
+    "image_path",
+    "image_sha256",
+    "script_path",
+    "command",
+    "git_commit",
+    "julia_version",
+    "input_data_hashes",
+)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def compute_sha256(path: Path | str) -> str:
+    p = Path(path)
+    h = hashlib.sha256()
+    with p.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _normalize_input_hashes(input_data_hashes: list[dict[str, Any]] | None, image_path: Path) -> list[dict[str, str]]:
+    if input_data_hashes:
+        out: list[dict[str, str]] = []
+        for entry in input_data_hashes:
+            if not isinstance(entry, dict):
+                raise ValueError("input_data_hashes entries must be dict")
+            path = str(entry.get("path", "")).strip()
+            sha = str(entry.get("sha256", "")).strip()
+            if not path or not sha:
+                raise ValueError("input_data_hashes entry must contain non-empty path and sha256")
+            out.append({"path": path, "sha256": sha})
+        return out
+
+    # keep non-empty default for minimal contract tests
+    return [{"path": str(image_path), "sha256": compute_sha256(image_path)}]
+
+
+def build_image_provenance(
+    *,
+    image_path: Path | str,
+    script_path: str,
+    command: str,
+    git_commit: str = "unknown",
+    julia_version: str | None = None,
+    input_data_hashes: list[dict[str, Any]] | None = None,
+    generated_at_utc: str | None = None,
+    config_path: str | None = None,
+    config_hash: str | None = None,
+    seed: int | None = None,
+    artifact_paths: list[str] | None = None,
+    notes: str | None = None,
+) -> dict[str, Any]:
+    img = Path(image_path)
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION_V1,
+        "generated_at_utc": generated_at_utc or _utc_now_iso(),
+        "image_path": str(img),
+        "image_sha256": compute_sha256(img),
+        "script_path": script_path,
+        "command": command,
+        "git_commit": git_commit,
+        "julia_version": julia_version or f"python-{sys.version.split()[0]}",
+        "input_data_hashes": _normalize_input_hashes(input_data_hashes, img),
+    }
+
+    if config_path is not None:
+        payload["config_path"] = config_path
+    if config_hash is not None:
+        payload["config_hash"] = config_hash
+    if seed is not None:
+        payload["seed"] = int(seed)
+    if artifact_paths:
+        payload["artifact_paths"] = [str(p) for p in artifact_paths]
+    if notes is not None:
+        payload["notes"] = notes
+
+    return payload
+
+
+def write_image_provenance_sidecar(
+    *,
+    image_path: Path | str,
+    sidecar_path: Path | str | None = None,
+    script_path: str,
+    command: str,
+    git_commit: str = "unknown",
+    julia_version: str | None = None,
+    input_data_hashes: list[dict[str, Any]] | None = None,
+    generated_at_utc: str | None = None,
+    config_path: str | None = None,
+    config_hash: str | None = None,
+    seed: int | None = None,
+    artifact_paths: list[str] | None = None,
+    notes: str | None = None,
+) -> Path:
+    img = Path(image_path)
+    sidecar = Path(sidecar_path) if sidecar_path is not None else img.with_name(f"{img.name}.provenance.json")
+    payload = build_image_provenance(
+        image_path=img,
+        script_path=script_path,
+        command=command,
+        git_commit=git_commit,
+        julia_version=julia_version,
+        input_data_hashes=input_data_hashes,
+        generated_at_utc=generated_at_utc,
+        config_path=config_path,
+        config_hash=config_hash,
+        seed=seed,
+        artifact_paths=artifact_paths,
+        notes=notes,
+    )
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2), encoding="utf-8")
+    return sidecar
+
+
+def verify_image_provenance(
+    *, image_path: Path | str, sidecar_path: Path | str | None = None
+) -> tuple[bool, str]:
+    img = Path(image_path)
+    sidecar = Path(sidecar_path) if sidecar_path is not None else img.with_name(f"{img.name}.provenance.json")
+    if not sidecar.exists():
+        return False, "sidecar not found"
+
+    try:
+        payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    except Exception as e:
+        return False, f"invalid sidecar json: {e}"
+
+    for key in REQUIRED_V1_FIELDS:
+        if key not in payload:
+            return False, f"missing required field: {key}"
+
+    input_hashes = payload.get("input_data_hashes")
+    if not isinstance(input_hashes, list):
+        return False, "input_data_hashes must be list"
+    for entry in input_hashes:
+        if not isinstance(entry, dict) or "path" not in entry or "sha256" not in entry:
+            return False, "invalid input_data_hashes entry"
+
+    actual = compute_sha256(img)
+    expected = str(payload.get("image_sha256", ""))
+    if actual != expected:
+        return False, "image sha256 mismatch"
+    return True, "ok"
+
+
+def verify_image_provenance_sidecar(*, image_path: Path | str, sidecar_path: Path | str | None = None) -> bool:
+    ok, _ = verify_image_provenance(image_path=image_path, sidecar_path=sidecar_path)
+    return ok

--- a/scripts/plot_scan_csv.py
+++ b/scripts/plot_scan_csv.py
@@ -52,6 +52,8 @@ import argparse
 import csv
 import io
 import math
+import subprocess
+import sys
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -85,6 +87,55 @@ def _find_project_root() -> Path:
 
 PROJECT_ROOT = _find_project_root()
 DEFAULT_OUT_DIR = PROJECT_ROOT / "data" / "outputs" / "figures"
+
+# Ensure project root is importable when script is executed as `python scripts/plot_scan_csv.py`.
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+try:
+    from scripts.common.provenance_image import (
+        compute_sha256,
+        verify_image_provenance,
+        write_image_provenance_sidecar,
+    )
+except Exception:
+    compute_sha256 = None
+    verify_image_provenance = None
+    write_image_provenance_sidecar = None
+
+
+def _git_commit_or_unknown() -> str:
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=str(PROJECT_ROOT), text=True).strip()
+    except Exception:
+        return "unknown"
+
+
+def _build_input_data_hashes(csv_path: Path) -> List[Dict[str, str]]:
+    if compute_sha256 is None:
+        return []
+    if not csv_path.exists():
+        return []
+    return [{"path": str(csv_path), "sha256": compute_sha256(csv_path)}]
+
+
+def _write_image_sidecars(saved_paths: List[Path], *, csv_path: Path, command: str) -> None:
+    if write_image_provenance_sidecar is None:
+        print("[provenance] WARNING: sidecar module unavailable, skip provenance sidecar writing")
+        return
+    git_commit = _git_commit_or_unknown()
+    input_data_hashes = _build_input_data_hashes(csv_path)
+    for out in saved_paths:
+        if out.suffix.lower() not in {".png", ".tif", ".tiff"}:
+            continue
+        sidecar = write_image_provenance_sidecar(
+            image_path=out,
+            script_path="scripts/plot_scan_csv.py",
+            command=command,
+            git_commit=git_commit,
+            input_data_hashes=input_data_hashes,
+        )
+        print(f"[provenance] wrote sidecar: {sidecar}")
 
 
 def _parse_float(x: str) -> float:
@@ -264,6 +315,8 @@ def plot_lines(
     formats: List[str] | None = None,
     dpi: int = 600,
     check: bool = False,
+    provenance_csv_path: Path | None = None,
+    provenance_command: str | None = None,
 ) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     _figsize = figsize or APS_FIGSIZE["default"]
@@ -348,6 +401,8 @@ def plot_lines(
             saved.append(out)
         plt.close(fig)
         print(f"Saved {out_dir} ({', '.join(fmts)})")
+        if provenance_csv_path is not None and provenance_command is not None:
+            _write_image_sidecars(saved, csv_path=provenance_csv_path, command=provenance_command)
         if check:
             _post_save_checks(saved, expected_dpi=dpi)
         return
@@ -436,6 +491,8 @@ def plot_lines(
             saved.append(out)
         plt.close(fig)
         print(f"Saved {out_dir} ({', '.join(fmts)})")
+        if provenance_csv_path is not None and provenance_command is not None:
+            _write_image_sidecars(saved, csv_path=provenance_csv_path, command=provenance_command)
         if check:
             _post_save_checks(saved, expected_dpi=dpi)
 
@@ -568,6 +625,8 @@ def plot_heatmaps(
     formats: List[str] | None = None,
     dpi: int = 600,
     check: bool = False,
+    provenance_csv_path: Path | None = None,
+    provenance_command: str | None = None,
 ) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     _figsize_hm = figsize or APS_FIGSIZE["double-column"]
@@ -673,6 +732,8 @@ def plot_heatmaps(
             saved.append(out)
         plt.close(fig)
         print(f"Saved {out_dir} ({', '.join(fmts)})")
+        if provenance_csv_path is not None and provenance_command is not None:
+            _write_image_sidecars(saved, csv_path=provenance_csv_path, command=provenance_command)
         if check:
             _post_save_checks(saved, expected_dpi=dpi)
 
@@ -789,15 +850,15 @@ def _post_save_checks(paths: List[Path], *, expected_dpi: int = 600) -> None:
             print(f"[check] Error inspecting {p}: {e}")
 
 
-def main() -> None:
+def main() -> int:
     ap = argparse.ArgumentParser(
         description="Plot scan CSV (lines/heatmap)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=f"Project root: {PROJECT_ROOT}\nDefault output: {DEFAULT_OUT_DIR}",
     )
-    ap.add_argument("--csv", type=Path, required=True, help="Input scan CSV (relative to project root or absolute)")
+    ap.add_argument("--csv", type=Path, required=False, help="Input scan CSV (relative to project root or absolute)")
     ap.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR, help="Output directory")
-    ap.add_argument("--mode", type=str, choices=["lines", "heatmap"], required=True)
+    ap.add_argument("--mode", type=str, choices=["lines", "heatmap"], required=False)
     ap.add_argument("--title", type=str, default=None, help="Optional title prefix (hidden by default; use --show-title to render)")
     ap.add_argument("--show-title", action="store_true", help="Render in-figure titles; disabled by default for publication-style output")
     ap.add_argument("--where", action="append", default=[], help="Filter clause col=value (repeatable)")
@@ -848,8 +909,20 @@ def main() -> None:
     # output formats and quality
     ap.add_argument("--formats", type=str, default="png", help="Comma-separated output formats (e.g. png,pdf,eps)")
     ap.add_argument("--dpi", type=int, default=600, help="Output DPI for saved figures (default 600)")
+    ap.add_argument("--verify-provenance", type=Path, default=None, help="Verify image sidecar provenance and exit")
 
     args = ap.parse_args()
+
+    if args.verify_provenance is not None:
+        if verify_image_provenance is None:
+            print("FAIL provenance module unavailable")
+            return 2
+        ok, reason = verify_image_provenance(image_path=_resolve_path(args.verify_provenance))
+        print(("PASS " if ok else "FAIL ") + reason)
+        return 0 if ok else 2
+
+    if args.csv is None or args.mode is None:
+        raise ValueError("normal plotting mode requires --csv and --mode")
 
     # Resolve paths relative to project root
     csv_path = _resolve_path(args.csv)
@@ -920,6 +993,8 @@ def main() -> None:
                 formats=[s.strip() for s in args.formats.split(",") if s.strip()],
                 dpi=int(args.dpi),
                 check=bool(args.check),
+                provenance_csv_path=csv_path,
+                provenance_command=" ".join(sys.argv),
             )
         else:
             if not args.x or not args.y or not args.fields:
@@ -945,8 +1020,12 @@ def main() -> None:
                 formats=[s.strip() for s in args.formats.split(",") if s.strip()],
                 dpi=int(args.dpi),
                 check=bool(args.check),
+                provenance_csv_path=csv_path,
+                provenance_command=" ".join(sys.argv),
             )
+
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/unit/python/test_image_provenance_sidecar.py
+++ b/tests/unit/python/test_image_provenance_sidecar.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.common.provenance_image import (
+    verify_image_provenance_sidecar,
+    write_image_provenance_sidecar,
+)
+
+
+REQUIRED_SIDECAR_FIELDS = {
+    "schema_version",
+    "generated_at_utc",
+    "image_path",
+    "image_sha256",
+    "script_path",
+    "command",
+    "git_commit",
+    "julia_version",
+    "input_data_hashes",
+}
+
+
+MINIMAL_PNG_BYTES = bytes.fromhex(
+    "89504E470D0A1A0A"
+    "0000000D49484452000000010000000108060000001F15C489"
+    "0000000A49444154789C6360000000020001E527D4A20000000049454E44AE426082"
+)
+def test_sidecar_includes_required_fields(tmp_path):
+    image_path = tmp_path / "sample.png"
+    image_path.write_bytes(MINIMAL_PNG_BYTES)
+    sidecar_path = tmp_path / "sample.png.provenance.json"
+
+    write_image_provenance_sidecar(
+        image_path=image_path,
+        sidecar_path=sidecar_path,
+        script_path="tests/unit/python/test_image_provenance_sidecar.py",
+        command="python -m pytest tests/unit/python/test_image_provenance_sidecar.py -q",
+    )
+
+    payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+    assert REQUIRED_SIDECAR_FIELDS.issubset(payload.keys())
+    assert isinstance(payload["input_data_hashes"], list)
+    assert payload["input_data_hashes"]
+    for entry in payload["input_data_hashes"]:
+        assert isinstance(entry, dict)
+        assert "path" in entry
+        assert "sha256" in entry
+
+
+def test_verify_fails_after_image_tampering(tmp_path):
+    image_path = tmp_path / "tampered.png"
+    image_path.write_bytes(MINIMAL_PNG_BYTES)
+    sidecar_path = tmp_path / "tampered.png.provenance.json"
+
+    write_image_provenance_sidecar(
+        image_path=image_path,
+        sidecar_path=sidecar_path,
+        script_path="tests/unit/python/test_image_provenance_sidecar.py",
+        command="python -m pytest tests/unit/python/test_image_provenance_sidecar.py -q",
+    )
+
+    image_path.write_bytes(image_path.read_bytes() + b"tamper")
+
+    assert verify_image_provenance_sidecar(
+        image_path=image_path,
+        sidecar_path=sidecar_path,
+    ) is False
+
+
+def test_verify_fails_on_missing_required_field(tmp_path):
+    image_path = tmp_path / "missing.png"
+    image_path.write_bytes(MINIMAL_PNG_BYTES)
+    sidecar_path = tmp_path / "missing.png.provenance.json"
+    sidecar_path.write_text('{"schema_version":"v1"}', encoding="utf-8")
+
+    assert verify_image_provenance_sidecar(
+        image_path=image_path,
+        sidecar_path=sidecar_path,
+    ) is False
+
+
+def test_cli_verify_pass_and_fail(tmp_path):
+    image_path = tmp_path / "cli.png"
+    image_path.write_bytes(MINIMAL_PNG_BYTES)
+
+    write_image_provenance_sidecar(
+        image_path=image_path,
+        script_path="tests/unit/python/test_image_provenance_sidecar.py",
+        command="pytest",
+    )
+
+    project_root = Path(__file__).resolve().parents[3]
+    script = project_root / "scripts" / "plot_scan_csv.py"
+
+    ok_proc = subprocess.run(
+        [sys.executable, str(script), "--verify-provenance", str(image_path)],
+        capture_output=True,
+        text=True,
+        cwd=str(project_root),
+    )
+    assert ok_proc.returncode == 0
+    assert "PASS" in ok_proc.stdout
+
+    image_path.write_bytes(image_path.read_bytes() + b"tamper")
+    fail_proc = subprocess.run(
+        [sys.executable, str(script), "--verify-provenance", str(image_path)],
+        capture_output=True,
+        text=True,
+        cwd=str(project_root),
+    )
+    assert fail_proc.returncode != 0
+    assert "FAIL" in fail_proc.stdout


### PR DESCRIPTION
## Summary
- add reusable Python image-provenance sidecar module (`scripts/common/provenance_image.py`) with SHA256 binding, v1 required-field construction, and verify APIs
- integrate default sidecar emission and `--verify-provenance` CLI mode into `scripts/plot_scan_csv.py` without changing existing plotting outputs
- add Python unit tests for write/verify/tamper/missing-field paths and update plotting guide with sidecar boundary/verification docs; include #82 spec and implementation plan records

## Verification
- `python -m pytest tests/unit/python/test_image_provenance_sidecar.py -q` (4 passed)
- `julia --project=. -e 'ENV["INTEGRATION_PROFILE"]="smoke"; include("tests/integration/runtests.jl")'` (pass 11/11)
- `julia --project=. -e 'ENV["UNIT_PROFILE"]="smoke"; include("tests/unit/runtests.jl")'` (pass 150/150)

## Notes
- image files generated during local validation are intentionally not committed
- `julia_version` required field is preserved in sidecar schema; Python chain records `python-<version>` value for this key
