### PR TITLE
fix(relaxtime): stabilize P1 manifest paths

### DIFF
--- a/scripts/relaxtime/build_paper_p1_figure_assets.py
+++ b/scripts/relaxtime/build_paper_p1_figure_assets.py
@@ -93,6 +93,10 @@ def default_asset_dir(out_dir: Path) -> Path:
     return out_dir / "figure_assets"
 
 
+def _manifest_path(path: Path) -> str:
+    return path.as_posix()
+
+
 def read_scan_csv(path: Path) -> list[dict[str, str]]:
     if not path.is_file():
         raise FileNotFoundError(path)
@@ -814,7 +818,7 @@ def plot_assets(
     for fmt_name in formats:
         target = figure_dir / f"p1_mott_phase_diagram.{fmt_name}"
         fig.savefig(target, dpi=300, bbox_inches="tight")
-        written.append(str(target))
+        written.append(_manifest_path(target))
     plt.close(fig)
 
     for xi in xi_values:
@@ -830,7 +834,7 @@ def plot_assets(
         for fmt_name in formats:
             target = figure_dir / f"p1_mott_phase_diagram_{tag}.{fmt_name}"
             fig.savefig(target, dpi=300, bbox_inches="tight")
-            written.append(str(target))
+            written.append(_manifest_path(target))
         plt.close(fig)
 
     if not trajectories:
@@ -892,7 +896,7 @@ def plot_assets(
     for fmt_name in formats:
         target = figure_dir / f"p1_isentropic_mott_paths.{fmt_name}"
         fig.savefig(target, dpi=300, bbox_inches="tight")
-        written.append(str(target))
+        written.append(_manifest_path(target))
     plt.close(fig)
 
     return written
@@ -970,10 +974,10 @@ def main() -> int:
     phase_fields = ["kind", "xi", "muB_MeV", "T_MeV", "variable", "curve_parameter", "plot_order_key", "source_csv"]
 
     assets = {
-        "mott_lines": str(asset_dir / "mott_lines.csv"),
-        "isentropic_trajectories": str(asset_dir / "isentropic_trajectories.csv"),
-        "isentropic_mott_crossings": str(asset_dir / "isentropic_mott_crossings.csv"),
-        "phase_overlay": str(asset_dir / "phase_overlay.csv"),
+        "mott_lines": _manifest_path(asset_dir / "mott_lines.csv"),
+        "isentropic_trajectories": _manifest_path(asset_dir / "isentropic_trajectories.csv"),
+        "isentropic_mott_crossings": _manifest_path(asset_dir / "isentropic_mott_crossings.csv"),
+        "phase_overlay": _manifest_path(asset_dir / "phase_overlay.csv"),
     }
     write_csv(Path(assets["mott_lines"]), mott_lines, mott_fields)
     write_csv(Path(assets["isentropic_trajectories"]), trajectories, trajectory_fields)
@@ -988,11 +992,11 @@ def main() -> int:
     manifest = {
         "schema_version": "paper_p1_assets_v1",
         "inputs": {
-            "mott_grid_csv": str(args.mott_grid_csv),
+            "mott_grid_csv": _manifest_path(args.mott_grid_csv),
             "mott_source": summarize_mott_source(args.mott_grid_csv),
-            "isentropic_csv": [str(path) for path in args.isentropic_csv],
-            "phase_dir": [str(path) for path in args.phase_dir],
-            "phase_reference_root": str(args.phase_reference_root) if args.phase_reference_root is not None else None,
+            "isentropic_csv": [_manifest_path(path) for path in args.isentropic_csv],
+            "phase_dir": [_manifest_path(path) for path in args.phase_dir],
+            "phase_reference_root": _manifest_path(args.phase_reference_root) if args.phase_reference_root is not None else None,
             "phase_reference_tag": args.phase_reference_tag,
             "phase_mu_scale": args.phase_mu_scale,
         },
@@ -1003,12 +1007,12 @@ def main() -> int:
             "phase_overlay_points": len(phase_overlay),
             "mott_line_quality": dict(Counter(fmt(row.get("bracket_kind", "unknown")) for row in mott_lines)),
         },
-        "asset_dir": str(asset_dir),
+        "asset_dir": _manifest_path(asset_dir),
         "assets": assets,
         "figures": figure_paths,
     }
-    manifest_path = args.out_dir / "plot_manifest.json"
-    manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=True), encoding="utf-8")
+    manifest_file = args.out_dir / "plot_manifest.json"
+    manifest_file.write_text(json.dumps(manifest, indent=2, ensure_ascii=True), encoding="utf-8")
 
     print(f"Wrote P1 paper figure assets under: {args.out_dir}")
     print(f"  csv_asset_dir={asset_dir}")

--- a/tests/integration/relaxtime/test_paper_p1_figure_assets_smoke.jl
+++ b/tests/integration/relaxtime/test_paper_p1_figure_assets_smoke.jl
@@ -133,6 +133,7 @@ end
     @test all(haskey(row, "plot_order_key") for row in phase_ref_rows)
     manifest_ref = JSON3.read(read(joinpath(out_dir_ref, "plot_manifest.json"), String))
     @test manifest_ref["inputs"]["phase_reference_tag"] == "demo"
+    @test !occursin("\\", string(manifest_ref["inputs"]["phase_reference_root"]))
 
     manifest = JSON3.read(read(joinpath(out_dir, "plot_manifest.json"), String))
     @test manifest["schema_version"] == "paper_p1_assets_v1"
@@ -154,5 +155,8 @@ end
         @test isfile(joinpath(out_dir_plot, "figures", "p1_mott_phase_diagram.png"))
         @test isfile(joinpath(out_dir_plot, "figures", "p1_mott_phase_diagram_xi_0.png"))
         @test isfile(joinpath(out_dir_plot, "figures", "p1_isentropic_mott_paths.png"))
+        manifest_plot = JSON3.read(read(joinpath(out_dir_plot, "plot_manifest.json"), String))
+        @test !isempty(manifest_plot["figures"])
+        @test all(!occursin("\\", string(path)) for path in manifest_plot["figures"])
     end
 end

--- a/tests/integration/relaxtime/test_paper_p1_figure_assets_smoke.jl
+++ b/tests/integration/relaxtime/test_paper_p1_figure_assets_smoke.jl
@@ -140,6 +140,11 @@ end
     @test manifest["inputs"]["mott_source"]["equilibrium_selector_policy"] == "pressure_max_under_constraints"
     @test manifest["counts"]["mott_line_points"] == 4
     @test manifest["counts"]["isentropic_crossings"] == 2
+    @test !occursin("\\", string(manifest["asset_dir"]))
+    @test all(!occursin("\\", string(path)) for path in values(manifest["assets"]))
+    @test !occursin("\\", string(manifest["inputs"]["mott_grid_csv"]))
+    @test all(!occursin("\\", string(path)) for path in manifest["inputs"]["isentropic_csv"])
+    @test all(!occursin("\\", string(path)) for path in manifest["inputs"]["phase_dir"])
 
     has_matplotlib = success(`$python -c "import matplotlib"`)
     if has_matplotlib


### PR DESCRIPTION
## 变更范围

- 修复 `scripts/relaxtime/build_paper_p1_figure_assets.py` 写入 `plot_manifest.json` 时的路径序列化。
- 将 manifest 中的 `asset_dir`、`assets`、`inputs`、`figures` 路径统一写为 POSIX-style `/` 分隔，避免 Windows 反斜杠进入正式图像 manifest。
- 在 P1 figure asset smoke 测试中增加 manifest 路径不含 `\` 的断言。

## 用户影响

- Windows 环境生成的 P1 figure-side `plot_manifest.json` 更稳定，便于跨平台审计和后续路径治理检查。
- 不改变 P1 物理计算、图像生成内容、CSV asset 布局或正式产物目录规则。

## 实现方式

- 增加 manifest path helper，集中使用 `Path.as_posix()` 序列化 manifest 路径。
- 保留文件系统实际路径逻辑不变，只调整写入 manifest 的字符串表示。

## 验证项

- `python -m py_compile scripts\relaxtime\build_paper_p1_figure_assets.py`
- `julia --project=. -e 'include("tests/integration/relaxtime/test_paper_p1_figure_assets_smoke.jl")'`
- `julia --project=. scripts/dev/check_data_output_path_guard.jl`
- `git diff --check origin/main...HEAD`

## 已知非目标

- 不处理 `mu_u/d/s` 非对称介子数密度扩展。
- 不迁移历史产物，不改动 P1 生产物理口径。
- 不扩大本轮 PR 到 meson density workflow 或 numerical baseline。