### PR TITLE
fix(relaxtime): normalize isotropic propagator thermo params

### DIFF
--- a/src/models/pnjl/workflows/TransportWorkflow.jl
+++ b/src/models/pnjl/workflows/TransportWorkflow.jl
@@ -490,6 +490,10 @@ end
     )
 end
 
+@inline function _isotropic_propagator_thermo_params(thermo_params)
+    return ThermoParams(merge(normalize_thermo_params(thermo_params), (ξ=0.0,)))
+end
+
 """一次性完成：平衡求解 →（可选）τ 计算 →（可选）ζ 导数 → 输运系数。
 
 返回值（NamedTuple）包含：
@@ -642,7 +646,7 @@ function solve_transport_from_equilibrium(
         if hasproperty(tau_kwargs_effective, :propagator_xi_policy) &&
            tau_kwargs_effective.propagator_xi_policy === :isotropic &&
            !hasproperty(tau_kwargs_effective, :propagator_quark_params)
-            propagator_thermo_params = merge(thermo_params, (ξ=0.0,))
+            propagator_thermo_params = _isotropic_propagator_thermo_params(thermo_params)
             propagator_A_vals = _A_from_equilibrium(
                 T_fm,
                 quark_params_basic,

--- a/src/models/workflow_apps/TransportWorkflow.jl
+++ b/src/models/workflow_apps/TransportWorkflow.jl
@@ -490,6 +490,10 @@ end
     )
 end
 
+@inline function _isotropic_propagator_thermo_params(thermo_params)
+    return ThermoParams(merge(normalize_thermo_params(thermo_params), (ξ=0.0,)))
+end
+
 """一次性完成：平衡求解 →（可选）τ 计算 →（可选）ζ 导数 → 输运系数。
 
 返回值（NamedTuple）包含：
@@ -642,7 +646,7 @@ function solve_transport_from_equilibrium(
         if hasproperty(tau_kwargs_effective, :propagator_xi_policy) &&
            tau_kwargs_effective.propagator_xi_policy === :isotropic &&
            !hasproperty(tau_kwargs_effective, :propagator_quark_params)
-            propagator_thermo_params = merge(thermo_params, (ξ=0.0,))
+            propagator_thermo_params = _isotropic_propagator_thermo_params(thermo_params)
             propagator_A_vals = _A_from_equilibrium(
                 T_fm,
                 quark_params_basic,

--- a/tests/unit/models/test_transport_workflow.jl
+++ b/tests/unit/models/test_transport_workflow.jl
@@ -142,6 +142,17 @@ end
         @test api.prepare_transport_provider !== nothing
     end
 
+    @testset "isotropic propagator thermo params normalize ThermoParams" begin
+        thermo_params = _TW.ThermoParams((T=0.15, Φ=0.41, Φbar=0.38, ξ=0.32))
+        propagator_thermo_params = _TW._isotropic_propagator_thermo_params(thermo_params)
+
+        @test propagator_thermo_params isa _TW.ThermoParams
+        @test propagator_thermo_params.T == thermo_params.T
+        @test propagator_thermo_params.Φ == thermo_params.Φ
+        @test propagator_thermo_params.Φbar == thermo_params.Φbar
+        @test propagator_thermo_params.ξ == 0.0
+    end
+
     @testset "workflow reproducibility metadata helper" begin
         @test isdefined(_TW, :_workflow_reproducibility_metadata)
         meta = _TW._workflow_reproducibility_metadata()


### PR DESCRIPTION
## Summary
- Fix the isotropic propagator diagnostic path so workflow `ThermoParams` are normalized before overriding `ξ=0.0`.
- Rebuild the overridden propagator thermo input as `ThermoParams` to preserve `_A_from_equilibrium` workflow type contracts.
- Add focused unit coverage for the `ThermoParams` isotropic propagator helper.

## Verification
- `julia --project=. -e 'ENV["UNIT_FILES"]="models/test_transport_workflow.jl"; include("tests/unit/runtests.jl")'`
- Single-point real phase-guided scan with `--propagator-xi-policy isotropic`, 1 valid CSV data row produced.
- `julia --project=. -e 'ENV["INTEGRATION_FILES"]="relaxtime/test_phase_guided_transport_scan_smoke.jl"; include("tests/integration/runtests.jl")'`
- `julia --project=. scripts/dev/check_models_entry_contract.jl`
- `julia --project=. scripts/dev/check_relaxtime_script_governance.jl`
- `git diff --check`

## Notes
This only repairs the diagnostic production path. It does not promote `propagator_xi_policy=:isotropic` to a formal physics fix.