### PR TITLE
fix(relaxtime): require independent coexistence convergence nodes

### DIFF
--- a/docs/dev/active/2026-07-14_relaxtime_rs_transport_energy_semantics_audit.md
+++ b/docs/dev/active/2026-07-14_relaxtime_rs_transport_energy_semantics_audit.md
@@ -2,7 +2,7 @@
 
 创建日期：2026-07-14
 
-状态：PR 1 已于 2026-07-15 合并到 `main@05be2c05186f8e12baf3097b68f8619e53d19711`；M1 完成；M2 candidate 产物已通过 [PR #132](https://github.com/w5851/Julia_RelaxTime/pull/132) 合并；M3 派生显示审计已通过 [PR #134](https://github.com/w5851/Julia_RelaxTime/pull/134) 合并，bulk equilibrium 复用、稳定分支与直接共存锚点代码已提交 [PR #135](https://github.com/w5851/Julia_RelaxTime/pull/135) 等待 review，修复后的新 production 尚未执行
+状态：PR 1 已于 2026-07-15 合并到 `main@05be2c05186f8e12baf3097b68f8619e53d19711`；M1 完成；M2 candidate 产物已通过 [PR #132](https://github.com/w5851/Julia_RelaxTime/pull/132) 合并；M3 派生显示审计已通过 [PR #134](https://github.com/w5851/Julia_RelaxTime/pull/134) 合并，bulk equilibrium 复用、稳定分支与直接共存锚点已通过 [PR #135](https://github.com/w5851/Julia_RelaxTime/pull/135) 合并到 `main@697be19a919c1c3e8203adecd813c1ccf2928319`；高精度相变 reference 与修复后的新 production 尚未执行
 
 基线提交：`ea706548e9167db61e0cb7537bab2d2d4daf4cad`
 
@@ -418,6 +418,17 @@ CI 进一步发现 `baseline_phase_guided_transport_mode_b_v1.csv` 仍保留旧�
 - 性能探针 `julia --project=. scripts/perf/relaxtime/bulk_derivative_context_probe.jl --repeats=3` 在 `T=0.5 fm^-1, mu=1.5 fm^-1, xi=0, p_num/t_num=12/6` 的预热本机样本中，将额外 primal solve 从 `5` 降为 `0`、Jacobian 构建/分解从 `5` 降为 `1`、导数 series 收敛为 `3` 个方向；中位耗时 `0.0817666 s -> 0.0035349 s`（`23.13x`），中位分配 `347952 -> 37456 bytes`。该结果只作为实现收益证据，不设固定加速比 CI gate。
 - mode-B baseline 审计确认共享 bulk context 使 16/16 点的 `zeta`、`zeta/s` 预期下降约 `0.0683%-0.0764%`；另仅 `T=120 MeV, mu_B=0, xi=0.2` 因修正后的相分类 seed 治理产生不超过 `0.00237%` 的上游 transport 漂移。未放宽 `rtol=1e-6`，只刷新实际超限字段；core + full 回归随后通过 `223/223`。
 - 最终聚焦验证：Taylor/bulk/plan unit `144/144`；transport workflow、bulk derivatives、phase-guided dry-run/exec integration `144/144`；一阶分支/共存固定点 regression `22/22`；mode-B core + full regression `223/223`。`check_script_entrypoints`、`check_relaxtime_script_governance`、`check_models_entry_contract`、`check_solver_contract_leakage`、`check_docs_consistency`、`check_active_docs_governance`、`check_data_output_path_guard`、workflow YAML 解析和 `git diff --check` 全部通过。
+- PR #135 已于 2026-07-17 squash 合并，merge commit 为 `697be19a919c1c3e8203adecd813c1ccf2928319`，12/12 CI 通过；旧 production 未改写，任务继续保留 active 直至新 reference 与 production 完成。
+
+### 8.7 高精度相变 reference 与重生产执行锁（2026-07-17）
+
+- 作者确认下一版正式 transport 的 phase reference、direct coexistence anchor、主 equilibrium 与 bulk derivative 统一采用 `p_num=24,t_num=8`。这是热力学精度升级；tau/截面侧继续保持上一版正式参数 `128/20/36/24/560` 与 `validated_anchored`，不得把本轮描述成全部参数逐项不变的重跑。
+- `24/8` 主节点必须由独立 `32/10` 节点复核；不得沿用 `max(p_num,24)` / `max(t_num,8)` 后去重成单节点的自比较。`12/6` 主节点仍使用 `24/8` 认证，更高主节点按 `p_num+8,t_num+2` 生成认证节点。
+- gate 修复后的隔离 dry-run 预检得到 `24/8` 共存温度 `T_c=125.7372580313 MeV`，独立 `32/10` 相对漂移为 `-7.0833e-5 MeV`；`xi=-0.003/+0.003` 分别通过夸克侧/强子侧认证。该结果只验证 anchor/相别 gate，不替代下述含 transport 与 bulk 的完整 pilot；外部诊断目录为 `D:\Desktop\Julia_RelaxTime_issue130_artifacts\thermo_convergence_gate_20260717_p24_t8`。
+- 在晋升 `24/8` 口径前执行代表性 `12/6 -> 24/8 -> 32/10` pilot，至少审计共存温度与 bracket、`xi=±0.003` 相别、平衡态、热力学量、bulk derivatives、`zeta/s`、tau、`eta/s`、`sigma/T`、失败/非有限/负值和运行时间。
+- 一阶相变 reference 使用新 tag/manifest 生成并独立 PR 审核；旧 `boundary.csv`、`cep.csv`、`spinodals.csv` 不覆盖。审核通过后再晋升新的 canonical sibling，并让 runtime 明确消费新 reference。
+- 通用 production workflow 在新 canonical reference 合并前继续保留现有 `12/6` 默认值，避免形成“新热力学默认 + 旧 reference”的过渡组合；phase-reference PR 同步把正式默认改为 `24/8`。
+- reference 合并后使用新 source commit、Action case name、正式 slug、CSV 和图像目录重跑；旧 production、旧图像及 registry 历史记录保持逐字节不变。新 case 先保持 `current_candidate`，由作者审核后决定是否晋升 `approved`。
 
 ## 9. 里程碑
 
@@ -454,7 +465,7 @@ CI 进一步发现 `baseline_phase_guided_transport_mode_b_v1.csv` 仍保留旧�
 - [x] 补扫并修正作者发现的两个 `mu_B=0` 残留显示噪点。
 - [x] 定位 `mu_B=900, alpha_T=1.0, xi=-0.01` 的 `zeta/s` 回落为主 continuation 亚稳支与 bulk 稳定支混用，并用同口径双根热力学势完成归因。
 - [x] 审计旧插值 phase anchor，完成当前 `12/6` 口径的直接等势温度 bracket 与 `xi=±0.003` 双侧相别认证。
-- [x] 通过独立代码 [PR #135](https://github.com/w5851/Julia_RelaxTime/pull/135) 在一阶区域按热力学势选择主稳定态，并让 bulk 导数复用主 equilibrium `base_state`；待 review/合并。
+- [x] 通过独立代码 [PR #135](https://github.com/w5851/Julia_RelaxTime/pull/135) 在一阶区域按热力学势选择主稳定态，并让 bulk 导数复用主 equilibrium `base_state`；已合并到 `main@697be19a919c1c3e8203adecd813c1ccf2928319`。
 - [x] 引入点内 derivative context，共享零阶状态、Jacobian/线性分解，并将重复的压力/质量 Taylor series 收敛为 `T`、`mu`、`T+mu` 三方向。
 - [x] 建立 direct coexistence anchor、共存点 missing/undefined 输运语义和自适应双侧近零认证，并补充 unit/integration/regression 与性能证据；本项没有新的外部物理参考量，validation 责任由双节点收敛 gate 和固定点回归承担。
 - [ ] 从修复提交重跑受影响的正式 production 和论文图，再决定 registry 是否晋升 `approved`。

--- a/docs/guides/scripts/README.md
+++ b/docs/guides/scripts/README.md
@@ -149,7 +149,7 @@ powershell -ExecutionPolicy Bypass -File scripts/dev/run_with_sysimage.ps1 scrip
   - `compute_bulk` 默认开启；如需更快的预览扫描，可显式传 `--no-compute-bulk`
   - mode a 的一阶区域默认使用 `--phase-anchor-policy direct_coexistence`：旧 phase reference 只作为初始 bracket，再按 `--p-num` / `--t-num`（默认 `12/6`）直接求两分支等热力学势温度；`reference_interpolation` 仅用于显式复现旧计划口径。
   - 一阶可能区每点都使用稳定多初值选优，continuation 只作为候选 seed。bulk 复用主扫描已解析的热力学节点和同一点 equilibrium；导数路径若跨支会显式失败。
-  - 直接锚定的 `alpha_T=1` 一阶共存切片不计算严格 `xi=0` 的唯一输运量，而是写入经默认节点和 `24/8` 节点共同认证的负/正近零点，分别表示夸克侧/强子侧极限；`sampling_plan.csv` 同步记录 anchor bracket、相别和节点收敛证据。
+  - 直接锚定的 `alpha_T=1` 一阶共存切片不计算严格 `xi=0` 的唯一输运量，而是写入经主热力学节点和独立更高节点共同认证的负/正近零点，分别表示夸克侧/强子侧极限；`sampling_plan.csv` 同步记录 anchor bracket、相别和节点收敛证据。`12/6` 主节点使用 `24/8` 认证；`24/8` 主节点自动使用 `32/10` 认证，禁止同节点自比较。
   - 异常区域诊断可显式传 `--propagator-xi-policy isotropic`，仅让 σ(s)/propagator 使用 `ξ=0`；也可传 `--sigma-cache-policy validated_anchored` 诊断 threshold-subtraction 与 σ-cache 插值放大效应。默认 `match_thermo` / `default` 不变，诊断分支完成复算与收敛检查前不作为正式修复口径
   - GitHub Actions 手动入口 `Relaxtime Phase-Guided Transport Production` 只生成可审阅 artifact；新增或修改该 workflow 后需先合入默认分支让 GitHub 注册，随后才能通过 `workflow_dispatch` 触发。该入口默认 verdict 为 `diagnostic-only`，不会自动把 artifact 晋升为仓库正式数据。
   - 高精度长任务应优先通过 action shard 触发：mode a 可用 `muB_list` + `alpha_t_list` 分片，mode b 可用 `t_list` + `muB_list` 分片，二者都可用 `xi_list` 缩小窗口，并用 `shard_label` 区分 artifact。workflow 会把扫描/绘图日志写入 result artifact；失败或取消时仍尽量上传 partial CSV、`failed_points.csv`、`channel_diagnostics.csv` 和日志，供本地合并与 convergence gate 使用。

--- a/scripts/relaxtime/README.md
+++ b/scripts/relaxtime/README.md
@@ -29,7 +29,7 @@
   - mode b：固定 `T`、离散 `mu_B`、连续扫描 `xi`。
   - mode a 的一阶区域默认使用 `--phase-anchor-policy direct_coexistence`：旧 phase reference 只提供初始 bracket，再以当前 `--p-num` / `--t-num`（默认 `12/6`）直接求两分支等热力学势温度；可显式传 `reference_interpolation` 复现旧计划口径。
   - 一阶可能区的每个主平衡态都由稳定多初值选优确定，温度/`xi` continuation 只作为候选 seed。bulk 复用同一点已经解析的热力学节点和主 equilibrium，不再独立重做全局 gap solve；若导数路径跨支则该点失败，而不是静默混合两支。
-  - 对直接锚定的 `alpha_T=1` 一阶共存切片，严格 `xi=0` 不定义唯一输运量，因此不进入计划；计划自适应加入经默认与 `24/8` 节点共同认证的负/正近零点，分别表示夸克侧和强子侧极限，并把 bracket、相别与收敛证据写入 `sampling_plan.csv`。
+  - 对直接锚定的 `alpha_T=1` 一阶共存切片，严格 `xi=0` 不定义唯一输运量，因此不进入计划；计划自适应加入经主热力学节点与独立更高节点共同认证的负/正近零点，分别表示夸克侧和强子侧极限，并把 bracket、相别与收敛证据写入 `sampling_plan.csv`。`12/6` 主节点使用 `24/8` 认证；`24/8` 主节点使用 `32/10` 认证，禁止同节点自比较。
   - 默认 canonical 输出根目录：
     - `data/outputs/results/relaxtime/transport/phase_guided/mode_a_fixed_muB_phase_scaled/`
     - `data/outputs/results/relaxtime/transport/phase_guided/mode_b_fixed_T_sparse_muB/`

--- a/scripts/relaxtime/gap_transport_scan_phase_equilibrium.jl
+++ b/scripts/relaxtime/gap_transport_scan_phase_equilibrium.jl
@@ -562,19 +562,35 @@ function direct_coexistence_anchor(
     )
 end
 
+function _default_coexistence_convergence_numerics(opts)
+    p_num = Int(opts.p_num)
+    t_num = Int(opts.t_num)
+    return (
+        p_num=p_num < 24 ? 24 : p_num + 8,
+        t_num=t_num < 8 ? 8 : t_num + 2,
+    )
+end
+
 function certify_coexistence_side_points(
     anchor,
     muB_MeV::Real,
     opts;
     delta_xi_candidates=(0.003, 0.005, 0.007, 0.01, 0.015, 0.02),
-    convergence_p_num::Int=max(Int(opts.p_num), 24),
-    convergence_t_num::Int=max(Int(opts.t_num), 8),
+    convergence_p_num::Int=_default_coexistence_convergence_numerics(opts).p_num,
+    convergence_t_num::Int=_default_coexistence_convergence_numerics(opts).t_num,
     anchor_convergence_tol_MeV::Real=0.1,
 )
-    node_configs = unique([
-        (p_num=Int(opts.p_num), t_num=Int(opts.t_num)),
-        (p_num=convergence_p_num, t_num=convergence_t_num),
-    ])
+    base_config = (p_num=Int(opts.p_num), t_num=Int(opts.t_num))
+    convergence_config = (p_num=convergence_p_num, t_num=convergence_t_num)
+    if convergence_config.p_num < base_config.p_num ||
+       convergence_config.t_num < base_config.t_num ||
+       convergence_config == base_config
+        throw(ArgumentError("coexistence certification requires an independent, non-lower thermodynamic node configuration: base=$(base_config), convergence=$(convergence_config)"))
+    end
+    node_configs = [
+        base_config,
+        convergence_config,
+    ]
     muq_fm = (Float64(muB_MeV) / 3.0) / Main.ħc_MeV_fm
     convergence_cfg = last(node_configs)
     convergence_anchor = if convergence_cfg.p_num == anchor.p_num && convergence_cfg.t_num == anchor.t_num

--- a/tests/regression/relaxtime/test_phase_guided_first_order_branch_regression.jl
+++ b/tests/regression/relaxtime/test_phase_guided_first_order_branch_regression.jl
@@ -93,5 +93,8 @@ end
     @test certification.delta_xi == 0.003
     @test certification.anchor_convergence_certified
     @test abs(certification.anchor_convergence_delta_MeV) < 0.1
+    @test certification.node_configs == [(p_num=12, t_num=6), (p_num=24, t_num=8)]
+    @test certification.convergence_anchor.p_num == 24
+    @test certification.convergence_anchor.t_num == 8
     @test all(row.minus_certified && row.plus_certified for row in certification.evidence)
 end

--- a/tests/unit/relaxtime/test_phase_guided_transport_scan_plan.jl
+++ b/tests/unit/relaxtime/test_phase_guided_transport_scan_plan.jl
@@ -143,3 +143,20 @@ end
     @test explicit.t_num == 8
     @test explicit.phase_anchor_policy === :reference_interpolation
 end
+
+@testset "coexistence certification always uses an independent higher node configuration" begin
+    low = Main.GapTransportScanPhaseEquilibrium._default_coexistence_convergence_numerics((p_num=12, t_num=6))
+    production = Main.GapTransportScanPhaseEquilibrium._default_coexistence_convergence_numerics((p_num=24, t_num=8))
+    higher = Main.GapTransportScanPhaseEquilibrium._default_coexistence_convergence_numerics((p_num=32, t_num=10))
+
+    @test low == (p_num=24, t_num=8)
+    @test production == (p_num=32, t_num=10)
+    @test higher == (p_num=40, t_num=12)
+    @test_throws ArgumentError Main.GapTransportScanPhaseEquilibrium.certify_coexistence_side_points(
+        nothing,
+        0.0,
+        (p_num=24, t_num=8);
+        convergence_p_num=24,
+        convergence_t_num=8,
+    )
+end


### PR DESCRIPTION
## 变更范围

- 修复 Issue #130 后续 `24/8` 热力学 production 会使共存点收敛 gate 退化为同节点自比较的问题。
- `12/6` 主节点继续使用 `24/8` 认证；`24/8` 使用 `32/10`；更高主节点按 `p_num+8,t_num+2` 生成独立认证节点。
- 同节点或任一维度更低的显式认证配置现在会抛出 `ArgumentError`。
- 同步回归、用户指南和活动任务单，并记录 PR #135 已合并及下一阶段精度执行锁。

## 用户影响

正式 transport 可安全把主 equilibrium/bulk 提升到 `p_num=24,t_num=8`，同时仍由独立更高精度节点认证一阶共存温度和 `xi=±0.003` 两侧相别，不会产生零漂移的伪收敛证据。

隔离 dry-run 预检得到：

- `24/8`: `T_c = 125.7372580313 MeV`
- `32/10 - 24/8`: `-7.0833e-5 MeV`
- `xi=-0.003/+0.003`: 分别通过夸克侧/强子侧认证

## 实现方式

- 新增内部默认认证节点 helper。
- 在进入共存点重算前强制认证配置独立且不低于主配置。
- 保留现有返回结构和 `12/6 -> 24/8` 数值契约。

## 验证项

- unit: `42/42`
- first-order branch regression: `25/25`
- phase-guided integration smoke: `22/22`
- `check_script_entrypoints.jl`
- `check_relaxtime_script_governance.jl`
- `check_docs_consistency.jl`
- `check_active_docs_governance.jl`
- `git diff --check`

未放宽任何容差，未刷新 baseline。

## 已知非目标

- 本 PR 不生成或晋升新的 phase reference。
- 本 PR 不修改 workflow 的通用 `12/6` 默认值；该默认值将在新 canonical reference 合并时同步切换到 `24/8`。
- 本 PR 不运行或导入正式 transport production，不修改旧 reference、旧 production、旧图像或 registry 状态。

Contributes to #130.