### PR TITLE
feat(relaxtime): promote meson density AD derivative reference chain

### DIFF
--- a/benchmark/relaxtime/README.md
+++ b/benchmark/relaxtime/README.md
@@ -18,6 +18,8 @@
 - `test_total_cross_section_performance.jl`：总截面完整链路性能测试（可选“完整计算”开关）。
 - `test_average_scattering_rate_performance.jl`：平均散射率的轻量性能烟囱测试。
 - `bench_bu_double_integral_phase_e3.jl`：Phase E3 最小 BU 双积分点计算基准，拆分平衡态求解与后续双积分成本。
+- `bench_meson_density_ad_diagnostic_chain.jl`：介子数密度 AD 诊断链基准，拆分平衡点求解、AD 诊断点与正式 phase-shift density 单点成本。
+- `bench_meson_density_generic_signature_overhead.jl`：`dδ/dω` 关键 helper 从 `Float64` 签名放宽为 Dual-compatible generic 后，在普通 `Float64` 调用下的微观开销对比。
 
 ## 运行
 

--- a/benchmark/relaxtime/bench_meson_density_ad_diagnostic_chain.jl
+++ b/benchmark/relaxtime/bench_meson_density_ad_diagnostic_chain.jl
@@ -1,0 +1,162 @@
+#!/usr/bin/env julia
+
+# Benchmark: meson-density AD diagnostic chain
+#
+# Goals:
+# - Measure absolute cost of the workflow-level AD diagnostic point.
+# - Measure relative cost share against equilibrium solve and meson-density point workflow.
+# - Provide a stable baseline before promoting AD as production dδ/dω derivative path.
+#
+# Run:
+#   julia --project=benchmark benchmark/relaxtime/bench_meson_density_ad_diagnostic_chain.jl
+#
+# Optional env knobs:
+#   BENCH_MD_AD_T_MEV=210.0
+#   BENCH_MD_AD_XI=0.0
+#   BENCH_MD_AD_Q=0.5
+#   BENCH_MD_AD_OMEGA=0.6
+#   BENCH_MD_AD_FD_STEP=1e-5
+#   BENCH_MD_AD_EQ_SAMPLES=8
+#   BENCH_MD_AD_DIAG_SAMPLES=8
+#   BENCH_MD_AD_DENSITY_SAMPLES=6
+#   BENCH_MD_AD_FULL_SAMPLES=5
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", ".."))
+const BENCH_ENV = normpath(joinpath(@__DIR__, ".."))
+
+pushfirst!(LOAD_PATH, PROJECT_ROOT)
+pushfirst!(LOAD_PATH, BENCH_ENV)
+
+using BenchmarkTools
+using Printf
+
+include(joinpath(PROJECT_ROOT, "src", "constants", "Constants_PNJL.jl"))
+include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+
+using .Constants_PNJL: ħc_MeV_fm
+using .Models: solve_gap_and_meson_point,
+               solve_phase_shift_point_diagnostic_from_meson_point,
+               solve_phase_shift_meson_density_from_meson_point,
+               solve_gap_and_phase_shift_meson_density_point
+
+const T_MEV = parse(Float64, get(ENV, "BENCH_MD_AD_T_MEV", "210.0"))
+const XI = parse(Float64, get(ENV, "BENCH_MD_AD_XI", "0.0"))
+const Q0 = parse(Float64, get(ENV, "BENCH_MD_AD_Q", "0.5"))
+const OMEGA0 = parse(Float64, get(ENV, "BENCH_MD_AD_OMEGA", "0.6"))
+const FD_STEP = parse(Float64, get(ENV, "BENCH_MD_AD_FD_STEP", "1e-5"))
+
+const EQ_SAMPLES = parse(Int, get(ENV, "BENCH_MD_AD_EQ_SAMPLES", "8"))
+const DIAG_SAMPLES = parse(Int, get(ENV, "BENCH_MD_AD_DIAG_SAMPLES", "8"))
+const DENSITY_SAMPLES = parse(Int, get(ENV, "BENCH_MD_AD_DENSITY_SAMPLES", "6"))
+const FULL_SAMPLES = parse(Int, get(ENV, "BENCH_MD_AD_FULL_SAMPLES", "5"))
+
+const T_FM = T_MEV / ħc_MeV_fm
+
+function build_equilibrium_point()
+    return solve_gap_and_meson_point(
+        T_FM,
+        0.0;
+        xi=XI,
+        p_num=12,
+        t_num=6,
+    )
+end
+
+const EQ_POINT = build_equilibrium_point()
+
+function ad_diag_post_equilibrium()
+    return solve_phase_shift_point_diagnostic_from_meson_point(
+        EQ_POINT;
+        mesons=(:pi,),
+        q_values=[Q0],
+        omega_values=[OMEGA0],
+        scheme=:current,
+        fd_step=FD_STEP,
+    )
+end
+
+function density_post_equilibrium()
+    return solve_phase_shift_meson_density_from_meson_point(
+        EQ_POINT;
+        scheme=:current,
+    )
+end
+
+function density_full_point()
+    return solve_gap_and_phase_shift_meson_density_point(
+        T_FM,
+        0.0;
+        xi=XI,
+        p_num=12,
+        t_num=6,
+    )
+end
+
+function summarize_trial(name::String, trial::BenchmarkTools.Trial)
+    estimate = median(trial)
+    return (
+        name=name,
+        time_ms=estimate.time / 1.0e6,
+        memory_kib=estimate.memory / 1024.0,
+        allocs=estimate.allocs,
+    )
+end
+
+function print_summary(summary)
+    @printf("%-38s %10.3f ms %10.1f KiB %8d allocs\n",
+        summary.name, summary.time_ms, summary.memory_kib, summary.allocs)
+end
+
+function register_suite!()
+    isdefined(Main, :SUITE) || return nothing
+    Main.SUITE["relaxtime"]["meson_density_equilibrium_point"] =
+        @benchmarkable build_equilibrium_point() evals=1
+    Main.SUITE["relaxtime"]["meson_density_ad_diag_post_eq"] =
+        @benchmarkable ad_diag_post_equilibrium() evals=1
+    Main.SUITE["relaxtime"]["meson_density_phase_shift_post_eq"] =
+        @benchmarkable density_post_equilibrium() evals=1
+    Main.SUITE["relaxtime"]["meson_density_phase_shift_full_point"] =
+        @benchmarkable density_full_point() evals=1
+    return nothing
+end
+
+function run_report()
+    # warmup
+    ad_diag_post_equilibrium()
+    density_post_equilibrium()
+    density_full_point()
+
+    eq_trial = @benchmark build_equilibrium_point() samples=EQ_SAMPLES evals=1
+    diag_trial = @benchmark ad_diag_post_equilibrium() samples=DIAG_SAMPLES evals=1
+    density_trial = @benchmark density_post_equilibrium() samples=DENSITY_SAMPLES evals=1
+    full_trial = @benchmark density_full_point() samples=FULL_SAMPLES evals=1
+
+    println("Meson-density AD diagnostic benchmark")
+    println(repeat("=", 88))
+    @printf("T=%.1f MeV, xi=%.3f, q=%.3f, omega=%.3f, fd_step=%g\n\n",
+        T_MEV, XI, Q0, OMEGA0, FD_STEP)
+
+    print_summary(summarize_trial("equilibrium meson point", eq_trial))
+    print_summary(summarize_trial("AD diagnostic post-equilibrium", diag_trial))
+    print_summary(summarize_trial("phase-shift density post-equilibrium", density_trial))
+    print_summary(summarize_trial("full phase-shift density point", full_trial))
+
+    eq_t = median(eq_trial).time
+    diag_t = median(diag_trial).time
+    density_t = median(density_trial).time
+    full_t = median(full_trial).time
+
+    println("\nRelative share")
+    println(repeat("-", 88))
+    @printf("AD diagnostic / equilibrium point: %.2f%%\n", 100 * diag_t / eq_t)
+    @printf("AD diagnostic / full density point: %.2f%%\n", 100 * diag_t / full_t)
+    @printf("post-eq density / full density point: %.2f%%\n", 100 * density_t / full_t)
+    @printf("equilibrium / full density point: %.2f%%\n", 100 * eq_t / full_t)
+    return nothing
+end
+
+register_suite!()
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    run_report()
+end

--- a/benchmark/relaxtime/bench_meson_density_ad_diagnostic_chain.jl
+++ b/benchmark/relaxtime/bench_meson_density_ad_diagnostic_chain.jl
@@ -157,6 +157,6 @@ end
 
 register_suite!()
 
-if abspath(PROGRAM_FILE) == @__FILE__
+if abspath(PROGRAM_FILE) == abspath(@__FILE__)
     run_report()
 end

--- a/benchmark/relaxtime/bench_meson_density_generic_signature_overhead.jl
+++ b/benchmark/relaxtime/bench_meson_density_generic_signature_overhead.jl
@@ -133,6 +133,6 @@ function run_report()
     return nothing
 end
 
-if abspath(PROGRAM_FILE) == @__FILE__
+if abspath(PROGRAM_FILE) == abspath(@__FILE__)
     run_report()
 end

--- a/benchmark/relaxtime/bench_meson_density_generic_signature_overhead.jl
+++ b/benchmark/relaxtime/bench_meson_density_generic_signature_overhead.jl
@@ -1,0 +1,138 @@
+#!/usr/bin/env julia
+
+# Benchmark: generic signature overhead on meson-density AD key path
+#
+# Goals:
+# - Isolate the cost of widening selected key-path helper signatures from Float64-only
+#   to Dual-compatible generic methods.
+# - Compare current production generic helpers against local Float64-shadow versions
+#   with equivalent formulas.
+#
+# Run:
+#   julia --project=benchmark benchmark/relaxtime/bench_meson_density_generic_signature_overhead.jl
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", ".."))
+const BENCH_ENV = normpath(joinpath(@__DIR__, ".."))
+
+pushfirst!(LOAD_PATH, PROJECT_ROOT)
+pushfirst!(LOAD_PATH, BENCH_ENV)
+
+using BenchmarkTools
+using Printf
+
+include(joinpath(PROJECT_ROOT, "src", "constants", "Constants_PNJL.jl"))
+include(joinpath(PROJECT_ROOT, "src", "QuarkDistribution_Aniso.jl"))
+
+using .PNJLQuarkDistributions_Aniso: quark_df_dE, antiquark_df_dE, correction_cos_theta_coefficient
+
+const E0 = 1.2
+const P0 = 0.9
+const M0 = 0.32
+const MU0 = 0.1
+const T0 = 0.18
+const PHI0 = 0.25
+const PHIBAR0 = 0.25
+const XI0 = 0.1
+const SAMPLES = parse(Int, get(ENV, "BENCH_MD_GENERIC_SAMPLES", "30"))
+
+@inline function _float_exp_clamped(x::Float64)
+    return exp(clamp(x, -460.0, 460.0))
+end
+
+@inline function quark_df_dE_float(E_inv_fm::Float64, μ_inv_fm::Float64, T_inv_fm::Float64, Φ::Float64, Φbar::Float64)
+    β_fm = 1 / T_inv_fm
+    exp_term = _float_exp_clamped(-(E_inv_fm - μ_inv_fm) * β_fm)
+    exp_term2 = exp_term * exp_term
+    exp_term3 = exp_term2 * exp_term
+
+    numerator = Φ * exp_term + 2 * Φbar * exp_term2 + exp_term3
+    denominator = 1 + 3 * Φ * exp_term + 3 * Φbar * exp_term2 + exp_term3
+    d_numerator = -(Φ * exp_term + 4 * Φbar * exp_term2 + 3 * exp_term3)
+    d_denominator = -(3 * Φ * exp_term + 6 * Φbar * exp_term2 + 3 * exp_term3)
+
+    df_dx = d_numerator * denominator - numerator * d_denominator
+    df_dx /= denominator ^ 2
+    return β_fm * df_dx
+end
+
+@inline function antiquark_df_dE_float(E_inv_fm::Float64, μ_inv_fm::Float64, T_inv_fm::Float64, Φ::Float64, Φbar::Float64)
+    β_fm = 1 / T_inv_fm
+    exp_term = _float_exp_clamped(-(E_inv_fm + μ_inv_fm) * β_fm)
+    exp_term2 = exp_term * exp_term
+    exp_term3 = exp_term2 * exp_term
+
+    numerator = Φbar * exp_term + 2 * Φ * exp_term2 + exp_term3
+    denominator = 1 + 3 * Φbar * exp_term + 3 * Φ * exp_term2 + exp_term3
+    d_numerator = -(Φbar * exp_term + 4 * Φ * exp_term2 + 3 * exp_term3)
+    d_denominator = -(3 * Φbar * exp_term + 6 * Φ * exp_term2 + 3 * exp_term3)
+
+    df_dx = d_numerator * denominator - numerator * d_denominator
+    df_dx /= denominator ^ 2
+    return β_fm * df_dx
+end
+
+@inline function correction_cos_theta_coefficient_float(
+    sign_::Symbol, p_inv_fm::Float64, m_inv_fm::Float64,
+    μ_inv_fm::Float64, T_inv_fm::Float64, Φ::Float64, Φbar::Float64, ξ::Float64)
+    E_inv_fm = sqrt(p_inv_fm^2 + m_inv_fm^2)
+    coeff = 0.5 * ξ * (p_inv_fm^2) / E_inv_fm
+    df_dE = sign_ === :quark ?
+        quark_df_dE_float(E_inv_fm, μ_inv_fm, T_inv_fm, Φ, Φbar) :
+        antiquark_df_dE_float(E_inv_fm, μ_inv_fm, T_inv_fm, Φ, Φbar)
+    return coeff * df_dE
+end
+
+function summarize_trial(name::String, trial::BenchmarkTools.Trial)
+    estimate = median(trial)
+    return (
+        name=name,
+        time_ns=estimate.time,
+        memory_bytes=estimate.memory,
+        allocs=estimate.allocs,
+    )
+end
+
+function print_pair(label::String, generic_summary, float_summary)
+    ratio = generic_summary.time_ns / float_summary.time_ns
+    @printf("%-28s generic=%10.1f ns  float=%10.1f ns  ratio=%6.3f  alloc=%d/%d\n",
+        label,
+        generic_summary.time_ns,
+        float_summary.time_ns,
+        ratio,
+        generic_summary.allocs,
+        float_summary.allocs,
+    )
+end
+
+function run_report()
+    # warmup
+    quark_df_dE(E0, MU0, T0, PHI0, PHIBAR0)
+    quark_df_dE_float(E0, MU0, T0, PHI0, PHIBAR0)
+    antiquark_df_dE(E0, MU0, T0, PHI0, PHIBAR0)
+    antiquark_df_dE_float(E0, MU0, T0, PHI0, PHIBAR0)
+    correction_cos_theta_coefficient(:quark, P0, M0, MU0, T0, PHI0, PHIBAR0, XI0)
+    correction_cos_theta_coefficient_float(:quark, P0, M0, MU0, T0, PHI0, PHIBAR0, XI0)
+
+    q_generic = @benchmark quark_df_dE($E0, $MU0, $T0, $PHI0, $PHIBAR0) samples=SAMPLES evals=1
+    q_float = @benchmark quark_df_dE_float($E0, $MU0, $T0, $PHI0, $PHIBAR0) samples=SAMPLES evals=1
+
+    aq_generic = @benchmark antiquark_df_dE($E0, $MU0, $T0, $PHI0, $PHIBAR0) samples=SAMPLES evals=1
+    aq_float = @benchmark antiquark_df_dE_float($E0, $MU0, $T0, $PHI0, $PHIBAR0) samples=SAMPLES evals=1
+
+    corr_generic = @benchmark correction_cos_theta_coefficient(:quark, $P0, $M0, $MU0, $T0, $PHI0, $PHIBAR0, $XI0) samples=SAMPLES evals=1
+    corr_float = @benchmark correction_cos_theta_coefficient_float(:quark, $P0, $M0, $MU0, $T0, $PHI0, $PHIBAR0, $XI0) samples=SAMPLES evals=1
+
+    println("Meson-density generic signature overhead benchmark")
+    println(repeat("=", 88))
+    println("Compare current generic helpers vs local Float64-shadow formulas")
+    println()
+
+    print_pair("quark_df_dE", summarize_trial("quark_df_dE_generic", q_generic), summarize_trial("quark_df_dE_float", q_float))
+    print_pair("antiquark_df_dE", summarize_trial("antiquark_df_dE_generic", aq_generic), summarize_trial("antiquark_df_dE_float", aq_float))
+    print_pair("correction_coeff", summarize_trial("correction_generic", corr_generic), summarize_trial("correction_float", corr_float))
+    return nothing
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    run_report()
+end

--- a/docs/dev/active/2026-04-30_介子数密度与BU工作流任务单.md
+++ b/docs/dev/active/2026-04-30_介子数密度与BU工作流任务单.md
@@ -254,6 +254,15 @@
     - `current` 近似 BU workflow：默认正式生产主线
     - `generalized BU` workflow：可重复运行的 stricter reference / analysis branch
   - generalized BU 当前不升格为默认主线，但应继续保留为正式 workflow / scan 契约的一部分，供后续论文对照直接复用
+  - 当前 AD 方向判断已固定为：
+    - `Re/Im D -> dδ/dω` 公式路线本身可 AD
+    - 当前生产阻碍主要来自 `PolarizationAniso` / `OneLoopIntegrals` / `MesonPropagator` 上的类型签名与 helper 锁定
+    - 若后续要把 `dδ/dω` 从有限差分升级到 AD，优先做 `B0 -> polarization -> propagator` 的最小 Dual 兼容收口，而不是直接对 `unwrap(arg D)` 做 AD
+    - 相关正式收口说明：`docs/dev/active/2026-05-03_PhaseE5_AD导数口径升格说明.md`
+  - `2026-05-03` 当前实施结论：
+    - Stage1/2 已完成到“正式 `xi = 0` 生产链可接受 `Dual`”
+    - `xi != 0` 的各向异性修正链已完成当前固定点 workflow probe 口径下的 Dual 兼容收口（`108/108` 样点通过）；但这不等于整个各向异性 transport / distribution 栈已全面 generic 化
+    - Stage3（以 AD 替换生产有限差分）暂不直接升格，待做 production AD-vs-FD 对点比较后再决定
 
 ### Phase F：数值扫描与图
 

--- a/docs/dev/active/2026-05-03_PhaseE5_AD导数口径升格说明.md
+++ b/docs/dev/active/2026-05-03_PhaseE5_AD导数口径升格说明.md
@@ -1,0 +1,282 @@
+# Phase E5 AD 导数口径升格说明
+
+更新日期：2026-05-03
+
+目的：在介子数密度 `dδ/dω` 这条链上，正式说明为什么后续生产实现应优先认可自动微分（AD）导数口径，而不是继续把有限差分（FD）当作默认真值口径；同时明确后续 generic 化推进策略与门禁。
+
+相关文档：
+
+- [2026-05-03_介子数密度dδdω最小生产级Dual兼容设计.md](./2026-05-03_%E4%BB%8B%E5%AD%90%E6%95%B0%E5%AF%86%E5%BA%A6d%CE%B4d%CF%89%E6%9C%80%E5%B0%8F%E7%94%9F%E4%BA%A7%E7%BA%A7Dual%E5%85%BC%E5%AE%B9%E8%AE%BE%E8%AE%A1.md)
+- [2026-04-30_介子数密度与BU工作流任务单.md](./2026-04-30_%E4%BB%8B%E5%AD%90%E6%95%B0%E5%AF%86%E5%BA%A6%E4%B8%8EBU%E5%B7%A5%E4%BD%9C%E6%B5%81%E4%BB%BB%E5%8A%A1%E5%8D%95.md)
+
+---
+
+## 1. 当前结论
+
+当前已经具备把 `dδ/dω` 的生产导数口径收敛到 AD 的证据。
+
+补充边界说明：
+
+- 当前正式 `phase_shift_meson_number_density` / `phase_shift_meson_density_summary`
+  主线并不直接使用 `dδ/dω`；
+- 当前正式产出 workflow 走的是 **分部积分后的 weighted-phase 形式**；
+- 因此这里讨论的“`dδ/dω` 升格到 AD”，当前首先对应的是：
+  - 正式参考诊断链；
+  - 以及后续若重新启用导数形式 workflow / helper 时，应默认采用 AD 而不是 FD。
+
+更准确地说：
+
+1. `Re/Im D -> dδ/dω` 解析公式路线可 AD；
+2. 该路线已通过正式 workflow 入口挂接固定点诊断；
+3. `xi = 0` 与当前固定点集下的 `xi != 0` 都已可跑通；
+4. AD 与解析公式之间保持机器精度级一致性；
+5. FD 与 AD 的显著差异，当前更合理地解释为“导数契约不同”，而不是 AD 实现错误。
+
+因此，后续如果要把生产上的 `dδ/dω` 从 FD 升级，默认应以 **AD 口径** 为准，而不是要求 AD 去拟合当前 FD 数值。
+
+---
+
+## 2. 已有证据链
+
+### 2.1 analysis-only probe
+
+已有两类 analysis-only probe：
+
+- 最小公式 probe：
+  - `scripts/analysis/relaxtime/probe_meson_phase_shift_ad_minimal.jl`
+- 真实微栈 probe：
+  - `scripts/analysis/relaxtime/probe_meson_phase_shift_ad_realstack_k0.jl`
+
+这两类 probe 已证明：
+
+1. 不是公式本身不可微；
+2. 也不是 `B0 -> polarization -> propagator` 结构天然不适合 AD；
+3. 当前主要阻碍是生产实现中的类型锁定与 helper 细节。
+
+### 2.2 workflow-level fixed-point probe
+
+当前已挂上正式 workflow 诊断入口：
+
+- `Models.solve_phase_shift_point_diagnostic_from_meson_point`
+
+配套脚本：
+
+- `scripts/analysis/relaxtime/probe_phase_shift_point_ad_vs_fd_workflow.jl`
+
+输出：
+
+- `data/outputs/results/relaxtime/analysis/meson_density_phase_point_ad_vs_fd.csv`
+- `data/outputs/results/relaxtime/analysis/meson_density_phase_point_ad_vs_fd_summary.md`
+
+当前固定点集：
+
+- `T = 208, 210, 212 MeV`
+- `xi = 0.0, 0.1`
+- `q = 0.0, 0.5, 1.0`
+- `omega = 0.3, 0.6, 1.0`
+- `meson = pi, K`
+
+结果：
+
+- successful rows = `108`
+- failed rows = `0`
+
+---
+
+## 3. 为什么当前应认可 AD，而不是继续以 FD 为真值
+
+### 3.1 AD 与解析公式严格一致
+
+workflow probe 显示：
+
+- `dphase_formula_abs_diff` 保持在机器精度量级
+
+这说明：
+
+```math
+\frac{d\delta}{d\omega}
+=
+\frac{\operatorname{Re}D \, d(\operatorname{Im}D)/d\omega
+- \operatorname{Im}D \, d(\operatorname{Re}D)/d\omega}
+{(\operatorname{Re}D)^2 + (\operatorname{Im}D)^2}
+```
+
+这条链在当前实现中是自洽的。
+
+因此，从“公式一致性”角度，AD 已经具备升格条件。
+
+### 3.2 FD 与 AD 的差异并不主要来自 `atan` 分支
+
+当前已经确认：
+
+1. 不只是 `dphase_ad` 与 `dphase_raw_fd` 不同；
+2. 连 `dReD/dω`、`dImD/dω` 的 AD 与 FD 也会显著不同。
+
+这说明问题不应再表述为：
+
+- “AD 没有正确处理 `arg` 的 branch”
+
+而应更准确地表述为：
+
+- AD 和 FD 当前在计算的，是**不同导数契约**。
+
+### 3.3 当前最合理的契约解释
+
+当前更合理的解释是：
+
+1. AD 作用在现有实现上时，得到的是
+   - **冻结奇点定位 / 分段区间 / 求积拓扑后的局部导数**
+2. FD 则会把
+   - `omega` 改变引起的区间漂移、
+   - 奇点位置漂移、
+   - piecewise integration 拓扑变化
+   一并采样进去
+
+因此：
+
+- `AD != FD` 并不自动表示 AD 错了；
+- 反而说明我们需要先把“生产上到底认可哪一种导数契约”说清楚。
+
+当前项目判断是：
+
+- 生产上应认可 AD 这条更清晰、可复用、可治理的导数链。
+
+---
+
+## 4. 当前 generic 化推进策略
+
+用户提出的推进方式：
+
+1. 先锁定关键路径
+2. 对关键路径先放宽签名
+3. 立即用 workflow fixed-point probe 回归
+4. 看新爆点在哪里，再继续最小修补
+
+当前判断：**可以，而且适合这条支线继续采用。**
+
+但需要准确命名：
+
+- 这更像 **受控的 compatibility campaign / spike**
+- 而不是严格意义上的 TDD
+
+原因是这里的主要不确定性不是业务行为，而是：
+
+1. 哪些 helper 会把 `Dual` 压回 `Float64`
+2. 哪些奇点 / 分段 / 求积辅助逻辑会暴露更深层类型锁定
+3. generic 化后数值语义是否仍对应当前认可的导数契约
+
+所以这条路可以继续走，但前提是：
+
+- 必须每一轮都配套 workflow probe 回归
+- 不能只做“签名放宽”而不看数值语义
+
+---
+
+## 5. 为什么这条方法比“helper 小补丁驱动”更干净
+
+如果关键路径已经明确，那么优先放宽关键函数的类型边界，通常比被动地在下游 helper 上逐个打补丁更一致。
+
+理由有三条：
+
+1. **代码边界更清楚**
+   - 哪一层允许 `Dual`，会直接体现在函数签名上；
+   - 比“下游不断补 `Float64 -> T`”更容易读懂。
+2. **回归路径更统一**
+   - 每次 generic 化后都走同一套 workflow fixed-point probe；
+   - 不需要为每个小 helper 单独发明验证逻辑。
+3. **更容易暴露真正的公共阻塞点**
+   - 例如 `correction_cos_theta_coefficient` 这种深层函数；
+   - 如果一开始只做零散补丁，往往更晚才暴露它们。
+
+因此，对这条支线而言，后续更推荐：
+
+- **关键路径优先的窄范围 generic 化**
+
+而不是：
+
+- **helper 级零散补丁优先**
+
+---
+
+## 6. 主要风险与当前门禁
+
+### 6.1 主要风险不是正确性，而是性能回退
+
+在当前阶段，最大的工程风险已经不是“会不会再报错”，而是：
+
+- 泛型化会不会让 meson-density / workflow 级计算出现明显性能退化
+
+因此，后续 generic 化推进的主门禁，应优先放在：
+
+- **benchmark / timing 对比**
+
+而不是继续拿 FD 结果当数值真值。
+
+### 6.2 建议的性能门禁
+
+后续每推进一轮 generic 化，至少检查两层：
+
+1. **绝对耗时**
+   - 单次 `phase_shift_point_diagnostic`
+   - 单次 meson-density 单点 helper
+2. **相对占比**
+   - 在 meson-density workflow 中，
+   - `dδ/dω` 相关链路的时间占比是否出现明显放大
+
+当前已补的基准入口：
+
+- `benchmark/relaxtime/bench_meson_density_ad_diagnostic_chain.jl`
+  - `equilibrium meson point`
+  - `AD diagnostic post-equilibrium`
+  - `phase-shift density post-equilibrium`
+  - `full phase-shift density point`
+
+当前首轮基准（`T=210 MeV, xi=0, q=0.5, omega=0.6`）结果：
+
+- `equilibrium meson point`: `4166.636 ms`
+- `AD diagnostic post-equilibrium`: `0.072 ms`
+- `phase-shift density post-equilibrium`: `37.571 ms`
+- `full phase-shift density point`: `4487.063 ms`
+
+对应相对占比：
+
+- `AD diagnostic / full density point`: 约 `0.00%`
+- `post-eq density / full density point`: 约 `0.84%`
+- `equilibrium / full density point`: 约 `92.86%`
+
+这说明在当前基线下：
+
+1. AD 诊断链本身不是主性能瓶颈；
+2. meson-density workflow 的主要耗时仍在 equilibrium / meson-point 求解；
+3. 因而把 `dδ/dω` 从 FD 升格到 AD，当前没有看到明显的一阶性能障碍。
+
+若性能变化不明显，说明这条 generic 化路径可以继续推进。
+
+若性能明显回退，再决定是否：
+
+1. 只保留诊断链 AD；
+2. 或对热点 helper 做更细的类型/分配优化。
+
+---
+
+## 7. 当前升格判断
+
+当前可以把结论收口为：
+
+1. `phase_shift_point_diagnostic` 这条 AD 证据链已经足以升格为正式参考诊断链；
+2. 生产上的 `dδ/dω` 后续应以 AD 口径为目标收敛；
+3. 后续 generic 化推进可以优先采用“关键路径先放宽签名，再用 workflow probe 收敛爆点”的方法；
+4. 该方法当前的主门禁不再是 FD 对齐，而是性能回退是否可接受。
+
+---
+
+## 8. 下一步建议
+
+建议按下面顺序继续：
+
+1. 把当前 AD 诊断链保留为正式 reference workflow 证据层；
+2. 选择 `dδ/dω` 生产替换所经过的关键路径，继续做窄范围 generic 化；
+3. 增加最小 benchmark：
+   - `phase_shift_point_diagnostic`
+   - meson-density 单点 helper
+4. 若 benchmark 通过，再决定是否进入“生产 FD -> AD 替换”。

--- a/docs/dev/active/2026-05-03_介子数密度dδdω最小生产级Dual兼容设计.md
+++ b/docs/dev/active/2026-05-03_介子数密度dδdω最小生产级Dual兼容设计.md
@@ -1,0 +1,446 @@
+# 介子数密度 `dδ/dω` 最小生产级 Dual 兼容设计
+
+更新日期：2026-05-03
+
+> 目的：在不改现有 meson-density workflow 契约的前提下，为后续把 `dδ/dω` 从有限差分升级到 AD 做最小生产级兼容设计。
+
+---
+
+## 1. 当前结论
+
+基于两轮 probe，当前可以把问题收束为：
+
+- `Re/Im D -> dδ/dω` 公式路线本身可 AD
+- analysis-only 的真实微栈 `B0(k=0) -> polarization_with_width -> propagator` 也可 AD
+- 当前生产阻碍不是 BU 公式本身，而是 `relaxtime` 这条实现链上的类型签名与 helper 锁定
+
+当前已有证据：
+
+- 最小公式 probe：
+  - `scripts/analysis/relaxtime/probe_meson_phase_shift_ad_minimal.jl`
+- 真实微栈 probe：
+  - `scripts/analysis/relaxtime/probe_meson_phase_shift_ad_realstack_k0.jl`
+
+---
+
+## 2. 设计目标
+
+本轮只追求以下目标：
+
+- 让生产实现中与 `dδ/dω` 直接相关的最小路径接受 `ForwardDiff.Dual`
+- 保持现有 workflow 入口、scan 入口、结果字段与治理分工不变
+- 不把全仓一口气泛型化
+
+更具体地说：
+
+- 目标口径：
+  - `current` BU workflow 仍是默认生产主线
+  - generalized BU workflow 仍是 stricter reference
+  - 这里只为 `dδ/dω` 的实现方式升级做底层兼容准备
+
+---
+
+## 3. 非目标
+
+本轮明确不做：
+
+- 不修改 meson-density workflow 的对外签名
+- 不把 `A(...)` 强行改成对 `ω` 的 AD 路径
+- 不处理 mixed meson propagator 的 Dual 兼容
+- 不处理完整 `Complex{Dual}` 复极点求解链
+- 不直接把所有 `Float64` 签名在全仓替换成泛型
+- 不改变 strict BW / current BU / generalized BU 的物理定义
+
+---
+
+## 4. 为什么 `A(...)` 不在最小改造范围内
+
+在当前 `dδ/dω` 计算中，导数变量是 `ω`。
+
+而 `A1_value` / `A2_value` 是在给定：
+
+- `m1, m2`
+- `T`
+- `μ`
+- `Φ, Φbar`
+
+后预计算的常量，对 `ω` 不再变化。
+
+因此：
+
+- `A(...)` 可以继续保持当前 `Float64` 风格
+- 只要 `B0(λ, q, ...)` 与其上层组合能接受 `Dual`，就足以支撑
+  `Re D(ω,q)` / `Im D(ω,q)` 的 AD
+
+这也是 probe 已经给出的明确结论。
+
+---
+
+## 5. 最小生产级改造边界
+
+### 5.1 必改模块
+
+#### A. `src/relaxtime/PolarizationAniso.jl`
+
+最关键入口：
+
+- `polarization_with_width`
+
+建议改造方式：
+
+- 新增或放宽为 `where {T<:Real}` 风格
+- 允许 `k0::T`
+- 允许内部 `λ = k0 + μ1 - μ2` 为 `Dual`
+- 返回 `(polarization_real::T, polarization_imag::T)` 的自然推断类型
+
+本轮不建议动：
+
+- `polarization_aniso`
+- `polarization_complex`
+
+除非在实际接线时发现它们也被 `dδ/dω` 主链直接依赖。
+
+#### B. `src/relaxtime/MesonPropagator.jl`
+
+最关键入口：
+
+- `meson_propagator_simple`
+
+建议改造方式：
+
+- 把 `Π::ComplexF64` 放宽为 `Π::Complex{T} where T<:Real`
+- `_isfinite_complex` 也放宽到 `Complex{T}`
+- `denom` 的数值保护改为类型保持的写法，避免把 `Dual` 压回 `Float64`
+
+这一层是低风险改动，因为 simple propagator 公式非常短。
+
+#### C. `src/relaxtime/OneLoopIntegrals.jl`
+
+这是最需要克制范围的地方。
+
+本轮只建议围绕 `B0` 主链做最小放宽：
+
+- `B0`
+- `tilde_B0`
+- `tilde_B0_k_zero`
+- `tilde_B0_k_positive`
+- `real_integrand_k_zero`
+- `real_integrand_k_positive`
+- `energy_cutoff`
+- `internal_momentum`
+- `distribution_value_b0`
+
+其中变量角色要分清：
+
+- `λ` 需要支持 `Dual`
+- `k` 在 meson-density 双积分中是外部扫描变量，当前可以继续 `Float64`
+- `m, μ, T, Φ, Φbar` 当前也可以继续 `Float64`
+
+因此目标不是“全参数泛型化”，而是更窄的：
+
+- 让 `λ` 可为 `T<:Real`
+- 其余参数优先保留现有 `Float64`
+
+这会显著降低改动面。
+
+### 5.2 暂不改模块
+
+#### A. `src/integration/IntervalQuadratureStrategies.jl`
+
+当前这里大量签名仍是：
+
+- `a::Float64`
+- `b::Float64`
+- 返回 `0.0`
+
+但在最小生产级方案里，可以先不立即改全套 hybrid 求积 helper，原因是：
+
+- 对 `dδ/dω` 的 AD，真正需要变的是 integrand 对 `λ(ω)` 的依赖
+- 积分区间端点 `a,b` 仍可保持 `Float64`
+- Julia 闭包 `f(x::Float64)` 返回 `Dual` 时，求积器理论上可以累加 `Dual`
+
+所以这里先做的不是“大改签名”，而是先验证：
+
+- 现有 `integrate_hybrid_interval` 是否仅因 `total = 0.0` 等实现细节压坏 `Dual`
+
+如果会压坏，再做最小修正：
+
+- 让 `total` 从首个有效积分值推断类型，或
+- 用 `zero(typeof(v))` 初始化
+
+也就是说，`IntervalQuadratureStrategies` 只在被证明确实阻塞时才进入本轮改动。
+
+#### B. `A(...)` 与其节点权重接口
+
+当前不动。
+
+#### C. mixed propagator / mixing matrix
+
+当前不动。
+
+---
+
+## 6. 推荐实施顺序
+
+### Stage 1: 只打通 `k=0` 生产路径
+
+目标：
+
+- 正式 `B0 -> polarization_with_width -> meson_propagator_simple` 可以吃 `Dual`
+- 先在 `k=0`、非奇点样点上跑通单点 AD smoke
+
+意义：
+
+- 对接前面 analysis-only probe
+- 改动最小
+- 最容易看清生产代码中真正的 blocker
+
+验收：
+
+- 新增一个 unit / integration smoke
+- 直接对正式实现中的 `Re D(ω)` 或 `Im D(ω)` 做 `ForwardDiff.derivative`
+
+### Stage 2: 扩到 `k>0` 的生产 `B0`
+
+目标：
+
+- 覆盖 meson-density 当前双积分实际使用的 `q>0` 常规路径
+
+这一步很可能会把最小修改推进到：
+
+- `real_integrand_k_positive`
+- `integrate_piecewise_hybrid`
+- `integrate_hybrid_interval`
+
+验收：
+
+- 在一个 meson-density 单点 helper 上
+  `ForwardDiff.derivative(reD_fun, ω0)` 可直接运行
+
+### Stage 3: 再决定是否替换生产中的有限差分
+
+---
+
+## 7. 2026-05-03 当前实验收口
+
+本轮已经把 analysis-only 的 workflow 固定点 probe 挂上：
+
+- `scripts/analysis/relaxtime/probe_phase_shift_point_ad_vs_fd_workflow.jl`
+- 输出：
+  - `data/outputs/results/relaxtime/analysis/meson_density_phase_point_ad_vs_fd.csv`
+  - `data/outputs/results/relaxtime/analysis/meson_density_phase_point_ad_vs_fd_summary.md`
+
+### 7.1 已确认的正面结果
+
+- `phase_shift_point_diagnostic` 已经通过正式 workflow 入口暴露：
+  - `Models.solve_phase_shift_point_diagnostic_from_meson_point`
+- `xi = 0` 主链上，`ReD/ImD`、`phase`、`weighted_phase` 的 AD 诊断可稳定输出
+- `xi != 0` 的一部分样点也已可跑通
+- `dphase_formula_abs_diff` 在 workflow probe 中保持机器精度量级
+
+这说明：
+
+- `Re/Im D -> dδ/dω` 解析公式本身没有问题
+- 当前 AD 结果在“冻结当前实现积分拓扑”的意义下是自洽的
+
+### 7.2 已暴露的核心限制
+
+workflow probe 同时证明：当前若直接推动“整体泛型化”，会遇到两类不同层次的问题。
+
+#### A. 深层各向异性 helper 曾存在 Float64-only 签名残留
+
+本轮已最小 generic 化：
+
+- `src/QuarkDistribution_Aniso.jl`
+  - `quark_df_dE`
+  - `antiquark_df_dE`
+  - `correction_cos_theta_coefficient`
+
+generic 化后，当前 workflow probe 固定点集：
+
+- `T = 208, 210, 212 MeV`
+- `xi = 0.0, 0.1`
+- `q = 0.0, 0.5, 1.0`
+- `omega = 0.3, 0.6, 1.0`
+- `meson = pi, K`
+
+已经达到：
+
+- successful rows = `108`
+- failed rows = `0`
+
+因此至少在当前 meson-density 诊断样点上，`xi != 0` 的 Dual 兼容已经从“局部打通”推进到“当前固定点集可完整跑通”。
+
+但这仍不等于“整个各向异性 transport / distribution 栈已全面完成 generic 化”。
+
+#### B. AD 与 FD 的大差异不是单纯 `atan` 分支问题
+
+在 workflow probe 里：
+
+- `dphase_formula_abs_diff` 很小
+- 但 `|dphase_ad - dphase_fd|`、`|dReD_domega - dReD_fd|`、`|dImD_domega - dImD_fd|` 可很大
+
+这说明差异在 `ReD/ImD` 层就已经出现，而不是只出现在 `δ = arg D` 这一步。
+
+当前最合理的解释是：
+
+- `ForwardDiff` 走到的是“冻结奇点区间 / 分段映射 / 求积拓扑”之后的局部导数
+- 有限差分则把 `omega` 改变后带来的区间漂移、奇点位置漂移也一起采样进去了
+
+### 7.3 对“整体受控泛型化”的判断
+
+可以做，而且这一轮已经证明：对这条支线而言，“先放宽关键签名、再用 workflow probe 收敛爆点”是有效的。
+
+但它更像 **受控 spike / compatibility campaign**，不是严格意义上的 TDD。
+
+原因是这里的主要不确定性不是业务行为本身，而是：
+
+- 哪些数值 helper 会把 `Dual` 压回 `Float64`
+- 哪些分支/奇点/区间构造会暴露更深层的类型锁定
+- generic 化后数值语义是否仍对应我们认可的导数契约
+
+所以更合适的工作方式是：
+
+1. 先用最小 probe 选定关键路径；
+2. 对关键路径做窄范围 generic 化；
+3. 每次放宽后立即用 workflow 级 fixed-point probe 回归；
+4. 只在 probe 证明必要时继续向更深层扩展。
+
+若要真正验证“整体泛型化”是否值得，需要把实验分成两个正交方向：
+
+1. **类型链 generic 化**
+   - 继续清理 `xi != 0` 支路中的 `Float64` 签名与临时缓冲
+   - 目标：让更多样点至少“能跑”
+
+2. **积分拓扑导数契约澄清**
+   - 明确我们究竟要：
+     - 冻结拓扑的局部导数，还是
+     - 包含分段/奇点漂移在内的“完整数值导数”
+   - 若目标是后者，就不是简单 generic 化，而是要重写区间构造 / 奇点定位 / piecewise integration 的导数语义
+
+因此，当前更稳妥的路线不是“整体泛型化后立刻替换生产 FD”，而是：
+
+- 先把 AD probe 作为分析链固定下来；
+- 再单独决定：
+  - 是否继续补 `xi != 0` 的类型兼容；
+  - 是否把生产口径定义为 frozen-topology derivative 或 full numerical derivative。
+
+只有在 Stage 1/2 都稳定后，才考虑：
+
+- 用 AD 替换当前 `dδ/dω` 的有限差分实现
+
+这一步必须单独做回归比较，不能和 generic 化混在一起。
+
+---
+
+## 7. 推荐测试策略
+
+### 7.1 新增一个 analysis-to-production 对接 smoke
+
+建议位置优先考虑：
+
+- `tests/integration/relaxtime/`
+
+最小测试内容：
+
+- 构造一个 `π` 通道固定样点
+- 调用正式 `polarization_with_width`
+- 调用正式 `meson_propagator_simple`
+- 检查：
+  - `ForwardDiff.derivative(reD_fun, ω0)` 有限
+  - `ForwardDiff.derivative(imD_fun, ω0)` 有限
+
+### 7.2 保持现有 workflow regression 不漂移
+
+本轮如果只做底层签名兼容而不切换生产 `dδ/dω` 算法，则：
+
+- 不应改变已有 workflow 数值输出
+- regression 风险主要来自类型推广或数值保护分支变化
+
+因此最小回归检查即可：
+
+- 现有 meson-density integration smoke
+- 或一个固定单点 workflow smoke
+
+---
+
+## 8. 风险点
+
+### 风险 1：`Dual` 被求积器内部 `0.0` 初始化压回 `Float64`
+
+这是最现实的工程风险。
+
+### 风险 2：某些 `isfinite` / `abs` / `complex(...)` 写法对 `Dual` 不稳
+
+尤其在 propagator 分母保护与 B0 分段逻辑里要留意。
+
+### 风险 3：PV / singular 分段在 `λ` 变成 `Dual` 后触发比较歧义
+
+例如：
+
+- `abs(k) < EPS_K`
+- `disc < 0.0`
+- `if E2 > E1`
+
+这些判断如果直接基于 `Dual`，可能报错或语义不清。
+
+因此本轮推荐策略是：
+
+- 几何分段判断仍尽量基于 `Float64` 外层参数
+- 把 `Dual` 影响限制在 integrand 值与组合公式，而不是区间拓扑判断本身
+
+---
+
+## 9. 当前推荐决策
+
+当前最稳的下一步不是全仓泛型化，而是：
+
+1. 先按 Stage 1 改正式 `k=0` 最小路径
+2. 用一个生产级 AD smoke 验证
+3. 再判断 `k>0` 求积 helper 是否必须跟进
+
+如果 Stage 1 的生产改造足够干净，再考虑 Stage 2 的受控扩展。
+
+---
+
+## 10. 2026-05-03 实施结果更新
+
+当前已完成：
+
+- Stage 1：正式 `k=0` 路径已可接受 `Dual`
+- Stage 2：正式 `k>0` 的 `B0` 主链也已可接受 `Dual`
+- 已新增 unit smoke：
+  - `tests/unit/relaxtime/test_meson_phase_shift_dual_compat.jl`
+- 已新增 workflow fixed-point probe：
+  - `scripts/analysis/relaxtime/probe_phase_shift_point_ad_vs_fd_workflow.jl`
+- 已新增性能基准：
+  - `benchmark/relaxtime/bench_meson_density_ad_diagnostic_chain.jl`
+  - `benchmark/relaxtime/bench_meson_density_generic_signature_overhead.jl`
+
+当前实现边界：
+
+- 已验证可 AD 的正式链：
+  - `B0(λ, q, ...)`
+  - `polarization_with_width(...; xi = 0)`
+  - `meson_propagator_simple`
+- `xi != 0` 的各向异性修正链在当前 meson-density fixed-point workflow probe 口径下也已打通
+  - 当前样点集：`T = 208, 210, 212 MeV`
+  - `xi = 0.0, 0.1`
+  - `q = 0.0, 0.5, 1.0`
+  - `omega = 0.3, 0.6, 1.0`
+  - `meson = pi, K`
+  - `108/108` 样点通过
+- 但这仍不等于整个各向异性 transport / distribution 栈已全面 generic 化
+
+对应 Stage 3 决策：
+
+- 当前正式产出主线仍保持分部积分后的 weighted-phase 形式
+- `dδ/dω` 当前首先升格为 AD-backed reference / diagnostic chain
+
+原因：
+
+- 当前正式 `phase_shift_meson_number_density` 主线并不直接消费 `dδ/dω`
+- 因此这里的 AD 升格首先对应：
+  - `phase_shift_point_diagnostic`
+  - 导数形式 reference helper / workflow
+- 若未来恢复或新增导数形式生产入口，应默认采用 AD 而不是 FD

--- a/scripts/analysis/relaxtime/probe_phase_shift_point_ad_vs_fd_workflow.jl
+++ b/scripts/analysis/relaxtime/probe_phase_shift_point_ad_vs_fd_workflow.jl
@@ -1,0 +1,254 @@
+"""
+Phase E5 / meson-density point diagnostic workflow probe.
+
+目标：
+- 直接走当前 `Models.solve_gap_and_meson_point -> Models.solve_phase_shift_point_diagnostic_from_meson_point`
+  workflow 合同；
+- 在固定 `(T, xi, q, ω)` 点上导出 `AD / formula / FD` 对照；
+- 判断当前 AD 结果更像“完整导数”还是“冻结积分拓扑后的局部导数”。
+
+输出：
+- CSV: `data/outputs/results/relaxtime/analysis/meson_density_phase_point_ad_vs_fd.csv`
+- Markdown summary: `data/outputs/results/relaxtime/analysis/meson_density_phase_point_ad_vs_fd_summary.md`
+"""
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+include(joinpath(PROJECT_ROOT, "src", "constants", "Constants_PNJL.jl"))
+include(joinpath(PROJECT_ROOT, "src", "models", "Models.jl"))
+
+using .Constants_PNJL: ħc_MeV_fm
+using .Models: solve_gap_and_meson_point, solve_phase_shift_point_diagnostic_from_meson_point
+
+const DEFAULT_CSV = joinpath(
+    PROJECT_ROOT,
+    "data",
+    "outputs",
+    "results",
+    "relaxtime",
+    "analysis",
+    "meson_density_phase_point_ad_vs_fd.csv",
+)
+
+const DEFAULT_MD = joinpath(
+    PROJECT_ROOT,
+    "data",
+    "outputs",
+    "results",
+    "relaxtime",
+    "analysis",
+    "meson_density_phase_point_ad_vs_fd_summary.md",
+)
+
+const DEFAULT_T_MEV = [208.0, 210.0, 212.0]
+const DEFAULT_XI = [0.0, 0.1]
+const DEFAULT_Q = [0.0, 0.5, 1.0]
+const DEFAULT_OMEGA = [0.3, 0.6, 1.0]
+const DEFAULT_MESONS = (:pi, :K)
+const DEFAULT_SCHEME = :current
+const DEFAULT_FD_STEP = 1e-5
+const DEFAULT_ETA = 1e-6
+
+@inline _fmt_bool(x::Bool) = x ? "true" : "false"
+@inline _fmt(x) = x isa Bool ? _fmt_bool(x) : string(x)
+
+function _parse_float_list(raw::AbstractString)
+    vals = Float64[]
+    for seg in split(raw, ',')
+        s = strip(seg)
+        isempty(s) && continue
+        push!(vals, parse(Float64, s))
+    end
+    isempty(vals) && throw(ArgumentError("parsed float list is empty"))
+    return vals
+end
+
+function _parse_symbol_list(raw::AbstractString)
+    vals = Symbol[]
+    for seg in split(raw, ',')
+        s = strip(seg)
+        isempty(s) && continue
+        push!(vals, Symbol(s))
+    end
+    isempty(vals) && throw(ArgumentError("parsed symbol list is empty"))
+    return Tuple(vals)
+end
+
+_selected_t_mev() = isempty(strip(get(ENV, "MESON_PHASE_AD_T_MEV", ""))) ? DEFAULT_T_MEV : _parse_float_list(ENV["MESON_PHASE_AD_T_MEV"])
+_selected_xi() = isempty(strip(get(ENV, "MESON_PHASE_AD_XI", ""))) ? DEFAULT_XI : _parse_float_list(ENV["MESON_PHASE_AD_XI"])
+_selected_q() = isempty(strip(get(ENV, "MESON_PHASE_AD_Q", ""))) ? DEFAULT_Q : _parse_float_list(ENV["MESON_PHASE_AD_Q"])
+_selected_omega() = isempty(strip(get(ENV, "MESON_PHASE_AD_OMEGA", ""))) ? DEFAULT_OMEGA : _parse_float_list(ENV["MESON_PHASE_AD_OMEGA"])
+_selected_mesons() = isempty(strip(get(ENV, "MESON_PHASE_AD_MESONS", ""))) ? DEFAULT_MESONS : _parse_symbol_list(ENV["MESON_PHASE_AD_MESONS"])
+
+function _write_csv(path::String, rows::Vector{NamedTuple})
+    isempty(rows) && error("no rows to write")
+    headers = collect(keys(rows[1]))
+    open(path, "w") do io
+        println(io, join(string.(headers), ","))
+        for row in rows
+            vals = [_fmt(getproperty(row, h)) for h in headers]
+            println(io, join(vals, ","))
+        end
+    end
+end
+
+function _failed_row(T_MeV, T_fm, xi, meson, q, ω, err)
+    return (
+        T_MeV=T_MeV,
+        T_fm=T_fm,
+        converged=true,
+        status="error",
+        error=replace(sprint(showerror, err), ',' => ';'),
+        meson=meson,
+        omega=Float64(ω),
+        q=Float64(q),
+        xi=Float64(xi),
+        temperature=Float64(T_fm),
+        eta=DEFAULT_ETA,
+        fd_step=DEFAULT_FD_STEP,
+        scheme=DEFAULT_SCHEME,
+        reD=NaN,
+        imD=NaN,
+        phase=NaN,
+        weighted_phase=NaN,
+        dReD_domega=NaN,
+        dImD_domega=NaN,
+        dReD_fd=NaN,
+        dImD_fd=NaN,
+        dphase_ad=NaN,
+        dphase_formula=NaN,
+        dphase_fd=NaN,
+        dphase_raw_fd=NaN,
+        dphase_abs_diff=NaN,
+        dphase_formula_abs_diff=NaN,
+        dphase_raw_fd_abs_diff=NaN,
+        dweighted_ad=NaN,
+        dweighted_fd=NaN,
+        dweighted_abs_diff=NaN,
+    )
+end
+
+function _collect_rows(; scheme::Symbol, fd_step::Float64, eta::Float64)
+    all_rows = NamedTuple[]
+    for xi in _selected_xi(), T_MeV in _selected_t_mev()
+        T_fm = T_MeV / ħc_MeV_fm
+        meson_point = solve_gap_and_meson_point(
+            T_fm,
+            0.0;
+            xi=xi,
+            p_num=12,
+            t_num=6,
+        )
+        Bool(meson_point.equilibrium.converged) || error("workflow point did not converge at T=$(T_MeV) MeV, xi=$(xi)")
+
+        for meson in _selected_mesons(), q in _selected_q(), ω in _selected_omega()
+            try
+                diag = solve_phase_shift_point_diagnostic_from_meson_point(
+                    meson_point;
+                    mesons=(meson,),
+                    q_values=[q],
+                    omega_values=[ω],
+                    scheme=scheme,
+                    eta=eta,
+                    fd_step=fd_step,
+                )
+                row = only(diag.rows)
+                push!(all_rows, merge((
+                    T_MeV=T_MeV,
+                    T_fm=T_fm,
+                    converged=Bool(meson_point.equilibrium.converged),
+                    status="ok",
+                    error="",
+                ), row))
+            catch err
+                push!(all_rows, _failed_row(T_MeV, T_fm, xi, meson, q, ω, err))
+            end
+        end
+    end
+    return all_rows
+end
+
+function _max_by(rows::Vector{NamedTuple}, pred)
+    best_idx = 1
+    best_val = pred(rows[1])
+    for i in 2:length(rows)
+        val = pred(rows[i])
+        if val > best_val
+            best_idx = i
+            best_val = val
+        end
+    end
+    return rows[best_idx], best_val
+end
+
+function _summarize(rows::Vector{NamedTuple}, md_path::String; scheme::Symbol, fd_step::Float64, eta::Float64)
+    ok_rows = filter(r -> r.status == "ok", rows)
+    err_rows = filter(r -> r.status != "ok", rows)
+    isempty(ok_rows) && error("no successful rows to summarize")
+    max_formula_row, max_formula = _max_by(ok_rows, r -> r.dphase_formula_abs_diff)
+    max_phase_row, max_phase = _max_by(ok_rows, r -> r.dphase_abs_diff)
+    max_raw_row, max_raw = _max_by(ok_rows, r -> r.dphase_raw_fd_abs_diff)
+    max_re_row, max_re = _max_by(ok_rows, r -> abs(r.dReD_domega - r.dReD_fd))
+    max_im_row, max_im = _max_by(ok_rows, r -> abs(r.dImD_domega - r.dImD_fd))
+
+    open(md_path, "w") do io
+        println(io, "# Meson Density Phase Point AD vs FD Workflow Probe")
+        println(io)
+        println(io, "## Configuration")
+        println(io)
+        println(io, "- scheme: `", scheme, "`")
+        println(io, "- eta: `", eta, "`")
+        println(io, "- fd_step: `", fd_step, "`")
+        println(io, "- T_MeV: `", join(_selected_t_mev(), ", "), "`")
+        println(io, "- xi: `", join(_selected_xi(), ", "), "`")
+        println(io, "- q: `", join(_selected_q(), ", "), "`")
+        println(io, "- omega: `", join(_selected_omega(), ", "), "`")
+        println(io, "- mesons: `", join(string.(collect(_selected_mesons())), ", "), "`")
+        println(io)
+        println(io, "## Top Findings")
+        println(io)
+        println(io, "- successful rows: `", length(ok_rows), "`")
+        println(io, "- failed rows: `", length(err_rows), "`")
+        println(io, "- `dphase_formula_abs_diff` max = `", max_formula, "` at `(T_MeV=", max_formula_row.T_MeV, ", xi=", max_formula_row.xi, ", meson=", max_formula_row.meson, ", q=", max_formula_row.q, ", omega=", max_formula_row.omega, ")`")
+        println(io, "- `|dphase_ad - dphase_fd|` max = `", max_phase, "` at `(T_MeV=", max_phase_row.T_MeV, ", xi=", max_phase_row.xi, ", meson=", max_phase_row.meson, ", q=", max_phase_row.q, ", omega=", max_phase_row.omega, ")`")
+        println(io, "- `|dphase_ad - dphase_raw_fd|` max = `", max_raw, "` at `(T_MeV=", max_raw_row.T_MeV, ", xi=", max_raw_row.xi, ", meson=", max_raw_row.meson, ", q=", max_raw_row.q, ", omega=", max_raw_row.omega, ")`")
+        println(io, "- `|dReD_domega - dReD_fd|` max = `", max_re, "` at `(T_MeV=", max_re_row.T_MeV, ", xi=", max_re_row.xi, ", meson=", max_re_row.meson, ", q=", max_re_row.q, ", omega=", max_re_row.omega, ")`")
+        println(io, "- `|dImD_domega - dImD_fd|` max = `", max_im, "` at `(T_MeV=", max_im_row.T_MeV, ", xi=", max_im_row.xi, ", meson=", max_im_row.meson, ", q=", max_im_row.q, ", omega=", max_im_row.omega, ")`")
+        println(io)
+        println(io, "## Reading")
+        println(io)
+        println(io, "1. `dphase_formula_abs_diff` should stay near machine precision if the AD path and the `Re/Im D` analytic derivative formula are internally consistent.")
+        println(io, "2. If `dphase_abs_diff` remains visibly nonzero while (1) is tiny, the main gap is not `atan` branch handling alone; it already exists at the `ReD/ImD` derivative level.")
+        println(io, "3. In the current implementation, that usually means AD is differentiating a frozen-topology integrand, while FD also samples how singularity intervals / segmentation move with `omega`.")
+        if !isempty(err_rows)
+            println(io)
+            println(io, "## Unsupported Points")
+            println(io)
+            for row in err_rows
+                println(io, "- `(T_MeV=", row.T_MeV, ", xi=", row.xi, ", meson=", row.meson, ", q=", row.q, ", omega=", row.omega, ")`: `", row.error, "`")
+            end
+        end
+    end
+end
+
+function main()
+    csv_path = isempty(ARGS) ? DEFAULT_CSV : abspath(ARGS[1])
+    md_path = length(ARGS) >= 2 ? abspath(ARGS[2]) : DEFAULT_MD
+    mkpath(dirname(csv_path))
+    mkpath(dirname(md_path))
+
+    rows = _collect_rows(
+        scheme=DEFAULT_SCHEME,
+        fd_step=DEFAULT_FD_STEP,
+        eta=DEFAULT_ETA,
+    )
+    _write_csv(csv_path, rows)
+    _summarize(rows, md_path; scheme=DEFAULT_SCHEME, fd_step=DEFAULT_FD_STEP, eta=DEFAULT_ETA)
+
+    println("Wrote workflow AD/FD CSV: ", csv_path)
+    println("Wrote workflow AD/FD summary: ", md_path)
+end
+
+if abspath(PROGRAM_FILE) == abspath(@__FILE__)
+    main()
+end

--- a/src/QuarkDistribution_Aniso.jl
+++ b/src/QuarkDistribution_Aniso.jl
@@ -8,19 +8,26 @@ module PNJLQuarkDistributions_Aniso
 
 export distribution_aniso_correction, distribution_aniso, correction_cos_theta_coefficient
 
+using ForwardDiff
+
 const _QUARK_DISTRIBUTION_PATH = normpath(joinpath(@__DIR__, "QuarkDistribution.jl"))
 if !isdefined(Main, :PNJLQuarkDistributions)
     Base.include(Main, _QUARK_DISTRIBUTION_PATH)
 end
 
 using Main.PNJLQuarkDistributions: quark_distribution, antiquark_distribution
+
+@inline _primal_value(x::Float64) = x
+@inline _primal_value(x::ForwardDiff.Dual) = ForwardDiff.value(x)
+@inline _exp_clamped(x::T) where {T<:Real} = exp(clamp(_primal_value(x), -460.0, 460.0))
+
 """计算PNJL模型中夸克有效分布函数对能量的导数"""
-function quark_df_dE(E_inv_fm::Float64, μ_inv_fm::Float64, T_inv_fm::Float64, Φ::Float64, Φbar::Float64)
+function quark_df_dE(E_inv_fm::T, μ_inv_fm::Float64, T_inv_fm::Float64, Φ::Float64, Φbar::Float64) where {T<:Real}
     # 计算温度的倒数
     β_fm = 1 / T_inv_fm
 
     # 计算指数项
-    exp_term = clamp(exp(-(E_inv_fm - μ_inv_fm) * β_fm), 1e-200, 1e200)
+    exp_term = _exp_clamped(-(E_inv_fm - μ_inv_fm) * β_fm)
     exp_term2 = exp_term * exp_term
     exp_term3 = exp_term2 * exp_term
 
@@ -41,12 +48,12 @@ function quark_df_dE(E_inv_fm::Float64, μ_inv_fm::Float64, T_inv_fm::Float64, �
 end
 
 """计算PNJL模型中反夸克有效分布函数对能量的导数"""
-function antiquark_df_dE(E_inv_fm::Float64, μ_inv_fm::Float64, T_inv_fm::Float64, Φ::Float64, Φbar::Float64)
+function antiquark_df_dE(E_inv_fm::T, μ_inv_fm::Float64, T_inv_fm::Float64, Φ::Float64, Φbar::Float64) where {T<:Real}
     # 计算温度的倒数
     β_fm = 1 / T_inv_fm
 
     # 计算指数项
-    exp_term = clamp(exp(-(E_inv_fm + μ_inv_fm) * β_fm), 1e-200, 1e200)
+    exp_term = _exp_clamped(-(E_inv_fm + μ_inv_fm) * β_fm)
     exp_term2 = exp_term * exp_term
     exp_term3 = exp_term2 * exp_term
 
@@ -72,8 +79,8 @@ end
 计算PNJL模型中分布函数一阶修正项中cosθ的系数
 # ps:x=cosθ,x^2对立体角积分相比于没有x^2的结果多了个1/3因子,如果原积分函数不含x,在调用此函数时需乘以1/3
 """
-function correction_cos_theta_coefficient(sign_::Symbol, p_inv_fm::Float64, m_inv_fm::Float64, 
-    μ_inv_fm::Float64, T_inv_fm::Float64, Φ::Float64, Φbar::Float64, ξ::Float64)
+function correction_cos_theta_coefficient(sign_::Symbol, p_inv_fm::T, m_inv_fm::Float64,
+    μ_inv_fm::Float64, T_inv_fm::Float64, Φ::Float64, Φbar::Float64, ξ::Float64) where {T<:Real}
     E_inv_fm = sqrt(p_inv_fm^2 + m_inv_fm^2)
     coeff = 0.5 * ξ * (p_inv_fm^2) / E_inv_fm
     if sign_ === :quark

--- a/src/models/entrypoints.jl
+++ b/src/models/entrypoints.jl
@@ -17,6 +17,8 @@ export solve_gap_and_meson_point
 export solve_meson_density_from_meson_point, solve_gap_and_meson_density_point
 export solve_strict_bw_meson_density_from_meson_point, solve_gap_and_strict_bw_meson_density_point
 export solve_phase_shift_meson_density_from_meson_point, solve_gap_and_phase_shift_meson_density_point
+export solve_phase_shift_point_diagnostic_from_meson_point
+export solve_phase_shift_derivative_reference_from_meson_point
 export solve_gas_liquid_point
 export solve_rotation_point
 export run_phase_pipeline, run_production_phase_pipeline, find_cep, build_phase_artifacts
@@ -57,7 +59,9 @@ end
          isdefined(workflow, :solve_strict_bw_meson_density_from_meson_point) &&
          isdefined(workflow, :solve_gap_and_strict_bw_meson_density_point) &&
          isdefined(workflow, :solve_phase_shift_meson_density_from_meson_point) &&
-         isdefined(workflow, :solve_gap_and_phase_shift_meson_density_point))
+         isdefined(workflow, :solve_gap_and_phase_shift_meson_density_point) &&
+         isdefined(workflow, :solve_phase_shift_derivative_reference_from_meson_point) &&
+         isdefined(workflow, :solve_phase_shift_point_diagnostic_from_meson_point))
         error("MesonDensityWorkflow module loaded but required API is missing")
     end
     return workflow
@@ -236,6 +240,14 @@ end
 
 function solve_gap_and_phase_shift_meson_density_point(args...; kwargs...)
     return _meson_density_workflow_module().solve_gap_and_phase_shift_meson_density_point(args...; kwargs...)
+end
+
+function solve_phase_shift_point_diagnostic_from_meson_point(args...; kwargs...)
+    return _meson_density_workflow_module().solve_phase_shift_point_diagnostic_from_meson_point(args...; kwargs...)
+end
+
+function solve_phase_shift_derivative_reference_from_meson_point(args...; kwargs...)
+    return _meson_density_workflow_module().solve_phase_shift_derivative_reference_from_meson_point(args...; kwargs...)
 end
 
 function solve_gas_liquid_point(args...; kwargs...)

--- a/src/models/workflow_apps/MesonDensityWorkflow.jl
+++ b/src/models/workflow_apps/MesonDensityWorkflow.jl
@@ -23,6 +23,8 @@ using Main.MesonDensity: DEFAULT_MESON_DENSITY_Q_NODES,
                          DEFAULT_PHASE_SHIFT_OMEGA_MAX,
                          DEFAULT_PHASE_SHIFT_OMEGA_NODES,
                          meson_degeneracy,
+                         phase_shift_point_diagnostic,
+                         phase_shift_meson_density_derivative_reference_summary,
                          phase_shift_meson_density_summary,
                          strict_bw_meson_density_summary,
                          strict_bw_qpole_density_summary,
@@ -36,6 +38,8 @@ export solve_strict_bw_meson_density_from_meson_point
 export solve_gap_and_strict_bw_meson_density_point
 export solve_phase_shift_meson_density_from_meson_point
 export solve_gap_and_phase_shift_meson_density_point
+export solve_phase_shift_point_diagnostic_from_meson_point
+export solve_phase_shift_derivative_reference_from_meson_point
 
 @inline function _require_result_field(result, field::Symbol)
     hasproperty(result, field) || throw(ArgumentError("meson workflow result missing required field: $(field)"))
@@ -326,6 +330,85 @@ function solve_gap_and_phase_shift_meson_density_point(
     meson_point = solve_gap_and_meson_point(T_fm, mu_fm; kwargs...)
     density = solve_phase_shift_meson_density_from_meson_point(meson_point; density_kwargs...)
     return merge(meson_point, (phase_shift_meson_density=density,))
+end
+
+function solve_phase_shift_derivative_reference_from_meson_point(
+    meson_point;
+    scheme::Symbol=:current,
+    qmax::Float64=DEFAULT_PHASE_SHIFT_Q_MAX,
+    q_nodes::Int=DEFAULT_PHASE_SHIFT_Q_NODES,
+    omega_min::Float64=0.05,
+    omega_max::Float64=DEFAULT_PHASE_SHIFT_OMEGA_MAX,
+    omega_nodes::Int=DEFAULT_PHASE_SHIFT_OMEGA_NODES,
+    eta::Float64=1e-6,
+)
+    thermo_params_raw = _require_result_field(meson_point, :thermo_params)
+    quark_params_raw = _require_result_field(meson_point, :quark_params)
+
+    thermo_params = normalize_thermo_params(thermo_params_raw)
+    quark_params = ensure_quark_params_has_A(
+        normalize_quark_params(quark_params_raw),
+        thermo_params,
+    )
+
+    density = phase_shift_meson_density_derivative_reference_summary(
+        quark_params,
+        thermo_params;
+        scheme=scheme,
+        qmax=qmax,
+        q_nodes=q_nodes,
+        omega_min=omega_min,
+        omega_max=omega_max,
+        omega_nodes=omega_nodes,
+        eta=eta,
+    )
+
+    return merge(density, (
+        m_pi=haskey(meson_point.meson_results, :pi) ? Float64(meson_point.meson_results[:pi].mass) : NaN,
+        m_K=haskey(meson_point.meson_results, :K) ? Float64(meson_point.meson_results[:K].mass) : NaN,
+    ))
+end
+
+function solve_phase_shift_point_diagnostic_from_meson_point(
+    meson_point;
+    mesons::Tuple=(:pi, :K),
+    q_values::AbstractVector{<:Real}=[0.0],
+    omega_values::AbstractVector{<:Real}=[0.2],
+    scheme::Symbol=:current,
+    eta::Float64=1e-6,
+    fd_step::Float64=1e-5,
+)
+    thermo_params_raw = _require_result_field(meson_point, :thermo_params)
+    quark_params_raw = _require_result_field(meson_point, :quark_params)
+
+    thermo_params = normalize_thermo_params(thermo_params_raw)
+    quark_params = ensure_quark_params_has_A(
+        normalize_quark_params(quark_params_raw),
+        thermo_params,
+    )
+
+    rows = NamedTuple[]
+    for meson in mesons, q in q_values, ω in omega_values
+        push!(rows, phase_shift_point_diagnostic(
+            meson,
+            Float64(ω),
+            Float64(q),
+            quark_params,
+            thermo_params;
+            scheme=scheme,
+            eta=eta,
+            fd_step=fd_step,
+        ))
+    end
+
+    return (
+        T_fm=Float64(thermo_params.T),
+        xi=Float64(thermo_params.ξ),
+        scheme=scheme,
+        eta=eta,
+        fd_step=fd_step,
+        rows=rows,
+    )
 end
 
 end # module

--- a/src/relaxtime/MesonDensity.jl
+++ b/src/relaxtime/MesonDensity.jl
@@ -906,11 +906,7 @@ function phase_shift_meson_number_density_derivative_reference(
     q_grid, q_w = gauleg(0.0, qmax, q_nodes)
     omega_grid, omega_w = gauleg(omega_min, omega_max, omega_nodes)
 
-    q_shell_weighted_sum = 0.0
-    q_shell_at_qmax = NaN
-    max_formula_abs_diff = 0.0
-    @inbounds for iq in eachindex(q_grid, q_w)
-        q = q_grid[iq]
+    function q_shell_from_q(q::Float64)
         omega_val = 0.0
         for iω in eachindex(omega_grid, omega_w)
             ω = Float64(omega_grid[iω])
@@ -933,12 +929,18 @@ function phase_shift_meson_number_density_derivative_reference(
             omega_val += omega_w[iω] * gω * dweighted_ad
         end
         omega_val /= (2.0 * π)
-        q_shell = (q^2 / (2.0 * π^2)) * omega_val
-        q_shell_weighted_sum += q_w[iq] * q_shell
-        if iq == length(q_grid)
-            q_shell_at_qmax = q_shell
-        end
+        return (q^2 / (2.0 * π^2)) * omega_val
     end
+
+    q_shell_weighted_sum = 0.0
+    q_shell_at_qmax = 0.0
+    max_formula_abs_diff = 0.0
+    @inbounds for iq in eachindex(q_grid, q_w)
+        q = q_grid[iq]
+        q_shell = q_shell_from_q(q)
+        q_shell_weighted_sum += q_w[iq] * q_shell
+    end
+    q_shell_at_qmax = q_shell_from_q(qmax)
 
     density = Float64(degeneracy) * q_shell_weighted_sum
     return (

--- a/src/relaxtime/MesonDensity.jl
+++ b/src/relaxtime/MesonDensity.jl
@@ -12,6 +12,7 @@ MesonDensity
 """
 module MesonDensity
 
+using ForwardDiff
 using ..GaussLegendre: gauleg
 using ..AFieldBuilder: ensure_quark_params_has_A
 using ..EffectiveCouplings: calculate_G_from_A, calculate_effective_couplings
@@ -28,6 +29,8 @@ export stable_meson_number_density, stable_kpi_ratio, stable_kpi_scan
 export strict_bw_meson_number_density, strict_bw_meson_density_summary
 export strict_bw_qpole_meson_number_density, strict_bw_qpole_density_summary
 export phase_shift_meson_number_density, phase_shift_meson_density_summary
+export phase_shift_meson_number_density_derivative_reference, phase_shift_meson_density_derivative_reference_summary
+export phase_shift_point_diagnostic
 
 const DEFAULT_MESON_DENSITY_Q_NODES = 256
 const DEFAULT_PHASE_SHIFT_Q_MAX = 12.0
@@ -691,8 +694,13 @@ end
     throw(ArgumentError("$(name) must be > 1, got $(n)"))
 end
 
-@inline function _complex_phase(z::ComplexF64)::Float64
+@inline function _complex_phase(z::Complex{T})::T where {T<:Real}
     return atan(imag(z), real(z))
+end
+
+@inline function _phase_derivative_from_components(reD::T, imD::T, dre::T, dim::T) where {T<:Real}
+    denom = reD * reD + imD * imD
+    return (reD * dim - imD * dre) / denom
 end
 
 function _unwrap_phases(phases::Vector{Float64})
@@ -721,16 +729,24 @@ end
     throw(ArgumentError("phase-shift scheme must be :current/:phase_e3 or :gbu/:gbu_reference/:generalized_bu, got $(scheme)"))
 end
 
-@inline function _gbu_phase_function(δ::Float64)::Float64
+@inline function _gbu_phase_function(δ::T)::T where {T<:Real}
     return δ - 0.5 * sin(2.0 * δ)
 end
 
-@inline function _phase_shift_weighted_phase(δ::Float64, scheme::Symbol)::Float64
+@inline function _phase_shift_weighted_phase(δ::T, scheme::Symbol)::T where {T<:Real}
     scheme_sym = _phase_shift_scheme_symbol(scheme)
     if scheme_sym === :phase_shift_current
         return δ
     end
     return _gbu_phase_function(δ)
+end
+
+@inline function _phase_shift_weight_derivative_factor(δ::T, scheme::Symbol)::T where {T<:Real}
+    scheme_sym = _phase_shift_scheme_symbol(scheme)
+    if scheme_sym === :phase_shift_current
+        return one(T)
+    end
+    return T(2) * sin(δ)^2
 end
 
 function _simple_meson_pol_params(meson::Symbol, qp)
@@ -760,7 +776,7 @@ function _build_k_coeffs(qp)
     return calculate_effective_couplings(G_fm2, K_fm5, G_u, G_s)
 end
 
-function _propagator_phase(meson::Symbol, ω::Float64, q::Float64, qp, tp, K_coeffs; eta::Float64)
+function _propagator_components(meson::Symbol, ω::T, q::Float64, qp, tp, K_coeffs; eta::Float64) where {T<:Real}
     pol = _simple_meson_pol_params(meson, qp)
     Π_re, Π_im = polarization_with_width(
         pol.channel, ω, 2.0 * eta, q,
@@ -769,9 +785,228 @@ function _propagator_phase(meson::Symbol, ω::Float64, q::Float64, qp, tp, K_coe
         Float64(tp.T), Float64(tp.Φ), Float64(tp.Φbar), Float64(tp.ξ),
         pol.A1, pol.A2, pol.num_s_quark,
     )
-    Π = ComplexF64(Π_re, Π_im)
+    Π = Complex{T}(Π_re, Π_im)
     D = meson_propagator_simple(meson, K_coeffs, Π)
-    return _complex_phase(D)
+    return real(D), imag(D)
+end
+
+function _propagator_phase(meson::Symbol, ω::T, q::Float64, qp, tp, K_coeffs; eta::Float64) where {T<:Real}
+    reD, imD = _propagator_components(meson, ω, q, qp, tp, K_coeffs; eta=eta)
+    return atan(imD, reD)
+end
+
+function phase_shift_point_diagnostic(
+    meson::Symbol,
+    ω::Float64,
+    q::Float64,
+    quark_params,
+    thermo_params;
+    scheme::Symbol=:current,
+    eta::Float64=DEFAULT_PHASE_SHIFT_ETA,
+    fd_step::Float64=1e-5,
+)
+    fd_step > 0.0 || throw(ArgumentError("fd_step must be positive, got $(fd_step)"))
+    qp = ensure_quark_params_has_A(quark_params, thermo_params)
+    tp = thermo_params
+    K_coeffs = _build_k_coeffs(qp)
+    scheme_sym = _phase_shift_scheme_symbol(scheme)
+
+    re0, im0 = _propagator_components(meson, ω, q, qp, tp, K_coeffs; eta=eta)
+    phase0 = atan(im0, re0)
+    weighted0 = _phase_shift_weighted_phase(phase0, scheme_sym)
+
+    re_fun(x) = first(_propagator_components(meson, x, q, qp, tp, K_coeffs; eta=eta))
+    im_fun(x) = last(_propagator_components(meson, x, q, qp, tp, K_coeffs; eta=eta))
+    phase_fun(x) = _propagator_phase(meson, x, q, qp, tp, K_coeffs; eta=eta)
+    weighted_fun(x) = _phase_shift_weighted_phase(phase_fun(x), scheme_sym)
+
+    dre = ForwardDiff.derivative(re_fun, ω)
+    dim = ForwardDiff.derivative(im_fun, ω)
+    dphase_ad = ForwardDiff.derivative(phase_fun, ω)
+    dphase_formula = _phase_derivative_from_components(re0, im0, dre, dim)
+    dweighted_ad = ForwardDiff.derivative(weighted_fun, ω)
+
+    dre_fd = (re_fun(ω + fd_step) - re_fun(ω - fd_step)) / (2fd_step)
+    dim_fd = (im_fun(ω + fd_step) - im_fun(ω - fd_step)) / (2fd_step)
+    dphase_fd = _phase_derivative_from_components(re0, im0, dre_fd, dim_fd)
+    dphase_raw_fd = (phase_fun(ω + fd_step) - phase_fun(ω - fd_step)) / (2fd_step)
+    dweighted_fd = (weighted_fun(ω + fd_step) - weighted_fun(ω - fd_step)) / (2fd_step)
+
+    return (
+        meson=meson,
+        omega=ω,
+        q=q,
+        xi=Float64(tp.ξ),
+        temperature=Float64(tp.T),
+        eta=eta,
+        fd_step=fd_step,
+        scheme=scheme_sym,
+        reD=Float64(re0),
+        imD=Float64(im0),
+        phase=Float64(phase0),
+        weighted_phase=Float64(weighted0),
+        dReD_domega=Float64(dre),
+        dImD_domega=Float64(dim),
+        dReD_fd=Float64(dre_fd),
+        dImD_fd=Float64(dim_fd),
+        dphase_ad=Float64(dphase_ad),
+        dphase_formula=Float64(dphase_formula),
+        dphase_fd=Float64(dphase_fd),
+        dphase_raw_fd=Float64(dphase_raw_fd),
+        dphase_abs_diff=abs(Float64(dphase_ad) - Float64(dphase_fd)),
+        dphase_formula_abs_diff=abs(Float64(dphase_formula) - Float64(dphase_ad)),
+        dphase_raw_fd_abs_diff=abs(Float64(dphase_ad) - Float64(dphase_raw_fd)),
+        dweighted_ad=Float64(dweighted_ad),
+        dweighted_fd=Float64(dweighted_fd),
+        dweighted_abs_diff=abs(Float64(dweighted_ad) - Float64(dweighted_fd)),
+    )
+end
+
+function phase_shift_meson_number_density_derivative_reference(
+    meson::Symbol,
+    quark_params,
+    thermo_params;
+    degeneracy::Integer=meson_degeneracy(meson),
+    scheme::Symbol=:current,
+    qmax::Float64=DEFAULT_PHASE_SHIFT_Q_MAX,
+    q_nodes::Int=DEFAULT_PHASE_SHIFT_Q_NODES,
+    omega_min::Float64=0.05,
+    omega_max::Float64=DEFAULT_PHASE_SHIFT_OMEGA_MAX,
+    omega_nodes::Int=DEFAULT_PHASE_SHIFT_OMEGA_NODES,
+    eta::Float64=DEFAULT_PHASE_SHIFT_ETA,
+)
+    degeneracy > 0 || throw(ArgumentError("degeneracy must be positive, got $(degeneracy)"))
+    _require_positive_node_count("q_nodes", q_nodes)
+    _require_positive_node_count("omega_nodes", omega_nodes)
+    qmax > 0.0 || throw(ArgumentError("qmax must be positive, got $(qmax)"))
+    omega_max > omega_min || throw(ArgumentError("omega_max must exceed omega_min"))
+    scheme_sym = _phase_shift_scheme_symbol(scheme)
+
+    tp = thermo_params
+    _require_nonnegative("temperature T", Float64(tp.T))
+    _require_phase_shift_isotropic_xi(Float64(tp.ξ))
+    Float64(tp.T) > 0.0 || return (
+        meson=meson,
+        density=0.0,
+        q_integral_estimate=0.0,
+        omega_shell_at_qmax=0.0,
+        qmax=qmax,
+        q_nodes=q_nodes,
+        omega_min=omega_min,
+        omega_max=omega_max,
+        omega_nodes=omega_nodes,
+        degeneracy=Int(degeneracy),
+        scheme=scheme_sym,
+        derivative_backend=:forwarddiff,
+        max_formula_abs_diff=0.0,
+    )
+
+    qp = ensure_quark_params_has_A(quark_params, tp)
+    K_coeffs = _build_k_coeffs(qp)
+    q_grid, q_w = gauleg(0.0, qmax, q_nodes)
+    omega_grid, omega_w = gauleg(omega_min, omega_max, omega_nodes)
+
+    q_shell_weighted_sum = 0.0
+    q_shell_at_qmax = NaN
+    max_formula_abs_diff = 0.0
+    @inbounds for iq in eachindex(q_grid, q_w)
+        q = q_grid[iq]
+        omega_val = 0.0
+        for iω in eachindex(omega_grid, omega_w)
+            ω = Float64(omega_grid[iω])
+            gω = bose_distribution(ω, 0.0, Float64(tp.T))
+            re0, im0 = _propagator_components(meson, ω, q, qp, tp, K_coeffs; eta=eta)
+            phase0 = atan(im0, re0)
+            weight_factor = _phase_shift_weight_derivative_factor(phase0, scheme_sym)
+
+            re_fun(x) = first(_propagator_components(meson, x, q, qp, tp, K_coeffs; eta=eta))
+            im_fun(x) = last(_propagator_components(meson, x, q, qp, tp, K_coeffs; eta=eta))
+            weighted_fun(x) = _phase_shift_weighted_phase(_propagator_phase(meson, x, q, qp, tp, K_coeffs; eta=eta), scheme_sym)
+
+            dre = ForwardDiff.derivative(re_fun, ω)
+            dim = ForwardDiff.derivative(im_fun, ω)
+            dphase_formula = _phase_derivative_from_components(re0, im0, dre, dim)
+            dweighted_formula = weight_factor * dphase_formula
+            dweighted_ad = ForwardDiff.derivative(weighted_fun, ω)
+            max_formula_abs_diff = max(max_formula_abs_diff, abs(Float64(dweighted_ad) - Float64(dweighted_formula)))
+
+            omega_val += omega_w[iω] * gω * dweighted_ad
+        end
+        omega_val /= (2.0 * π)
+        q_shell = (q^2 / (2.0 * π^2)) * omega_val
+        q_shell_weighted_sum += q_w[iq] * q_shell
+        if iq == length(q_grid)
+            q_shell_at_qmax = q_shell
+        end
+    end
+
+    density = Float64(degeneracy) * q_shell_weighted_sum
+    return (
+        meson=meson,
+        density=density,
+        q_integral_estimate=q_shell_weighted_sum,
+        omega_shell_at_qmax=q_shell_at_qmax,
+        qmax=qmax,
+        q_nodes=q_nodes,
+        omega_min=omega_min,
+        omega_max=omega_max,
+        omega_nodes=omega_nodes,
+        degeneracy=Int(degeneracy),
+        scheme=scheme_sym,
+        derivative_backend=:forwarddiff,
+        max_formula_abs_diff=max_formula_abs_diff,
+    )
+end
+
+function phase_shift_meson_density_derivative_reference_summary(
+    quark_params,
+    thermo_params;
+    pi_channel::Symbol=:pi,
+    k_channel::Symbol=:K,
+    d_pi::Integer=meson_degeneracy(:pi),
+    d_K::Integer=meson_degeneracy(:K),
+    scheme::Symbol=:current,
+    qmax::Float64=DEFAULT_PHASE_SHIFT_Q_MAX,
+    q_nodes::Int=DEFAULT_PHASE_SHIFT_Q_NODES,
+    omega_min::Float64=0.05,
+    omega_max::Float64=DEFAULT_PHASE_SHIFT_OMEGA_MAX,
+    omega_nodes::Int=DEFAULT_PHASE_SHIFT_OMEGA_NODES,
+    eta::Float64=DEFAULT_PHASE_SHIFT_ETA,
+)
+    pi_density = phase_shift_meson_number_density_derivative_reference(
+        pi_channel, quark_params, thermo_params;
+        degeneracy=Int(d_pi), scheme=scheme, qmax=qmax, q_nodes=q_nodes,
+        omega_min=omega_min, omega_max=omega_max, omega_nodes=omega_nodes, eta=eta,
+    )
+    k_density = phase_shift_meson_number_density_derivative_reference(
+        k_channel, quark_params, thermo_params;
+        degeneracy=Int(d_K), scheme=scheme, qmax=qmax, q_nodes=q_nodes,
+        omega_min=omega_min, omega_max=omega_max, omega_nodes=omega_nodes, eta=eta,
+    )
+    n_pi = Float64(pi_density.density)
+    n_K = Float64(k_density.density)
+    return (
+        T_fm=Float64(thermo_params.T),
+        xi=Float64(thermo_params.ξ),
+        pi_channel=pi_channel,
+        k_channel=k_channel,
+        d_pi=Int(d_pi),
+        d_K=Int(d_K),
+        n_pi=n_pi,
+        n_K=n_K,
+        kpi_ratio=iszero(n_pi) ? NaN : n_K / n_pi,
+        qmax=qmax,
+        q_nodes=q_nodes,
+        omega_min=omega_min,
+        omega_max=omega_max,
+        omega_nodes=omega_nodes,
+        eta=eta,
+        scheme=_phase_shift_scheme_symbol(scheme),
+        derivative_backend=:forwarddiff,
+        max_formula_abs_diff=max(pi_density.max_formula_abs_diff, k_density.max_formula_abs_diff),
+        pi_density=pi_density,
+        k_density=k_density,
+    )
 end
 
 """

--- a/src/relaxtime/MesonPropagator.jl
+++ b/src/relaxtime/MesonPropagator.jl
@@ -21,7 +21,7 @@ using LinearAlgebra: det
 # 注意：这不是物理“宽度”建模，只是数值稳健性保护；值应尽量小。
 const PROPAGATOR_DENOM_EPS = 1e-12
 
-@inline function _isfinite_complex(z::ComplexF64)::Bool
+@inline function _isfinite_complex(z::Complex{T})::Bool where {T<:Real}
     return isfinite(real(z)) && isfinite(imag(z))
 end
 
@@ -250,7 +250,7 @@ D_sigma_pi = meson_propagator_simple(:sigma_pi, K_coeffs, Π_uu_S)
 ```
 """
 @inline @fastmath function meson_propagator_simple(meson_type::Symbol, K_coeffs::NamedTuple, 
-                                                   Π::ComplexF64)
+                                                   Π::Complex{T}) where {T<:Real}
     # 根据介子类型自动选择K系数
     if meson_type == :pi
         K = K_coeffs.K123_plus  # π是赝标量P通道，用K⁺
@@ -265,14 +265,14 @@ D_sigma_pi = meson_propagator_simple(:sigma_pi, K_coeffs, Π_uu_S)
     end
     
     # D = 2K / (1 - 4KΠ)
-    denom = 1.0 - 4.0 * K * Π
+    denom = one(Π) - T(4) * T(K) * Π
     if !_isfinite_complex(denom)
-        return 0.0 + 0.0im
+        return zero(Π)
     end
-    if abs(denom) < PROPAGATOR_DENOM_EPS
-        denom += complex(0.0, PROPAGATOR_DENOM_EPS)
+    if abs(denom) < T(PROPAGATOR_DENOM_EPS)
+        denom += Complex{T}(zero(T), T(PROPAGATOR_DENOM_EPS))
     end
-    return (2.0 * K) / denom
+    return (T(2) * T(K)) / denom
 end
 
 # ----------------------------------------------------------------------------

--- a/src/relaxtime/OneLoopIntegrals.jl
+++ b/src/relaxtime/OneLoopIntegrals.jl
@@ -10,6 +10,7 @@ module OneLoopIntegrals
 import ..GaussLegendre  # needed by IntervalQuadratureStrategies (bare `GaussLegendre.gauleg`)
 include("../integration/IntervalQuadratureStrategies.jl")
 using ..GaussLegendre: gauleg
+using ForwardDiff
 using Main.PNJLQuarkDistributions: quark_distribution, antiquark_distribution,
     quark_distribution_integral, antiquark_distribution_integral
 using Main.Constants_PNJL: Λ_inv_fm
@@ -42,6 +43,9 @@ end
     m_pos = max(m, 0.0)
     return sqrt(E * E - m_pos * m_pos)
 end
+
+@inline _primal_value(x::Float64) = x
+@inline _primal_value(x::ForwardDiff.Dual) = ForwardDiff.value(x)
 
 """计算夸克有效分布函数的值（供 A 积分使用：分别用夸克/反夸克分布）"""
 @inline function distribution_value(mode::Symbol, sign_flag::Symbol, E::Float64, μ::Float64,
@@ -112,10 +116,10 @@ end
 # -----------------------------------------------------------------------------
 # k=0 时的积分计算相关函数
 """k=0时的积分实部被积函数"""
-@inline function real_integrand_k_zero(sign_flag::Symbol, λ::Float64, m::Float64, denominator_term::Float64,
-    μ::Float64, T::Float64, Φ::Float64, Φbar::Float64, E::Float64)
+@inline function real_integrand_k_zero(sign_flag::Symbol, λ::T, m::Float64, denominator_term::T,
+    μ::Float64, T0::Float64, Φ::Float64, Φbar::Float64, E::Float64) where {T<:Real}
     p = internal_momentum(E, m)
-    dist = distribution_value_b0(sign_flag, E, μ, T, Φ, Φbar)
+    dist = distribution_value_b0(sign_flag, E, μ, T0, Φ, Φbar)
     denominator = λ * E + denominator_term
     if !isfinite(p) || !isfinite(dist) || !isfinite(denominator)
         return 0.0
@@ -130,8 +134,10 @@ end
 
 """k=0时的奇点计算函数
 返回位于 (Emin, Emax) 内的 E 奇点值列表；若无奇点则返回空列表"""
-@inline function singularity_k_zero(λ::Float64, Emin::Float64, Emax::Float64, denominator_term::Float64)::Vector{Float64}
-    E0 = -denominator_term / λ
+@inline function singularity_k_zero(λ::T, Emin::Float64, Emax::Float64, denominator_term::T)::Vector{Float64} where {T<:Real}
+    λ0 = _primal_value(λ)
+    denominator0 = _primal_value(denominator_term)
+    E0 = -denominator0 / λ0
     if !isfinite(E0)
         return Float64[]
     end
@@ -146,21 +152,21 @@ end
 end
 
 """三动量大小k=0(小于EPS_K)时的 B0分量 积分计算"""
-@inline function tilde_B0_k_zero(sign_flag::Symbol, λ::Float64, m::Float64, m_prime::Float64, μ::Float64, T::Float64,
-    Φ::Float64, Φbar::Float64)
+@inline function tilde_B0_k_zero(sign_flag::Symbol, λ::T, m::Float64, m_prime::Float64, μ::Float64, T0::Float64,
+    Φ::Float64, Φbar::Float64) where {T<:Real}
     m_pos = max(m, 0.0)
     m_prime_pos = max(m_prime, 0.0)
     Emin = m_pos
     Emax = energy_cutoff(m_pos)
-    denominator_term = (λ ^ 2 + m_pos ^ 2 - m_prime_pos ^ 2) / 2.0
+    denominator_term = (λ ^ 2 + m_pos ^ 2 - m_prime_pos ^ 2) / T(2)
     singularity = singularity_k_zero(λ, Emin, Emax, denominator_term)
     integrand_fun(E) = real_integrand_k_zero(sign_flag, λ, m_pos, denominator_term,
-        μ, T, Φ, Φbar, E) # 闭包被积函数
+        μ, T0, Φ, Φbar, E) # 闭包被积函数
 
-    imag_part = 0.0
+    imag_part = zero(T)
     if isempty(singularity) # 无奇点
         real_part = integrate_hybrid_interval(integrand_fun, Emin, Emax, SING_NONE; n=HYBRID_N_SMOOTH)
-        return real_part * 2.0, imag_part / λ
+        return real_part * T(2), imag_part / λ
     end
 
     # 有奇点：主值积分（PV）。
@@ -169,7 +175,7 @@ end
 
     @inline function numer(E::Float64)
         p = internal_momentum(E, m_pos)
-        dist = distribution_value_b0(sign_flag, E, μ, T, Φ, Φbar)
+        dist = distribution_value_b0(sign_flag, E, μ, T0, Φ, Φbar)
         if !isfinite(p) || !isfinite(dist)
             return 0.0
         end
@@ -215,18 +221,18 @@ end
 
     # 解析虚部（残数项）
     p0 = internal_momentum(E0, m_pos)
-    imag_part = 2.0 * π * p0 * distribution_value_b0(sign_flag, E0, μ, T, Φ, Φbar)
+    imag_part = T(2π * p0 * distribution_value_b0(sign_flag, E0, μ, T0, Φ, Φbar))
 
     # 与无奇点分支保持相同归一化：返回 2×(PV 积分结果)
-    return pv_integral * 2.0, imag_part / λ
+    return pv_integral * T(2), imag_part / λ
 end
 # ----------------------------------------------------------------------------
 # k>0 时的积分计算相关函数
 """k>0 时的积分实部被积函数"""
-@inline @fastmath function real_integrand_k_positive(sign_flag::Symbol, λ::Float64, k::Float64, m::Float64, m_prime::Float64,
-    μ::Float64, T::Float64, Φ::Float64, Φbar::Float64, E::Float64)
+@inline @fastmath function real_integrand_k_positive(sign_flag::Symbol, λ::T, k::Float64, m::Float64, m_prime::Float64,
+    μ::Float64, T0::Float64, Φ::Float64, Φbar::Float64, E::Float64) where {T<:Real}
     p = internal_momentum(E, m)
-    dist = distribution_value_b0(sign_flag, E, μ, T, Φ, Φbar)
+    dist = distribution_value_b0(sign_flag, E, μ, T0, Φ, Φbar)
     common_part = (λ + E)^2 - m_prime^2
     numerator = common_part - (p - k)^2
     denominator = common_part - (p + k)^2
@@ -241,14 +247,14 @@ end
 
     # 避免除以 0 造成 Inf/NaN
     if abs(denominator) < EPS_SEGMENT
-        denominator = (denominator == 0.0) ? EPS_SEGMENT : sign(denominator) * EPS_SEGMENT
+        denominator = (denominator == zero(T)) ? T(EPS_SEGMENT) : sign(denominator) * T(EPS_SEGMENT)
     end
 
     ratio = abs(numerator / denominator)
     if !isfinite(ratio)
         return 0.0
     end
-    ratio = max(ratio, 1e-300)
+    ratio = max(ratio, T(1e-300))
     log_term = log(ratio)
     if !isfinite(log_term)
         return 0.0
@@ -268,15 +274,16 @@ k>0 时的奇点计算函数
 - a < 0 (λ² < k²): 虚部积分区间为 [Emin, E1] ∪ [E2, Emax]
 - a ≈ 0 (λ² ≈ k²): 退化为线性情况，特殊处理
 """
-@inline function singularity_k_positive(λ::Float64, k::Float64, m::Float64, m_prime::Float64,
-    Emin::Float64, Emax::Float64)::Tuple{Vector{Tuple{Float64, Float64}}, Symbol}
+@inline function singularity_k_positive(λ::T, k::Float64, m::Float64, m_prime::Float64,
+    Emin::Float64, Emax::Float64)::Tuple{Vector{Tuple{Float64, Float64}}, Symbol} where {T<:Real}
     # 解析解：
     # E_{1,2} = [λ(λ^2 - k^2 + m^2 - m'^2) ± k * sqrt((λ^2 - k^2 + m^2 - m'^2)^2 - 4 m^2 (k^2 - λ^2))] / [2 (k^2 - λ^2)]
     
     intervals = Tuple{Float64, Float64}[]
     
-    a = λ ^ 2 - k ^ 2                # 二次项系数
-    d0 = k ^ 2 - λ ^ 2               # 分母的一半系数 (未乘 2) = -a
+    λ0 = _primal_value(λ)
+    a = λ0 ^ 2 - k ^ 2                # 二次项系数
+    d0 = k ^ 2 - λ0 ^ 2               # 分母的一半系数 (未乘 2) = -a
     denom = 2.0 * d0                 # 实际分母 2(k^2 - λ^2) = -2a
     
     # 情况3: a ≈ 0 (λ² ≈ k²)，退化为线性情况
@@ -286,10 +293,10 @@ k>0 时的奇点计算函数
         # 有解条件: λ > 0 且 m' > m
         # 解的范围: E > (m'² - m²)/(4λ) + λm²/(m'² - m²)
         
-        if λ > 0.0 && m_prime > m
+        if λ0 > 0.0 && m_prime > m
             # 计算临界能量
             m2_diff = m_prime ^ 2 - m ^ 2
-            E_crit = m2_diff / (4.0 * λ) + λ * m ^ 2 / m2_diff
+            E_crit = m2_diff / (4.0 * λ0) + λ0 * m ^ 2 / m2_diff
             
             # 虚部积分区间为 [max(E_crit, Emin), Emax]
             if E_crit < Emax
@@ -301,7 +308,7 @@ k>0 时的奇点计算函数
         return (intervals, :none)
     end
     
-    A = λ ^ 2 - k ^ 2 + m ^ 2 - m_prime ^ 2
+    A = λ0 ^ 2 - k ^ 2 + m ^ 2 - m_prime ^ 2
     disc = A ^ 2 + 4.0 * m ^ 2 * d0    # 判别式
     
     # 判别式为负无实根
@@ -310,8 +317,8 @@ k>0 时的奇点计算函数
     end
     
     sqrt_disc = sqrt(disc)
-    E1 = (λ * A - k * sqrt_disc) / denom
-    E2 = (λ * A + k * sqrt_disc) / denom
+    E1 = (λ0 * A - k * sqrt_disc) / denom
+    E2 = (λ0 * A + k * sqrt_disc) / denom
     
     # 保证 E1 <= E2
     if E1 > E2
@@ -450,36 +457,36 @@ end
     return total
 end
 
-function tilde_B0_k_positive(sign_flag::Symbol, λ::Float64, k::Float64, m::Float64, m_prime::Float64, μ::Float64, T::Float64,
-    Φ::Float64, Φbar::Float64)
+function tilde_B0_k_positive(sign_flag::Symbol, λ::T, k::Float64, m::Float64, m_prime::Float64, μ::Float64, T0::Float64,
+    Φ::Float64, Φbar::Float64) where {T<:Real}
     m_pos = max(m, 0.0)
     m_prime_pos = max(m_prime, 0.0)
     Emin = m_pos
     Emax = energy_cutoff(m_pos)
-    integrand_fun(E) = real_integrand_k_positive(sign_flag, λ, k, m_pos, m_prime_pos, μ, T, Φ, Φbar, E) # 闭包被积函数
-    intervals, sign_type = singularity_k_positive(λ, k, m_pos, m_prime_pos, Emin, Emax)
+    integrand_fun(E) = real_integrand_k_positive(sign_flag, λ, k, m_pos, m_prime_pos, μ, T0, Φ, Φbar, E) # 闭包被积函数
+    intervals, _ = singularity_k_positive(λ, k, m_pos, m_prime_pos, Emin, Emax)
     
-    imag_part = 0.0
+    imag_part = zero(T)
     real_part = integrate_piecewise_hybrid(integrand_fun, Emin, Emax, intervals)
     
     # 根据区间类型计算虚部
     if !isempty(intervals)
         for (E1, E2) in intervals
-            imag_part += distribution_integral_b0(sign_flag, E1, E2, μ, T, Φ, Φbar)
+            imag_part += T(distribution_integral_b0(sign_flag, E1, E2, μ, T0, Φ, Φbar))
         end
-        imag_part *= π * sign(λ)
+        imag_part *= T(π) * sign(λ)
     end
     
     return real_part / k, imag_part / k
 end
 
 """计算单个 ̃B0 分量的函数"""
-@inline function tilde_B0(sign_flag::Symbol, λ::Float64, k::Float64, m::Float64, m_prime::Float64, μ::Float64, T::Float64,
-    Φ::Float64, Φbar::Float64)
+@inline function tilde_B0(sign_flag::Symbol, λ::T, k::Float64, m::Float64, m_prime::Float64, μ::Float64, T0::Float64,
+    Φ::Float64, Φbar::Float64) where {T<:Real}
     if abs(k) < EPS_K
-        return tilde_B0_k_zero(sign_flag, λ, m, m_prime, μ, T, Φ, Φbar)
+        return tilde_B0_k_zero(sign_flag, λ, m, m_prime, μ, T0, Φ, Φbar)
     else
-        return tilde_B0_k_positive(sign_flag, λ, k, m, m_prime, μ, T, Φ, Φbar)
+        return tilde_B0_k_positive(sign_flag, λ, k, m, m_prime, μ, T0, Φ, Φbar)
     end
 end
 
@@ -488,12 +495,12 @@ end
 根据文档公式组合四个 ̃B0 项得到完整的 B₀ 积分。
 λ = k0 + μ1 - μ2, 其中k0是传播子能量
 """
-function B0(λ::Float64, k::Float64, m1::Float64, μ1::Float64, m2::Float64, μ2::Float64, T::Float64;
-    Φ::Float64=0.0, Φbar::Float64=0.0)
-    term1 = tilde_B0(:plus, -λ, k, m1, m2, μ1, T, Φ, Φbar)
-    term2 = tilde_B0(:minus, λ, k, m1, m2, μ1, T, Φ, Φbar)
-    term3 = tilde_B0(:plus, λ, k, m2, m1, μ2, T, Φ, Φbar)
-    term4 = tilde_B0(:minus, -λ, k, m2, m1, μ2, T, Φ, Φbar)
+function B0(λ::T, k::Float64, m1::Float64, μ1::Float64, m2::Float64, μ2::Float64, T0::Float64;
+    Φ::Float64=0.0, Φbar::Float64=0.0) where {T<:Real}
+    term1 = tilde_B0(:plus, -λ, k, m1, m2, μ1, T0, Φ, Φbar)
+    term2 = tilde_B0(:minus, λ, k, m1, m2, μ1, T0, Φ, Φbar)
+    term3 = tilde_B0(:plus, λ, k, m2, m1, μ2, T0, Φ, Φbar)
+    term4 = tilde_B0(:minus, -λ, k, m2, m1, μ2, T0, Φ, Φbar)
 
     real_part = term1[1] - term2[1] + term3[1] - term4[1]
     imag_part = term1[2] - term2[2] + term3[2] - term4[2]

--- a/src/relaxtime/OneLoopIntegrals.jl
+++ b/src/relaxtime/OneLoopIntegrals.jl
@@ -122,14 +122,14 @@ end
     dist = distribution_value_b0(sign_flag, E, μ, T0, Φ, Φbar)
     denominator = λ * E + denominator_term
     if !isfinite(p) || !isfinite(dist) || !isfinite(denominator)
-        return 0.0
+        return zero(denominator)
     end
     if abs(denominator) < EPS_SEGMENT
         # PV 附近直接返回 0，避免 1/0 -> Inf/NaN
-        return 0.0
+        return zero(denominator)
     end
     val = p * dist / denominator
-    return isfinite(val) ? val : 0.0
+    return isfinite(val) ? val : zero(val)
 end
 
 """k=0时的奇点计算函数
@@ -237,12 +237,12 @@ end
     numerator = common_part - (p - k)^2
     denominator = common_part - (p + k)^2
     if !isfinite(p) || !isfinite(dist) || !isfinite(numerator) || !isfinite(denominator)
-        return 0.0
+        return zero(common_part)
     end
 
     # 避免 0/0 -> NaN（这是你看到 quadgk 报 NaN 的典型触发点）
     if abs(numerator) < EPS_SEGMENT && abs(denominator) < EPS_SEGMENT
-        return 0.0
+        return zero(common_part)
     end
 
     # 避免除以 0 造成 Inf/NaN
@@ -252,15 +252,15 @@ end
 
     ratio = abs(numerator / denominator)
     if !isfinite(ratio)
-        return 0.0
+        return zero(ratio)
     end
     ratio = max(ratio, T(1e-300))
     log_term = log(ratio)
     if !isfinite(log_term)
-        return 0.0
+        return zero(log_term)
     end
     val = dist * log_term
-    return isfinite(val) ? val : 0.0
+    return isfinite(val) ? val : zero(val)
 end
 
 """

--- a/src/relaxtime/OneLoopIntegrals.jl
+++ b/src/relaxtime/OneLoopIntegrals.jl
@@ -38,7 +38,7 @@ const PV_GAP_REL = 1e-6
 end
 
 """计算给定能量和质量对应的动量"""
-@inline @fastmath function internal_momentum(E::Float64, m::Float64)
+@inline @fastmath function internal_momentum(E::T, m::Float64) where {T<:Real}
     m_pos = max(m, 0.0)
     return sqrt(E * E - m_pos * m_pos)
 end

--- a/src/relaxtime/OneLoopIntegralsAniso.jl
+++ b/src/relaxtime/OneLoopIntegralsAniso.jl
@@ -8,10 +8,14 @@ export B0_correction, A_correction, A_aniso,
 
 import ..GaussLegendre  # needed by IntervalQuadratureStrategies
 include("../integration/IntervalQuadratureStrategies.jl")
+using ForwardDiff
 using ..GaussLegendre: transform_standard16, transform_standard32, gauleg, gausslegendre
 using Main.PNJLQuarkDistributions_Aniso: correction_cos_theta_coefficient, distribution_aniso
 using ..OneLoopIntegrals: internal_momentum, EPS_K,
     energy_cutoff, singularity_k_positive, const_integral_term_A
+
+@inline _primal_value(x::Float64) = x
+@inline _primal_value(x::ForwardDiff.Dual) = ForwardDiff.value(x)
 
 """ k>0时
 对x积分所得结果的Sokhotski–Plemelj formula实部部分(柯西主值积分)
@@ -21,7 +25,7 @@ using ..OneLoopIntegrals: internal_momentum, EPS_K,
 A对应的形参名:coeff_x
 B对应的形参名:denominator_const
 """
-function real_integral_tool(coeff_x::Float64, denominator_const::Float64)
+function real_integral_tool(coeff_x::Float64, denominator_const::T) where {T<:Real}
     term1 = -2*denominator_const/coeff_x^2
     term2 = denominator_const^2/coeff_x^3
     log_arg = (coeff_x + denominator_const) / (coeff_x - denominator_const)
@@ -31,19 +35,19 @@ function real_integral_tool(coeff_x::Float64, denominator_const::Float64)
 end
 
 """对x积分的虚部部分"""
-function imag_integral_tool(coeff_x::Float64, denominator_const::Float64)
+function imag_integral_tool(coeff_x::Float64, denominator_const::T) where {T<:Real}
     return π *denominator_const ^ 2 / coeff_x^3
 end
 
 """阶跃函数,确保奇点出现在积分范围内时才贡献虚部"""
-@inline function heaviside_step(coeff_x::Float64, denominator_const::Float64, x_min::Float64, x_max::Float64)
+@inline function heaviside_step(coeff_x::T1, denominator_const::T2, x_min::Float64, x_max::Float64) where {T1<:Real,T2<:Real}
     # 计算奇点位置
-    x = -denominator_const / coeff_x 
+    x = -_primal_value(denominator_const) / _primal_value(coeff_x)
     return (x >= x_min && x <= x_max) ? 1.0 : 0.0
 end
 
 """coeff_x和denominator_const的计算函数"""
-@inline function compute_coefficients(λ::Float64, k::Float64, m::Float64, m_prime::Float64, E::Float64)
+@inline function compute_coefficients(λ::T, k::Float64, m::Float64, m_prime::Float64, E::Float64) where {T<:Real}
     if k>EPS_K # k>0
         denominator_const = λ^2+2*λ*E + m^2 - m_prime^2-k^2
         p = internal_momentum(E,m)
@@ -61,8 +65,8 @@ end
 返回值 f(E) = (4/3) * p(E) * correction_cos_theta_coefficient(...)
 此函数仅计算分子部分，便于在外部进行奇点减法或在不同分母下复用。
 """
-function real_integrand_k_zero_numer(sign_::Symbol, λ::Float64, m::Float64, m_prime::Float64, E::Float64,
-    ξ::Float64, T::Float64, μ::Float64, Φ::Float64, Φbar::Float64)
+function real_integrand_k_zero_numer(sign_::Symbol, λ::R, m::Float64, m_prime::Float64, E::Float64,
+    ξ::Float64, T::Float64, μ::Float64, Φ::Float64, Φbar::Float64) where {R<:Real}
     p = internal_momentum(E, m)
     return (4.0/3.0) * p * correction_cos_theta_coefficient(sign_, p, m, μ, T, Φ, Φbar, ξ)
 end
@@ -72,22 +76,22 @@ end
 返回值 denom(E) = coeff_E * E + denominator_const
 此处复用 `compute_coefficients` 的 k=0 分支以确保与其它代码一致。
 """
-@inline function real_integrand_k_zero_denom(λ::Float64, m::Float64, m_prime::Float64, E::Float64)
+@inline function real_integrand_k_zero_denom(λ::T, m::Float64, m_prime::Float64, E::Float64) where {T<:Real}
     coeff_E, denominator_const = compute_coefficients(λ, 0.0, m, m_prime, E)
     return coeff_E * E + denominator_const
 end
 
 """k=0时的积分实部被积函数（保留原名，用分子/分母组合）"""
-function real_integrand_k_zero(sign_::Symbol, λ::Float64, m::Float64, m_prime::Float64, E::Float64,
-    ξ::Float64, T::Float64, μ::Float64, Φ::Float64, Φbar::Float64)
+function real_integrand_k_zero(sign_::Symbol, λ::R, m::Float64, m_prime::Float64, E::Float64,
+    ξ::Float64, T::Float64, μ::Float64, Φ::Float64, Φbar::Float64) where {R<:Real}
     num = real_integrand_k_zero_numer(sign_, λ, m, m_prime, E, ξ, T, μ, Φ, Φbar)
     den = real_integrand_k_zero_denom(λ, m, m_prime, E)
     return isfinite(den) && isfinite(num) ? num / den : 0.0
 end
 
 """k>0时的积分实部被积函数"""
-function real_integrand_k_positive(sign_::Symbol, λ::Float64, k::Float64, m::Float64, m_prime::Float64, E::Float64,
-    ξ::Float64, T::Float64, μ::Float64, Φ::Float64, Φbar::Float64)
+function real_integrand_k_positive(sign_::Symbol, λ::R, k::Float64, m::Float64, m_prime::Float64, E::Float64,
+    ξ::Float64, T::Float64, μ::Float64, Φ::Float64, Φbar::Float64) where {R<:Real}
     coeff_x, denominator_const = compute_coefficients(λ, k, m, m_prime, E)
     p = internal_momentum(E,m)
     # 含各向异性修正项
@@ -97,8 +101,8 @@ function real_integrand_k_positive(sign_::Symbol, λ::Float64, k::Float64, m::Fl
 end
 
 """k=0时的积分虚部函数"""
-function imag_integrand_k_zero(sign_::Symbol, λ::Float64, m::Float64, m_prime::Float64,
-    ξ::Float64, T::Float64, μ::Float64, Φ::Float64, Φbar::Float64)
+function imag_integrand_k_zero(sign_::Symbol, λ::R, m::Float64, m_prime::Float64,
+    ξ::Float64, T::Float64, μ::Float64, Φ::Float64, Φbar::Float64) where {R<:Real}
     coeff_E, denominator_const = compute_coefficients(λ, 0.0, m, m_prime, 0.0)
     E_pole = -denominator_const / coeff_E
     Θ = heaviside_step(coeff_E, denominator_const, m, energy_cutoff(m))
@@ -107,15 +111,14 @@ function imag_integrand_k_zero(sign_::Symbol, λ::Float64, m::Float64, m_prime::
     else
         p_pole = internal_momentum(E_pole,m)
         # 含各向异性修正项
-        imag_ = π*(4.0/3.0)*p_pole/coeff_E*
-            correction_cos_theta_coefficient(sign_, p_pole, m, μ, T, Φ, Φbar, ξ)
+        imag_ = R(π*(4.0/3.0)*p_pole)*correction_cos_theta_coefficient(sign_, p_pole, m, μ, T, Φ, Φbar, ξ) / coeff_E
         return imag_
     end
 end
 
 """k>0时的积分虚部被积函数"""
-function imag_integrand_k_positive(sign_::Symbol, λ::Float64, k::Float64, m::Float64, m_prime::Float64, E::Float64,
-    ξ::Float64, T::Float64, μ::Float64, Φ::Float64, Φbar::Float64)
+function imag_integrand_k_positive(sign_::Symbol, λ::R, k::Float64, m::Float64, m_prime::Float64, E::Float64,
+    ξ::Float64, T::Float64, μ::Float64, Φ::Float64, Φbar::Float64) where {R<:Real}
 
     coeff_x, denominator_const = compute_coefficients(λ, k, m, m_prime, E)
     
@@ -127,18 +130,18 @@ function imag_integrand_k_positive(sign_::Symbol, λ::Float64, k::Float64, m::Fl
 end
 
 """k=0时的 B0分量 含各向异性修正项的积分计算"""
-function tilde_B0_correction_k_zero(sign_::Symbol, λ::Float64, m::Float64, m_prime::Float64, μ::Float64, T::Float64,
-    Φ::Float64, Φbar::Float64, ξ::Float64)
+function tilde_B0_correction_k_zero(sign_::Symbol, λ::T, m::Float64, m_prime::Float64, μ::Float64, T0::Float64,
+    Φ::Float64, Φbar::Float64, ξ::Float64) where {T<:Real}
     Emin = m
     Emax = energy_cutoff(m)
     # 采用奇点减法：f(E) = (4/3)*p(E)*correction(...) ，integrand = f(E) / (coeff_E*E + denominator_const)
-    coeff_E = 2.0 * λ
+    coeff_E = T(2) * λ
     denominator_const = λ^2 + m^2 - m_prime^2
 
     # 寻找奇点 E0，当 coeff_E != 0 时
     E0 = nothing
-    if coeff_E != 0.0
-        E0_val = -denominator_const / coeff_E
+    if _primal_value(coeff_E) != 0.0
+        E0_val = -_primal_value(denominator_const) / _primal_value(coeff_E)
         if isfinite(E0_val) && (E0_val >= Emin) && (E0_val <= Emax)
             E0 = E0_val
         end
@@ -155,34 +158,37 @@ function tilde_B0_correction_k_zero(sign_::Symbol, λ::Float64, m::Float64, m_pr
     # 使用 GL 节点处直接评估剩余函数 (f(E)-A)/den，节点恰好命中奇点的概率极小。
     if E0 !== nothing
         # 直接调用分子函数计算 A = f(E0)
-        A = real_integrand_k_zero_numer(sign_, λ, m, m_prime, E0, ξ, T, μ, Φ, Φbar)
-        vals = similar(nodes)
+        A = real_integrand_k_zero_numer(sign_, λ, m, m_prime, E0, ξ, T0, μ, Φ, Φbar)
+        real_part = zero(T)
         @inbounds for i in eachindex(nodes)
             E = nodes[i]
             den = coeff_E * E + denominator_const
-            v = (real_integrand_k_zero_numer(sign_, λ, m, m_prime, E, ξ, T, μ, Φ, Φbar) - A)
-            vals[i] = isfinite(den) && isfinite(v) ? v / den : 0.0
+            v = (real_integrand_k_zero_numer(sign_, λ, m, m_prime, E, ξ, T0, μ, Φ, Φbar) - A)
+            if isfinite(den) && isfinite(v)
+                real_part += weights[i] * (v / den)
+            end
         end
-        real_part = sum(weights .* vals)
         # 将常数项 A 的主值积分解析部分加回：
         # PV ∫_Emin^Emax A / (coeff_E * E + denominator_const) dE = A/coeff_E * ln|coeff_E*E + denominator_const| |_Emin^Emax
-        if coeff_E != 0.0
+        if _primal_value(coeff_E) != 0.0
             real_part += A/coeff_E * (log(abs(coeff_E * Emax + denominator_const)) - log(abs(coeff_E * Emin + denominator_const)))
         end
         imag_part = imag_integrand_k_zero(sign_, λ, m, m_prime,
-            ξ, T, μ, Φ, Φbar)
+            ξ, T0, μ, Φ, Φbar)
         return real_part, imag_part
     else
         # 无奇点或 coeff_E == 0：直接用 GL 对原始实部被积函数求积
-        vals = similar(nodes)
+        real_part = zero(T)
         @inbounds for i in eachindex(nodes)
             E = nodes[i]
-            vals[i] = real_integrand_k_zero(sign_, λ, m, m_prime, E,
-                ξ, T, μ, Φ, Φbar)
+            v = real_integrand_k_zero(sign_, λ, m, m_prime, E,
+                ξ, T0, μ, Φ, Φbar)
+            if isfinite(v)
+                real_part += weights[i] * v
+            end
         end
-        real_part = sum(weights .* vals)
         imag_part = imag_integrand_k_zero(sign_, λ, m, m_prime,
-            ξ, T, μ, Φ, Φbar)
+            ξ, T0, μ, Φ, Φbar)
         return real_part , imag_part
     end
 end
@@ -202,11 +208,12 @@ end
 
 返回在 [Emin, Emax] 范围内的有效根。
 """
-function find_roots_AB(λ::Float64, k::Float64, m::Float64, m_prime::Float64, Emin::Float64, Emax::Float64)
-    C = λ^2 + m^2 - m_prime^2 - k^2
+function find_roots_AB(λ::T, k::Float64, m::Float64, m_prime::Float64, Emin::Float64, Emax::Float64) where {T<:Real}
+    λ0 = _primal_value(λ)
+    C = λ0^2 + m^2 - m_prime^2 - k^2
     
-    a = k^2 - λ^2
-    b = -λ * C
+    a = k^2 - λ0^2
+    b = -λ0 * C
     c = -(k^2 * m^2 + C^2 / 4)
     
     # 处理 a ≈ 0 的情况 (k ≈ |λ|)
@@ -220,7 +227,7 @@ function find_roots_AB(λ::Float64, k::Float64, m::Float64, m_prime::Float64, Em
             # 验证原方程
             p = sqrt(max(0.0, E^2 - m^2))
             A = 2*k*p
-            B = λ^2 + 2*λ*E + m^2 - m_prime^2 - k^2
+            B = λ0^2 + 2*λ0*E + m^2 - m_prime^2 - k^2
             if abs(A + B) < 1e-10 || abs(A - B) < 1e-10
                 return [E]
             end
@@ -249,7 +256,7 @@ function find_roots_AB(λ::Float64, k::Float64, m::Float64, m_prime::Float64, Em
             # 验证原方程 A ± B = 0
             p = sqrt(E^2 - m^2)
             A = 2*k*p
-            B = λ^2 + 2*λ*E + m^2 - m_prime^2 - k^2
+            B = λ0^2 + 2*λ0*E + m^2 - m_prime^2 - k^2
             
             # A + B = 0 或 A - B = 0
             if abs(A + B) < 1e-10 || abs(A - B) < 1e-10
@@ -295,17 +302,17 @@ end
 返回:
 - (real_part, imag_part) 或 (real_part, imag_part, diagnostics)
 """
-function tilde_B0_correction_k_positive(sign_::Symbol, λ::Float64, k::Float64, m::Float64, m_prime::Float64, μ::Float64, T::Float64,
+function tilde_B0_correction_k_positive(sign_::Symbol, λ::T, k::Float64, m::Float64, m_prime::Float64, μ::Float64, T0::Float64,
     Φ::Float64, Φbar::Float64, ξ::Float64;
-    diagnostics::Bool=false)
+    diagnostics::Bool=false) where {T<:Real}
     
     t_start = time()
     Emin = m
     Emax = energy_cutoff(m)
 
     # 被积函数闭包
-    integrand_real(E) = real_integrand_k_positive(sign_, λ, k, m, m_prime, E, ξ, T, μ, Φ, Φbar)
-    integrand_imag(E) = imag_integrand_k_positive(sign_, λ, k, m, m_prime, E, ξ, T, μ, Φ, Φbar)
+    integrand_real(E) = real_integrand_k_positive(sign_, λ, k, m, m_prime, E, ξ, T0, μ, Φ, Φbar)
+    integrand_imag(E) = imag_integrand_k_positive(sign_, λ, k, m, m_prime, E, ξ, T0, μ, Φ, Φbar)
 
     # 获取虚部积分区间
     intervals_imag, _ = singularity_k_positive(λ, k, m, m_prime, Emin, Emax)
@@ -344,7 +351,7 @@ function tilde_B0_correction_k_positive(sign_::Symbol, λ::Float64, k::Float64, 
     end
     
     # 计算虚部（使用标准 16 节点 GL，无分配）
-    imag_part = 0.0
+    imag_part = zero(T)
     if !isempty(intervals_imag)
         for (E1, E2) in intervals_imag
             half = (E2 - E1) / 2
@@ -376,13 +383,13 @@ function tilde_B0_correction_k_positive(sign_::Symbol, λ::Float64, k::Float64, 
 end
 
 """含各向异性修正项的 B0分量 积分计算"""
-function tilde_B0_correction(sign_::Symbol, λ::Float64, k::Float64, m::Float64, m_prime::Float64, μ::Float64, T::Float64,
-    Φ::Float64, Φbar::Float64, ξ::Float64)
+function tilde_B0_correction(sign_::Symbol, λ::T, k::Float64, m::Float64, m_prime::Float64, μ::Float64, T0::Float64,
+    Φ::Float64, Φbar::Float64, ξ::Float64) where {T<:Real}
     if k > EPS_K
-        return tilde_B0_correction_k_positive(sign_, λ, k, m, m_prime, μ, T,
+        return tilde_B0_correction_k_positive(sign_, λ, k, m, m_prime, μ, T0,
             Φ, Φbar, ξ)
     else
-        return tilde_B0_correction_k_zero(sign_, λ, m, m_prime, μ, T,
+        return tilde_B0_correction_k_zero(sign_, λ, m, m_prime, μ, T0,
             Φ, Φbar, ξ)
     end
 end
@@ -391,13 +398,13 @@ end
     B0_correction(λ, k, m1, m2, μ1, μ2, T, Φ, Φbar, ξ)
 动量各向异性下B0的一阶修正
 """
-function B0_correction(λ::Float64, k::Float64, m1::Float64, m2::Float64, μ1::Float64, μ2::Float64, T::Float64,
-    Φ::Float64, Φbar::Float64, ξ::Float64)
+function B0_correction(λ::T, k::Float64, m1::Float64, m2::Float64, μ1::Float64, μ2::Float64, T0::Float64,
+    Φ::Float64, Φbar::Float64, ξ::Float64) where {T<:Real}
 
-    term1 = tilde_B0_correction(:quark, -λ, k, m1, m2, μ1, T, Φ, Φbar, ξ)
-    term2 = tilde_B0_correction(:antiquark, λ, k, m1, m2, μ1, T, Φ, Φbar, ξ)
-    term3 = tilde_B0_correction(:quark, λ, k, m2, m1, μ2, T, Φ, Φbar, ξ)
-    term4 = tilde_B0_correction(:antiquark, -λ, k, m2, m1, μ2, T, Φ, Φbar, ξ)
+    term1 = tilde_B0_correction(:quark, -λ, k, m1, m2, μ1, T0, Φ, Φbar, ξ)
+    term2 = tilde_B0_correction(:antiquark, λ, k, m1, m2, μ1, T0, Φ, Φbar, ξ)
+    term3 = tilde_B0_correction(:quark, λ, k, m2, m1, μ2, T0, Φ, Φbar, ξ)
+    term4 = tilde_B0_correction(:antiquark, -λ, k, m2, m1, μ2, T0, Φ, Φbar, ξ)
 
     # 注意：B0 的 pm=-1(antiquark) 分支语义是 NJL 中的f(-E-μ)=1-f(E+μ)
     # 这里f(E+μ)是NJL中反粒子的分布函数，为避免 PNJL 分布在负能量下的数值溢出，

--- a/src/relaxtime/OneLoopIntegralsAniso.jl
+++ b/src/relaxtime/OneLoopIntegralsAniso.jl
@@ -86,7 +86,7 @@ function real_integrand_k_zero(sign_::Symbol, λ::R, m::Float64, m_prime::Float6
     ξ::Float64, T::Float64, μ::Float64, Φ::Float64, Φbar::Float64) where {R<:Real}
     num = real_integrand_k_zero_numer(sign_, λ, m, m_prime, E, ξ, T, μ, Φ, Φbar)
     den = real_integrand_k_zero_denom(λ, m, m_prime, E)
-    return isfinite(den) && isfinite(num) ? num / den : 0.0
+    return isfinite(den) && isfinite(num) ? num / den : zero(den)
 end
 
 """k>0时的积分实部被积函数"""
@@ -107,7 +107,7 @@ function imag_integrand_k_zero(sign_::Symbol, λ::R, m::Float64, m_prime::Float6
     E_pole = -denominator_const / coeff_E
     Θ = heaviside_step(coeff_E, denominator_const, m, energy_cutoff(m))
     if Θ == 0.0
-        return 0.0
+        return zero(coeff_E)
     else
         p_pole = internal_momentum(E_pole,m)
         # 含各向异性修正项

--- a/src/relaxtime/PolarizationAniso.jl
+++ b/src/relaxtime/PolarizationAniso.jl
@@ -68,37 +68,37 @@ end
 在保持实数B0积分路径的前提下，引入复数能量 p0 = k0 + i*gamma/2 的宽度效应。
 返回 polarization_real, polarization_imag
 """
-function polarization_with_width(channel::Symbol, k0::Float64, gamma::Float64, k_norm::Float64,
+function polarization_with_width(channel::Symbol, k0::T, gamma::Float64, k_norm::Float64,
                                  m1::Float64, m2::Float64, μ1::Float64, μ2::Float64,
-                                 T::Float64, Φ::Float64, Φbar::Float64,
-                                 ξ::Float64, A1_value::Float64, A2_value::Float64, num_s_quark::Int)
-    factor = -N_color / (8π^2)
+                                 T0::Float64, Φ::Float64, Φbar::Float64,
+                                 ξ::Float64, A1_value::Float64, A2_value::Float64, num_s_quark::Int) where {T<:Real}
+    factor = T(-N_color / (8π^2))
     λ = k0 + μ1 - μ2
 
     # 计算B0函数项（仍走实数路径）
-    B0_real, B0_imag = B0(λ, k_norm, m1, μ1, m2, μ2, T; Φ=Φ, Φbar=Φbar)
+    B0_real, B0_imag = B0(λ, k_norm, m1, μ1, m2, μ2, T0; Φ=Φ, Φbar=Φbar)
     if num_s_quark == 1
         λ_extra = -k0 + μ1 - μ2
-        B0_real_extra, B0_imag_extra = B0(λ_extra, k_norm, m1, μ1, m2, μ2, T; Φ=Φ, Φbar=Φbar)
-        B0_real = 0.5 * (B0_real + B0_real_extra)
-        B0_imag = 0.5 * (B0_imag + B0_imag_extra)
+        B0_real_extra, B0_imag_extra = B0(λ_extra, k_norm, m1, μ1, m2, μ2, T0; Φ=Φ, Φbar=Φbar)
+        B0_real = T(0.5) * (B0_real + B0_real_extra)
+        B0_imag = T(0.5) * (B0_imag + B0_imag_extra)
     end
 
     # 计算B0函数项的修正
     if abs(ξ) > EPS_SEGMENT
-        B0_corr_real, B0_corr_imag = B0_correction(λ, k_norm, m1, m2, μ1, μ2, T, Φ, Φbar, ξ)
+        B0_corr_real, B0_corr_imag = B0_correction(λ, k_norm, m1, m2, μ1, μ2, T0, Φ, Φbar, ξ)
         if num_s_quark == 1
-            B0_corr_real_extra, B0_corr_imag_extra = B0_correction(λ_extra, k_norm, m1, m2, μ1, μ2, T, Φ, Φbar, ξ)
-            B0_corr_real = 0.5 * (B0_corr_real + B0_corr_real_extra)
-            B0_corr_imag = 0.5 * (B0_corr_imag + B0_corr_imag_extra)
+            B0_corr_real_extra, B0_corr_imag_extra = B0_correction(λ_extra, k_norm, m1, m2, μ1, μ2, T0, Φ, Φbar, ξ)
+            B0_corr_real = T(0.5) * (B0_corr_real + B0_corr_real_extra)
+            B0_corr_imag = T(0.5) * (B0_corr_imag + B0_corr_imag_extra)
         end
-        B0_real += B0_corr_real
-        B0_imag += B0_corr_imag
+        B0_real += T(B0_corr_real)
+        B0_imag += T(B0_corr_imag)
     end
 
     # 组合极化函数实部/虚部（宽度通过组合项进入）
-    real_part = A1_value + A2_value
-    imag_part = 0.0
+    real_part = T(A1_value + A2_value)
+    imag_part = zero(T)
     prefactor = k_norm^2 - λ^2
     if channel == :P
         prefactor += (m1 - m2)^2
@@ -108,7 +108,7 @@ function polarization_with_width(channel::Symbol, k0::Float64, gamma::Float64, k
         throw(ArgumentError("Unsupported channel: $channel. Use :P or :S."))
     end
 
-    prefactor += (gamma^2) / 4.0
+    prefactor += T((gamma^2) / 4.0)
     real_part += prefactor * B0_real - gamma * λ * B0_imag
     imag_part += prefactor * B0_imag + gamma * λ * B0_real
 

--- a/tests/unit/models/test_meson_density_workflow.jl
+++ b/tests/unit/models/test_meson_density_workflow.jl
@@ -17,12 +17,14 @@ const _MDW = Models.MesonDensityWorkflow
         @test isdefined(_MDW, :solve_gap_and_strict_bw_meson_density_point)
         @test isdefined(_MDW, :solve_phase_shift_meson_density_from_meson_point)
         @test isdefined(_MDW, :solve_gap_and_phase_shift_meson_density_point)
+        @test isdefined(_MDW, :solve_phase_shift_derivative_reference_from_meson_point)
         @test _MDW.solve_meson_density_from_meson_point isa Function
         @test _MDW.solve_gap_and_meson_density_point isa Function
         @test _MDW.solve_strict_bw_meson_density_from_meson_point isa Function
         @test _MDW.solve_gap_and_strict_bw_meson_density_point isa Function
         @test _MDW.solve_phase_shift_meson_density_from_meson_point isa Function
         @test _MDW.solve_gap_and_phase_shift_meson_density_point isa Function
+        @test _MDW.solve_phase_shift_derivative_reference_from_meson_point isa Function
     end
 
     @testset "后处理消费 meson workflow 返回值" begin
@@ -329,5 +331,37 @@ const _MDW = Models.MesonDensityWorkflow
         @test !isapprox(current.n_K, gbu.n_K; rtol=1e-6, atol=1e-10)
         @test full.phase_shift_meson_density.n_pi ≈ gbu.n_pi rtol=1e-10
         @test full.phase_shift_meson_density.n_K ≈ gbu.n_K rtol=1e-10
+    end
+
+    @testset "Phase-E5 derivative reference 复用同一 workflow 入口" begin
+        T_fm = 210.0 / Main.Constants_PNJL.ħc_MeV_fm
+        muq_fm = 0.0
+
+        meson_point = Models.solve_gap_and_meson_point(
+            T_fm,
+            muq_fm;
+            xi=0.0,
+            mesons=(:pi, :K),
+            mixed_branch_align=:strict_sign_binding,
+            p_num=8,
+            t_num=4,
+            solver_kwargs=(iterations=20,),
+            mass_kwargs=(iterations=20,),
+        )
+
+        density = Models.solve_phase_shift_derivative_reference_from_meson_point(
+            meson_point;
+            scheme=:current,
+            qmax=4.0,
+            q_nodes=6,
+            omega_max=3.0,
+            omega_nodes=6,
+        )
+
+        @test density.derivative_backend == :forwarddiff
+        @test density.scheme == :phase_shift_current
+        @test isfinite(density.n_pi)
+        @test isfinite(density.n_K)
+        @test density.max_formula_abs_diff < 1e-8
     end
 end

--- a/tests/unit/relaxtime/test_meson_density.jl
+++ b/tests/unit/relaxtime/test_meson_density.jl
@@ -19,6 +19,9 @@ using Main.RelaxTime.MesonDensity: DEFAULT_MESON_DENSITY_Q_NODES,
                                    _phase_shift_scheme_symbol,
                                    bose_distribution,
                                    meson_degeneracy,
+                                   phase_shift_point_diagnostic,
+                                   phase_shift_meson_density_derivative_reference_summary,
+                                   phase_shift_meson_number_density_derivative_reference,
                                    phase_shift_meson_number_density,
                                    phase_shift_meson_density_summary,
                                    strict_bw_meson_density_summary,
@@ -184,4 +187,62 @@ end
     @test summary.k_density.scheme == :phase_shift_gbu_reference
     @test summary.n_pi > 0.0
     @test summary.n_K > 0.0
+end
+
+@testset "MesonDensity derivative-reference helper is AD-backed" begin
+    qp = (m=(u=0.098, d=0.098, s=0.42), μ=(u=0.0, d=0.0, s=0.0), A=(u=0.1, d=0.1, s=0.08))
+    tp = (T=0.18, Φ=0.25, Φbar=0.25, ξ=0.0)
+
+    single = phase_shift_meson_number_density_derivative_reference(
+        :pi, qp, tp;
+        scheme=:current,
+        qmax=4.0,
+        q_nodes=6,
+        omega_min=0.05,
+        omega_max=3.0,
+        omega_nodes=6,
+    )
+    @test single.derivative_backend == :forwarddiff
+    @test isfinite(single.density)
+    @test single.max_formula_abs_diff < 1e-8
+
+    summary = phase_shift_meson_density_derivative_reference_summary(
+        qp, tp;
+        scheme=:gbu_reference,
+        qmax=4.0,
+        q_nodes=6,
+        omega_min=0.05,
+        omega_max=3.0,
+        omega_nodes=6,
+    )
+    @test summary.derivative_backend == :forwarddiff
+    @test summary.scheme == :phase_shift_gbu_reference
+    @test isfinite(summary.n_pi)
+    @test isfinite(summary.n_K)
+    @test summary.max_formula_abs_diff < 1e-8
+end
+
+@testset "MesonDensity phase-shift point diagnostic AD vs FD" begin
+    qp = (m=(u=0.098, d=0.098, s=0.42), μ=(u=0.0, d=0.0, s=0.0), A=(u=0.1, d=0.1, s=0.08))
+    tp_iso = (T=0.18, Φ=0.25, Φbar=0.25, ξ=0.0)
+    tp_aniso = (T=0.18, Φ=0.25, Φbar=0.25, ξ=0.1)
+
+    diag_iso = phase_shift_point_diagnostic(:pi, 0.4, 0.5, qp, tp_iso; scheme=:current, fd_step=1e-5)
+    @test isfinite(diag_iso.dphase_ad)
+    @test isfinite(diag_iso.dphase_fd)
+    @test isfinite(diag_iso.dphase_raw_fd)
+    @test isfinite(diag_iso.dweighted_ad)
+    @test isfinite(diag_iso.dweighted_fd)
+    @test diag_iso.dphase_formula_abs_diff < 1e-8
+    @test abs(diag_iso.dReD_domega - diag_iso.dReD_fd) > 1e-3
+    @test abs(diag_iso.dImD_domega - diag_iso.dImD_fd) > 1e-3
+
+    diag_aniso = phase_shift_point_diagnostic(:pi, 0.4, 0.5, qp, tp_aniso; scheme=:current, fd_step=1e-5)
+    @test diag_aniso.xi ≈ 0.1
+    @test isfinite(diag_aniso.dphase_ad)
+    @test isfinite(diag_aniso.dphase_fd)
+    @test isfinite(diag_aniso.dphase_raw_fd)
+    @test diag_aniso.dphase_formula_abs_diff < 1e-8
+    @test abs(diag_aniso.dReD_domega - diag_aniso.dReD_fd) > 1e-3
+    @test abs(diag_aniso.dImD_domega - diag_aniso.dImD_fd) > 1e-3
 end

--- a/tests/unit/relaxtime/test_meson_phase_shift_dual_compat.jl
+++ b/tests/unit/relaxtime/test_meson_phase_shift_dual_compat.jl
@@ -1,0 +1,77 @@
+using Test
+using ForwardDiff
+
+const PROJECT_ROOT = normpath(joinpath(@__DIR__, "..", "..", ".."))
+
+const _CONSTANTS_PATH = normpath(joinpath(PROJECT_ROOT, "src", "constants", "Constants_PNJL.jl"))
+if !isdefined(Main, :Constants_PNJL)
+    Base.include(Main, _CONSTANTS_PATH)
+end
+
+const _RELAXTIME_PATH = normpath(joinpath(PROJECT_ROOT, "src", "relaxtime", "RelaxTime.jl"))
+if !isdefined(Main, :RelaxTime)
+    Base.include(Main, _RELAXTIME_PATH)
+end
+
+using Main.Constants_PNJL: G_fm2, K_fm5
+using Main.RelaxTime.OneLoopIntegrals: B0, A
+using Main.RelaxTime.GaussLegendre: gauleg
+using Main.RelaxTime.PolarizationAniso: polarization_with_width
+using Main.RelaxTime.EffectiveCouplings: calculate_effective_couplings
+using Main.RelaxTime.MesonPropagator: meson_propagator_simple
+
+@testset "meson phase-shift dual compatibility smoke" begin
+    T0 = 0.18
+    Φ = 0.2
+    Φbar = 0.2
+    m1 = 0.3
+    m2 = 0.3
+    μ1 = 0.0
+    μ2 = 0.0
+    γ = 0.05
+
+    @testset "B0 accepts Dual on k=0 and k>0 branches" begin
+        f_k0(x) = first(B0(x, 0.0, m1, μ1, m2, μ2, T0; Φ=Φ, Φbar=Φbar))
+        f_kp(x) = first(B0(x, 0.4, m1, μ1, m2, μ2, T0; Φ=Φ, Φbar=Φbar))
+
+        d_k0 = ForwardDiff.derivative(f_k0, 0.2)
+        d_kp = ForwardDiff.derivative(f_kp, 0.2)
+
+        @test isfinite(d_k0)
+        @test isfinite(d_kp)
+    end
+
+    nodes_p, weights_p = gauleg(0.0, 20.0, 24)
+    A1 = A(m1, μ1, T0, Φ, Φbar, nodes_p, weights_p)
+    A2 = A(m2, μ2, T0, Φ, Φbar, nodes_p, weights_p)
+    K_coeffs = calculate_effective_couplings(G_fm2, K_fm5, 1.2, 1.0)
+
+    @testset "polarization_with_width and meson_propagator_simple accept Dual for xi=0" begin
+        re_fun(ω) = begin
+            Πr, Πi = polarization_with_width(:P, ω, γ, 0.4, m1, m2, μ1, μ2, T0, Φ, Φbar, 0.0, A1, A2, 0)
+            real(meson_propagator_simple(:pi, K_coeffs, Complex(Πr, Πi)))
+        end
+        im_fun(ω) = begin
+            Πr, Πi = polarization_with_width(:P, ω, γ, 0.4, m1, m2, μ1, μ2, T0, Φ, Φbar, 0.0, A1, A2, 0)
+            imag(meson_propagator_simple(:pi, K_coeffs, Complex(Πr, Πi)))
+        end
+
+        d_re = ForwardDiff.derivative(re_fun, 0.2)
+        d_im = ForwardDiff.derivative(im_fun, 0.2)
+
+        @test isfinite(d_re)
+        @test isfinite(d_im)
+    end
+
+    @testset "anisotropic correction also accepts Dual after minimal λ-generic upgrade" begin
+        f_xi0(ω) = first(polarization_with_width(:P, ω, γ, 0.0, m1, m2, μ1, μ2, T0, Φ, Φbar, 0.3, A1, A2, 0))
+        d_xi0 = ForwardDiff.derivative(f_xi0, 0.2)
+        @test isfinite(d_xi0)
+
+        re_fun_xi(ω) = begin
+            Πr, Πi = polarization_with_width(:P, ω, γ, 0.4, m1, m2, μ1, μ2, T0, Φ, Φbar, 0.3, A1, A2, 0)
+            real(meson_propagator_simple(:pi, K_coeffs, Complex(Πr, Πi)))
+        end
+        @test isfinite(ForwardDiff.derivative(re_fun_xi, 0.2))
+    end
+end


### PR DESCRIPTION
## Summary
- add the AD-backed meson-density derivative reference and workflow-facing diagnostic entrypoints
- restore the dual-compatible meson phase core on the clean branch so the derivative reference path actually runs
- add focused AD benchmark scripts and document the promotion path in the active task docs

## Validation
- julia --project=. -e 'include("tests/unit/relaxtime/test_meson_density.jl")'
- julia --project=. -e 'include("tests/unit/models/test_meson_density_workflow.jl")'

## Notes
- base branch is `codex/meson-density-workflow-scan`, not `main`
- untracked local analysis outputs were intentionally left out of this PR
- current production meson-density workflow remains the weighted-phase/by-parts path; AD is promoted first as derivative-reference and diagnostic support