### PR TITLE
docs(dev): archive meson mass path scan task doc

### DIFF
--- a/docs/dev/archived/2026-05-07_介子质量沿特征线扫描任务单.md
+++ b/docs/dev/archived/2026-05-07_介子质量沿特征线扫描任务单.md
@@ -1,8 +1,20 @@
+---
+title: 介子质量沿特征线扫描任务单
+archived: true
+original: docs/dev/active/2026-05-07_介子质量沿特征线扫描任务单.md
+archived_date: 2026-05-09
+---
+
+
+以下为原始内容（保留，以便审阅与历史参考）：
+
+---
+
 # 介子质量沿特征线扫描任务单
 
 更新日期：2026-05-07
 
-当前状态：待收尾；本线最小可用实现、freeze-out 正式 case、CLI、README/provenance 与图资产已落地，当前进入收尾归一与提交前检查阶段。
+当前状态：已完成；本线最小可用实现、freeze-out 正式 case、CLI、README/provenance 与图资产已落地，且本线已明确不纳入 regression 基线治理范围。
 
 > 目的：把“沿特征线扫描介子质量”从临时脚本想法收束成正式、可复用、可验证、可扩展的扫描能力，而不是继续在单一网格脚本上叠加特判。
 
@@ -33,7 +45,7 @@
 - [x] 已有面向介子质量的等熵线扫描正式入口
 - [x] 已有面向介子质量的 chemical freeze-out 路径扫描正式入口
 - [x] 已有最小统一的“路径生成 / 路径点扫描 / path scan 壳”抽象，可服务 freezeout 与 isentropic meson workflow
-- [ ] regression / plot-review / data-layer 的长期治理口径仍未全部收束
+- [x] regression / plot-review / data-layer 的本线治理口径已收束
 
 本任务单的目标是：
 
@@ -88,7 +100,7 @@
 - [x] `Models` 已补 `run_*meson_mass*_scan` 风格的特征线路径入口
 - [x] 等熵线能力已上升为正式路径扫描产品能力
 - [x] freeze-out 路径能力已复用到 meson-mass workflow
-- [ ] regression 口径仍未补齐；plot-review / data-layer 治理仅完成最小 freeze-out case
+- [x] regression 已明确不纳入本线范围；plot-review / data-layer 已完成最小 freeze-out case 治理
 
 ### 3.3 当前阶段判断
 
@@ -279,9 +291,9 @@ freeze-out 复用途径有两种可选策略：
 
 ### 7.3 regression
 
-- [ ] 至少锁一条轻量等熵线 canonical case
-- [ ] 至少锁一条轻量 freeze-out canonical case
-- [ ] 不通过放宽容差掩盖 meson-mass 路径求解漂移
+- [x] 本线决定不纳入 regression 基线治理
+- [x] 不更新 baseline，不新增 regression fixture
+- [x] 数值稳定性以 unit / integration smoke 与正式产出 README/provenance/figure 资产留痕为准
 
 ### 7.4 plot-review / data-layer
 
@@ -327,10 +339,10 @@ freeze-out 复用途径有两种可选策略：
 
 - [x] 添加 unit / integration 最小覆盖
   - 验收：已补 path profile / entrypoint unit，以及一条 freeze-out 与一条 isentropic integration smoke
-- [ ] regression 最小覆盖
-  - 验收：本线按用户要求未更新 baseline，也未新增 regression fixture
+- [x] regression 范围决策
+  - 验收：本线按用户要求不更新 baseline，也不新增 regression fixture，并在任务单中明确为范围外决策
 - [x] 明确 plot-review / regression / data-layer 三层分工
-  - 验收：freeze-out 正式 case 已区分原始 CSV、过滤后 valid-points、README/provenance 与图资产；regression 继续留待后续治理
+  - 验收：freeze-out 正式 case 已区分原始 CSV、过滤后 valid-points、README/provenance 与图资产；regression 明确不纳入本线
 
 ---
 


### PR DESCRIPTION
## 变更范围
- 归档 2026-05-07_介子质量沿特征线扫描任务单
- 将任务单中的 regression 表述收口为本线明确不纳入 regression 基线治理

## 用户影响
- docs/dev/active/ 不再保留该任务单
- docs/dev/archived/ 中保留可追溯归档记录

## 实现方式
- 先更新 active 文档状态与 regression 范围结论
- 使用 scripts/dev/archive_docs.jl 执行标准归档
- 保留 archive frontmatter 与原始正文内容

## 验证项
- julia --project=. scripts/dev/archive_docs.jl -c
- julia --project=. scripts/dev/check_active_docs_governance.jl

## 已知非目标
- 不改动已合并功能 PR 的代码与结果产物
- 不补做 regression 基线或数值 fixture