### PR TITLE
fix(pnjl): enforce dense reference CSV contract

### DIFF
--- a/.github/workflows/pnjl-dense-reference-replay.yml
+++ b/.github/workflows/pnjl-dense-reference-replay.yml
@@ -1,0 +1,149 @@
+name: PNJL Dense Reference Postprocess Replay
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: "包含完整 shard artifacts 的原 workflow run ID"
+        required: true
+        type: string
+      source_calculation_sha:
+        description: "原 shard 数值计算提交 SHA（必须与 manifest 一致）"
+        required: true
+        type: string
+      tag:
+        description: "原 artifact 标签后缀"
+        required: true
+        type: string
+      expected_xi_list:
+        description: "必须存在的初始 ξ 锚点（逗号分隔）"
+        required: true
+        type: string
+      include_xi_convergence_records:
+        description: "下载并合并原 run 的 staged ξ convergence records"
+        required: false
+        default: true
+        type: boolean
+      crossover_only:
+        description: "原 run 是否仅生成 crossover reference"
+        required: false
+        default: false
+        type: boolean
+      crossover_mu0_only:
+        description: "原 run 是否仅生成 mu_q = 0 crossover"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  replay:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      ARTIFACT_RETENTION_DAYS: "30"
+      SHARDS_ROOT: data/outputs/artifacts/pnjl_dense_reference/replay_${{ github.run_id }}/downloaded_shards
+      XI_PLAN_ROOT: data/outputs/artifacts/pnjl_dense_reference/replay_${{ github.run_id }}/downloaded_xi_plans
+      REFERENCE_ROOT: data/outputs/artifacts/pnjl_dense_reference/replay_${{ github.run_id }}/reference
+      REPORT_PATH: data/outputs/artifacts/pnjl_dense_reference/replay_${{ github.run_id }}/validation_report.json
+    steps:
+      - name: Checkout postprocess code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Download source xi shards
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_run_id }}
+          pattern: pnjl-dense-reference-shard-${{ inputs.tag }}-*
+          path: ${{ env.SHARDS_ROOT }}
+
+      - name: Download source xi convergence records
+        if: ${{ inputs.include_xi_convergence_records }}
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_run_id }}
+          pattern: pnjl-dense-reference-xi-plan-${{ inputs.tag }}-level*
+          path: ${{ env.XI_PLAN_ROOT }}
+
+      - name: Replay deterministic merge
+        shell: bash
+        run: |
+          rm -rf "${REFERENCE_ROOT}"
+          mkdir -p "${REFERENCE_ROOT}"
+          merge_cmd=(
+            python scripts/pnjl/merge_dense_phase_reference_shards.py
+            --shards-root "${SHARDS_ROOT}"
+            --reference-root "${REFERENCE_ROOT}"
+            --tag "${{ inputs.tag }}"
+            "--expected-xi-list=${{ inputs.expected_xi_list }}"
+            --expected-calculation-git-commit "${{ inputs.source_calculation_sha }}"
+            --postprocess-git-commit "${GITHUB_SHA}"
+            --source-workflow-run-id "${{ inputs.source_run_id }}"
+            --overwrite
+          )
+          if [ "${{ inputs.include_xi_convergence_records }}" = "true" ]; then
+            merge_cmd+=(--xi-convergence-root "${XI_PLAN_ROOT}")
+          fi
+          "${merge_cmd[@]}"
+
+      - name: Validate replayed dense reference artifact
+        shell: bash
+        run: |
+          validate_cmd=(
+            python scripts/pnjl/validate_dense_reference_artifact.py
+            --reference-root "${REFERENCE_ROOT}"
+            --tag "${{ inputs.tag }}"
+            --min-crossover-rows 1
+            --report-path "${REPORT_PATH}"
+          )
+          if [ "${{ inputs.crossover_only }}" = "true" ]; then
+            validate_cmd+=(--expect-crossover-only)
+          else
+            validate_cmd+=(--expect-full-reference)
+          fi
+          if [ "${{ inputs.crossover_mu0_only }}" = "true" ]; then
+            validate_cmd+=(--expect-mu0-only)
+          fi
+          "${validate_cmd[@]}"
+
+      - name: Upload replayed dense reference artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pnjl-dense-reference-replay-${{ inputs.tag }}-source-${{ inputs.source_run_id }}
+          path: |
+            ${{ env.REFERENCE_ROOT }}/*_${{ inputs.tag }}.csv
+            ${{ env.REFERENCE_ROOT }}/*_${{ inputs.tag }}.meta.json
+            ${{ env.REFERENCE_ROOT }}/phase_reference_${{ inputs.tag }}_manifest.json
+            ${{ env.REPORT_PATH }}
+          retention-days: ${{ fromJson(env.ARTIFACT_RETENTION_DAYS) }}
+          if-no-files-found: error
+
+      - name: Create replay summary
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads(Path(os.environ["REPORT_PATH"]).read_text(encoding="utf-8"))
+          with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as handle:
+              handle.write("## PNJL Dense Reference Postprocess Replay\n\n")
+              handle.write(f"- source workflow run: `{report['source_workflow_run_id']}`\n")
+              handle.write(f"- calculation SHA: `{report['calculation_git_commit']}`\n")
+              handle.write(f"- postprocess SHA: `{report['postprocess_git_commit']}`\n")
+              handle.write(f"- resolved xi values: `{report['xi_values']}`\n")
+              handle.write("- status: diagnostic replay only; no reference promotion\n")
+          PY

--- a/.github/workflows/pnjl-dense-reference.yml
+++ b/.github/workflows/pnjl-dense-reference.yml
@@ -348,6 +348,9 @@ jobs:
             --reference-root "${REFERENCE_ROOT}"
             --tag "${{ inputs.tag || 'dense' }}"
             "--expected-xi-list=${{ needs.plan.outputs.expected_xi_csv }}"
+            --expected-calculation-git-commit "${GITHUB_SHA}"
+            --postprocess-git-commit "${GITHUB_SHA}"
+            --source-workflow-run-id "${GITHUB_RUN_ID}"
             --overwrite
           )
           if [ "${{ needs.plan.outputs.xi_refine_levels }}" -ge 1 ]; then

--- a/docs/dev/active/2026-07-17_PNJL全温区相图热积分与参考生产.md
+++ b/docs/dev/active/2026-07-17_PNJL全温区相图热积分与参考生产.md
@@ -2,7 +2,7 @@
 
 创建日期：2026-07-17
 
-状态：执行中；PR 1 已通过作者审核并以 [PR #137](https://github.com/w5851/Julia_RelaxTime/pull/137) 合并为 `main@c0cde620`；独立依赖/AGENTS 治理 [PR #138](https://github.com/w5851/Julia_RelaxTime/pull/138) 已合并为 `main@8dd760b5`；PR 2 已通过作者审核并以 [PR #139](https://github.com/w5851/Julia_RelaxTime/pull/139) 合并为 `main@be7545d9`；PR 3 的首次 Action-only 收敛因 interval shard 超过 GitHub 单 job 六小时上限而暂停，staged one-xi corrective pipeline 的独立 branch smoke 已通过，当前等待 corrective PR 审核，尚未晋升 canonical reference
+状态：执行中；PR 1 已通过作者审核并以 [PR #137](https://github.com/w5851/Julia_RelaxTime/pull/137) 合并为 `main@c0cde620`；独立依赖/AGENTS 治理 [PR #138](https://github.com/w5851/Julia_RelaxTime/pull/138) 已合并为 `main@8dd760b5`；PR 2 已通过作者审核并以 [PR #139](https://github.com/w5851/Julia_RelaxTime/pull/139) 合并为 `main@be7545d9`；staged one-xi pipeline 已以 [PR #140](https://github.com/w5851/Julia_RelaxTime/pull/140) 合并为 `main@5df0866c`，C0 的 41 个数值 shard 全部完成但 level-1 assessment 暴露 CSV 转义合同缺口，当前正在独立 corrective PR 修复并建立后处理 replay 合同，尚未晋升 canonical reference
 
 关联背景：Issue #130 后续 transport production 依赖新的高精度 phase reference；现有 `24/8` 与 `32/10`、`T=60--240 MeV` 结果只作为算法改造前 pilot，不晋升 canonical。
 
@@ -139,6 +139,36 @@ corrective pipeline 的独立 branch smoke [run 29692826423](https://github.com/
 shard，随后的 xi midpoint 收敛评估、convergence record、确定性合并与最终 artifact 校验全部成功。
 该 smoke 只验证 workflow 调度、带符号 xi 参数传递与 merge 契约，不构成 convergence 或 production 证据；正式
 C0/C1/C2 仍须等 corrective PR 合并后从新的锁定 source SHA 依次重启。
+
+PR #140 合并后的 C0 [run 29810188129](https://github.com/w5851/Julia_RelaxTime/actions/runs/29810188129)
+在 `main@5df0866c` 完成全部 41 个 one-xi 数值 shard；`assess_xi_level1` 两次均确定性失败。仓库外逐文件审计
+205 个 CSV 后定位到唯一 malformed row：`xi=0.3` 的 `phase_grid_convergence` reason 为
+`midpoint_classification_changed_or_unresolved:valid,unknown,valid`，Julia writer 使用裸 `join(..., ',')`，使
+13 列记录被解析为 15 列。该失败是 CSV serialization 合同缺陷，不是本档数值 solver 失败，也不构成 C0
+convergence success。
+
+本轮 corrective PR 的附加防返工合同为：
+
+- [x] 三条 grid-convergence Julia writer 统一复用 RFC 4180 field escaping；
+- [x] shard validator 与 merge 均在读取边界报告文件、物理行号及期望/实际列数；
+- [x] 聚合 manifest 分别记录 `calculation_git_commit`、`postprocess_git_commit` 与原 workflow run ID；
+- [x] 新增只消费已完成 shard artifacts 的 postprocess replay workflow，且 replay 不自动晋升 reference；
+- [x] 用现有 41 个 C0 artifacts 做仓库外 diagnostic replay，确认修复后的 assessment/merge 路径可通过；
+- [ ] corrective PR 合并后从新 main SHA 重跑 C0；本次 writer 位于 shard 计算提交内，旧 malformed shard 不作为正式复用输入。
+
+后续若 C1/C2 或 final merge 只暴露 CSV、validator、merge 或 Action 后处理问题，不再机械重跑此前已经完整通过的
+C0。只要 solver、数值内核、grid/refinement 语义和 effective config 均未变化，就冻结原 shard artifact，使用
+`.github/workflows/pnjl-dense-reference-replay.yml` 重放相应档位，并以双 SHA provenance 审计。若上述任何计算语义
+发生变化，则 replay 不适用，必须从受影响的最早收敛档位重新计算。
+
+corrective PR 的本地验证包括：CSV/merge/validator/Action contract Python `20/20`；三个直接 Julia writer/plan
+测试分别 `26/26`、`23/23`、`8/8`；Python syntax、docs consistency、active docs、SOP governance、script
+entrypoints、data output path guard 与 unit skip policy 全部通过。仓库外 diagnostic replay 首先确认未修补 artifact
+在 `anchor-a016` 第 2 物理行以 `expected 13 fields, parsed 15` 早失败；仅在独立副本中引用该唯一 reason 后，
+41 个 shard 的 merge/validator 通过，level-1 的 20 个区间完成评估：7 个收敛、13 个未收敛，生成 26 个
+level-2 midpoint 候选；把 level-1 convergence records 合并后共 5623 条 grid records，双 provenance 为
+calculation `5df0866c...`、postprocess `diagnostic-working-tree`、source run `29810188129`。这些结果只验证合同与
+后处理可恢复性，不晋升旧 C0，也不替代修复合并后的正式 C0 重跑。
 
 ### PR 4：transport production
 

--- a/docs/guides/sop/workflows/pnjl_phase_structure.md
+++ b/docs/guides/sop/workflows/pnjl_phase_structure.md
@@ -155,6 +155,17 @@ run 同时占满 runner 配额；失败后只重跑失败的单 xi shard。
 去重，并把各层 xi convergence record 合并进 `phase_grid_convergence_<tag>.csv`。
 merge 产物通过 validator 后仍只是候选 artifact，不自动写入或晋升 canonical reference。
 
+dense-reference CSV 必须遵循 RFC 4180 字段转义：字段含逗号、双引号或换行时必须加双引号，字段内双引号写成
+两个双引号。shard validator 在上传前逐行拒绝列数不匹配，并报告文件、物理行号、期望/实际列数；merge 在消费
+任何 shard 时执行同一结构检查，不能把 malformed row 推迟到最终 `DictWriter` 才失败。
+
+数值计算与后处理使用双 provenance。聚合 manifest 的 `provenance.calculation_git_commit` 绑定生成 shard 的计算
+提交，`provenance.postprocess_git_commit` 绑定 merge/validator 提交，并可记录 `source_workflow_run_id`。只有 solver、
+数值内核、grid/refinement 语义或 effective config 改变时才必须重算对应 C0/C1/C2 档位。完整 shard artifacts 仍在
+保留期内且变更只涉及 CSV、merge、validator 或 Action 后处理时，可通过
+`.github/workflows/pnjl-dense-reference-replay.yml` 重放该档位；replay 必须显式给出原 run ID、原 calculation SHA、
+tag 与必需 xi anchors，SHA 不匹配即失败。replay 产物始终是 diagnostic candidate，不自动晋升 reference。
+
 ## 11. Regression / Validation 验收
 
 最小层级：
@@ -171,6 +182,7 @@ merge 产物通过 validator 后仍只是候选 artifact，不自动写入或晋
 - smoke 失败时先检查配置路径、sysimage 和 CLI 参数；
 - solver unknown 或失败比例异常时保留 `phase_summary.json` 和 report，不直接删点；
 - 改变网格或求解策略时使用新 case 目录；
+- 后处理修复优先重放已完成且 SHA 已核验的 shard artifacts；不得用 replay 掩盖数值代码或 effective config 变化；
 - 不在已有正式目录上用不同 effective config 覆盖运行；
 - CEP 未找到不自动等价于“物理上不存在 CEP”，必须结合扫描覆盖和诊断字段判断。
 

--- a/scripts/pnjl/build_dense_phase_reference.jl
+++ b/scripts/pnjl/build_dense_phase_reference.jl
@@ -386,7 +386,7 @@ end
 @inline _dense_record_value(row, key::Symbol, default=nothing) =
     hasproperty(row, key) ? getproperty(row, key) : default
 
-@inline _dense_csv_value(value) = value === nothing ? "" : string(value)
+@inline _dense_csv_value(value) = Models._phase_csv_value(value)
 @inline _dense_record_with_xi(row::NamedTuple, xi::Real) = merge(row, (xi=Float64(xi),))
 
 function write_grid_convergence_csv(path::String, rows)

--- a/scripts/pnjl/merge_dense_phase_reference_shards.py
+++ b/scripts/pnjl/merge_dense_phase_reference_shards.py
@@ -36,6 +36,18 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--tag", required=True)
     parser.add_argument("--expected-xi-list", required=True)
+    parser.add_argument(
+        "--expected-calculation-git-commit",
+        help="reject shards whose numerical calculation commit differs from this SHA",
+    )
+    parser.add_argument(
+        "--postprocess-git-commit",
+        help="commit providing merge/validation code; defaults to the calculation commit",
+    )
+    parser.add_argument(
+        "--source-workflow-run-id",
+        help="workflow run that produced the shard artifacts",
+    )
     parser.add_argument("--overwrite", action="store_true")
     return parser.parse_args()
 
@@ -85,7 +97,20 @@ def load_csv(path: Path) -> tuple[list[str], list[dict[str, str]]]:
         reader = csv.DictReader(handle)
         if reader.fieldnames is None:
             fail(f"missing CSV header: {path}")
-        return list(reader.fieldnames), [dict(row) for row in reader]
+        fieldnames = list(reader.fieldnames)
+        rows: list[dict[str, str]] = []
+        for row in reader:
+            extra = row.get(None) or []
+            missing = [name for name in fieldnames if row.get(name) is None]
+            if extra or missing:
+                actual_count = len(fieldnames) + len(extra) - len(missing)
+                fail(
+                    f"malformed CSV row in {path} ending at physical line {reader.line_num}: "
+                    f"expected {len(fieldnames)} fields, parsed {actual_count}; "
+                    f"missing={missing}, extra_values={extra}"
+                )
+            rows.append(dict(row))
+        return fieldnames, rows
 
 
 def write_csv(path: Path, fieldnames: list[str], rows: list[dict[str, str]]) -> None:
@@ -161,6 +186,16 @@ def main() -> None:
     commits = {payload.get("generator", {}).get("git_commit") for payload in payloads}
     if len(commits) != 1 or None in commits:
         fail(f"shards do not share one git commit: {sorted(str(value) for value in commits)}")
+    calculation_git_commit = str(next(iter(commits)))
+    if (
+        args.expected_calculation_git_commit is not None
+        and calculation_git_commit != args.expected_calculation_git_commit
+    ):
+        fail(
+            "shard calculation commit mismatch: "
+            f"expected {args.expected_calculation_git_commit}, got {calculation_git_commit}"
+        )
+    postprocess_git_commit = args.postprocess_git_commit or calculation_git_commit
     configs = [payload.get("config", {}) for payload in payloads]
     normalized = [normalize_config(config) for config in configs]
     if any(config != normalized[0] for config in normalized[1:]):
@@ -227,10 +262,15 @@ def main() -> None:
         "artifact": {"path": normalized_path(outputs["crossover"]), "row_count": len(crossover_rows)},
         "generator": {
             "script": "scripts/pnjl/merge_dense_phase_reference_shards.py",
-            "git_commit": next(iter(commits)),
+            "git_commit": calculation_git_commit,
             "generated_at": generated_at,
             "crossover_only": bool(configs[0].get("crossover_only")),
             "crossover_mu0_only": bool(configs[0].get("crossover_mu0_only")),
+        },
+        "provenance": {
+            "calculation_git_commit": calculation_git_commit,
+            "postprocess_git_commit": postprocess_git_commit,
+            "source_workflow_run_id": args.source_workflow_run_id,
         },
         "xi_coverage": {
             "count": len(xis),
@@ -272,10 +312,15 @@ def main() -> None:
         "schema_version": payloads[0].get("schema_version", "v1"),
         "generator": {
             "script": "scripts/pnjl/merge_dense_phase_reference_shards.py",
-            "git_commit": next(iter(commits)),
+            "git_commit": calculation_git_commit,
             "generated_at": generated_at,
             "crossover_only": bool(configs[0].get("crossover_only")),
             "crossover_mu0_only": bool(configs[0].get("crossover_mu0_only")),
+        },
+        "provenance": {
+            "calculation_git_commit": calculation_git_commit,
+            "postprocess_git_commit": postprocess_git_commit,
+            "source_workflow_run_id": args.source_workflow_run_id,
         },
         "config": final_config,
         "output_root": payloads[0].get("output_root"),
@@ -301,7 +346,8 @@ def main() -> None:
     final_manifest["artifacts"]["manifest"] = {"path": normalized_path(manifest_path)}
     manifest_path.write_text(json.dumps(final_manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
-    print(f"merged {len(manifests)} shards at commit {next(iter(commits))}")
+    print(f"merged {len(manifests)} shards calculated at commit {calculation_git_commit}")
+    print(f"postprocessed at commit {postprocess_git_commit}")
     print(f"resolved xi values: {xis}")
     print(f"manifest: {manifest_path}")
 

--- a/scripts/pnjl/plan_dense_reference_xi_refinement.jl
+++ b/scripts/pnjl/plan_dense_reference_xi_refinement.jl
@@ -195,7 +195,7 @@ function _load_reference_results(reference_root::String, tag::String)
 end
 
 
-@inline _csv_value(value) = value === nothing ? "" : string(value)
+@inline _csv_value(value) = Models._phase_csv_value(value)
 
 
 function _write_records(path::String, rows::Vector{NamedTuple})

--- a/scripts/pnjl/validate_dense_reference_artifact.py
+++ b/scripts/pnjl/validate_dense_reference_artifact.py
@@ -32,8 +32,22 @@ def load_json(path: Path):
 def load_csv_rows(path: Path):
     with path.open("r", encoding="utf-8", newline="") as fh:
         reader = csv.DictReader(fh)
-        rows = list(reader)
-    return reader.fieldnames or [], rows
+        fieldnames = reader.fieldnames or []
+        if not fieldnames:
+            fail(f"missing CSV header: {path}")
+        rows = []
+        for row in reader:
+            extra = row.get(None) or []
+            missing = [name for name in fieldnames if row.get(name) is None]
+            if extra or missing:
+                actual_count = len(fieldnames) + len(extra) - len(missing)
+                fail(
+                    f"malformed CSV row in {path} ending at physical line {reader.line_num}: "
+                    f"expected {len(fieldnames)} fields, parsed {actual_count}; "
+                    f"missing={missing}, extra_values={extra}"
+                )
+            rows.append(dict(row))
+    return fieldnames, rows
 
 
 def require_columns(fieldnames, required, artifact_name: str):
@@ -112,6 +126,15 @@ def main():
     meta_generator = meta.get("generator", {})
     if manifest_generator.get("git_commit") != meta_generator.get("git_commit"):
         fail("manifest generator.git_commit does not match meta generator.git_commit")
+
+    provenance = manifest.get("provenance")
+    if provenance is not None:
+        if provenance.get("calculation_git_commit") != manifest_generator.get("git_commit"):
+            fail("manifest provenance.calculation_git_commit does not match generator.git_commit")
+        if not provenance.get("postprocess_git_commit"):
+            fail("manifest provenance.postprocess_git_commit is missing")
+        if meta.get("provenance") != provenance:
+            fail("manifest provenance does not match crossover metadata provenance")
 
     if manifest_generator.get("crossover_only") != args.expect_crossover_only:
         fail("manifest crossover_only flag does not match workflow expectation")
@@ -210,6 +233,13 @@ def main():
         "crossover_only": args.expect_crossover_only,
         "mu0_only": args.expect_mu0_only,
         "git_commit": manifest_generator.get("git_commit"),
+        "calculation_git_commit": (
+            provenance.get("calculation_git_commit") if provenance else manifest_generator.get("git_commit")
+        ),
+        "postprocess_git_commit": (
+            provenance.get("postprocess_git_commit") if provenance else manifest_generator.get("git_commit")
+        ),
+        "source_workflow_run_id": provenance.get("source_workflow_run_id") if provenance else None,
         "generated_at_utc": manifest_generator.get("generated_at"),
         "crossover_rows": len(rows),
         "converged_rows": converged_count,

--- a/src/models/phase/PhaseArtifacts.jl
+++ b/src/models/phase/PhaseArtifacts.jl
@@ -74,7 +74,13 @@ end
     return hasproperty(record, key) ? getproperty(record, key) : default
 end
 
-@inline _phase_csv_value(value) = value === nothing ? "" : string(value)
+@inline function _phase_csv_value(value)
+    text = value === nothing ? "" : string(value)
+    if occursin(',', text) || occursin('"', text) || occursin('\n', text) || occursin('\r', text)
+        return string('"', replace(text, '"' => "\"\""), '"')
+    end
+    return text
+end
 
 function _write_grid_convergence(path::String, result::PhasePipelineResult)
     records = get(result.diagnostics, "grid_convergence_records", NamedTuple[])

--- a/tests/unit/models/test_phase_artifacts.jl
+++ b/tests/unit/models/test_phase_artifacts.jl
@@ -17,6 +17,15 @@ end
 
 @testset "PhaseArtifacts" begin
 
+    @testset "CSV field escaping" begin
+        @test Models._phase_csv_value(nothing) == ""
+        @test Models._phase_csv_value("plain") == "plain"
+        @test Models._phase_csv_value("a,b") == "\"a,b\""
+        @test Models._phase_csv_value("a\"b") == "\"a\"\"b\""
+        @test Models._phase_csv_value("a\nb") == "\"a\nb\""
+        @test Models._phase_csv_value("a\rb") == "\"a\rb\""
+    end
+
     @testset "resolve_phase_output_target 接口" begin
         @test isdefined(Models, :resolve_phase_output_target)
         target = Models.resolve_phase_output_target(:PNJL; project_root=PROJECT_ROOT)
@@ -46,6 +55,37 @@ end
         @test haskey(paths, "phase_grid_convergence")
         @test isfile(paths["phase_grid_convergence"])
         @test startswith(read(paths["phase_grid_convergence"], String), "axis,xi,T_MeV")
+    end
+
+    @testset "grid convergence reasons are valid quoted CSV fields" begin
+        tmp = mktempdir()
+        reason = "midpoint_classification_changed_or_unresolved:valid,unknown,\"valid\"\nreview"
+        result = Models.PhasePipelineResult(
+            xi=0.3,
+            diagnostics=Dict{String, Any}(
+                "grid_convergence_records" => [(
+                    axis="temperature",
+                    xi=0.3,
+                    T_MeV=10.0,
+                    level=1,
+                    left=5.0,
+                    right=15.0,
+                    midpoint=10.0,
+                    position_error_MeV=0.1,
+                    density_error=0.01,
+                    maxwell_area=1e-4,
+                    response_rtol=0.05,
+                    converged=false,
+                    reason=reason,
+                )],
+            ),
+        )
+        paths = Models.build_phase_artifacts(result; output_dir=tmp)
+        grid_csv = read(paths["phase_grid_convergence"], String)
+        @test occursin(
+            "\"midpoint_classification_changed_or_unresolved:valid,unknown,\"\"valid\"\"\nreview\"",
+            grid_csv,
+        )
     end
 
     @testset "promote_phase_artifacts 接口存在" begin

--- a/tests/unit/pnjl/test_build_dense_phase_reference.jl
+++ b/tests/unit/pnjl/test_build_dense_phase_reference.jl
@@ -110,6 +110,26 @@ end
 
     qualified = _dense_record_with_xi((axis="temperature", xi=-99.0, level=1), 0.25)
     @test qualified.xi == 0.25
+
+    mktempdir() do root
+        path = joinpath(root, "grid.csv")
+        write_grid_convergence_csv(path, [(
+            axis="temperature",
+            xi=0.3,
+            T_MeV=10.0,
+            level=1,
+            left=5.0,
+            right=15.0,
+            midpoint=10.0,
+            position_error_MeV=0.1,
+            density_error=0.01,
+            maxwell_area=1e-4,
+            response_rtol=0.05,
+            converged=false,
+            reason="valid,unknown,\"valid\"\nreview",
+        )])
+        @test occursin("\"valid,unknown,\"\"valid\"\"\nreview\"", read(path, String))
+    end
 end
 
 end # module DensePhaseReferenceContractTests

--- a/tests/unit/pnjl/test_dense_reference_xi_refinement_plan.jl
+++ b/tests/unit/pnjl/test_dense_reference_xi_refinement_plan.jl
@@ -82,6 +82,23 @@ end
         records = read(cfg.records_output, String)
         @test occursin("xi,0.0,,1,-0.1,0.1,0.0", records)
         @test occursin("interpolation_tolerance_exceeded", records)
+
+        _write_records(cfg.records_output, NamedTuple[(
+            axis="xi",
+            xi=0.0,
+            T_MeV=nothing,
+            level=1,
+            left=-0.1,
+            right=0.1,
+            midpoint=0.0,
+            position_error_MeV=0.2,
+            density_error=0.01,
+            maxwell_area=1e-4,
+            response_rtol=0.05,
+            converged=false,
+            reason="valid,unknown,\"valid\"\nreview",
+        )])
+        @test occursin("\"valid,unknown,\"\"valid\"\"\nreview\"", read(cfg.records_output, String))
     end
 end
 

--- a/tests/unit/python/test_merge_dense_phase_reference_shards.py
+++ b/tests/unit/python/test_merge_dense_phase_reference_shards.py
@@ -30,7 +30,13 @@ def write_csv(path: Path, header: list[str], rows: list[list[str]]) -> None:
         writer.writerows(rows)
 
 
-def write_shard(root: Path, name: str, xis: list[float], conflict_at_zero: bool = False) -> None:
+def write_shard(
+    root: Path,
+    name: str,
+    xis: list[float],
+    conflict_at_zero: bool = False,
+    grid_reason: str = "converged",
+) -> None:
     shard = root / name
     shard.mkdir(parents=True)
     boundary_rows: list[list[str]] = []
@@ -45,7 +51,7 @@ def write_shard(root: Path, name: str, xis: list[float], conflict_at_zero: bool 
         cep_rows.append([str(xi), str(130 + offset), str(295 + offset), str(3 * (295 + offset)), "0.05", "129.95", "130.05", "0.1"])
         spinodal_rows.append([str(xi), "100", str(310 + offset), str(290 + offset), "0.8", "2.2", "100", "100"])
         crossover_rows.append([str(xi), "0", str(180 + offset), "0.3", "peak", "true", "4", "phi_u", "0", "0"])
-        grid_rows.append(["rho", str(xi), "100", "1", "0", "1", "1", "0.01", "0.001", "0.00005", "0", "true", "converged"])
+        grid_rows.append(["rho", str(xi), "100", "1", "0", "1", "1", "0.01", "0.001", "0.00005", "0", "true", grid_reason])
         runs.append({
             "xi": xi,
             "run_id": f"xi_{xi}",
@@ -79,7 +85,12 @@ def write_shard(root: Path, name: str, xis: list[float], conflict_at_zero: bool 
     (shard / f"phase_reference_{TAG}_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
 
 
-def run_merge(shards: Path, output: Path, xi_convergence_root: Path | None = None) -> subprocess.CompletedProcess[str]:
+def run_merge(
+    shards: Path,
+    output: Path,
+    xi_convergence_root: Path | None = None,
+    extra_args: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     command = [
             sys.executable,
             str(SCRIPT),
@@ -94,6 +105,8 @@ def run_merge(shards: Path, output: Path, xi_convergence_root: Path | None = Non
         ]
     if xi_convergence_root is not None:
         command.extend(["--xi-convergence-root", str(xi_convergence_root)])
+    if extra_args is not None:
+        command.extend(extra_args)
     return subprocess.run(
         command,
         cwd=REPO_ROOT,
@@ -125,6 +138,11 @@ def test_merge_is_deterministic_and_deduplicates_interval_endpoints(tmp_path: Pa
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest["config"]["xi_values"] == [-0.1, 0.0, 0.1]
     assert len(manifest["shards"]) == 2
+    assert manifest["provenance"] == {
+        "calculation_git_commit": "abc123",
+        "postprocess_git_commit": "abc123",
+        "source_workflow_run_id": None,
+    }
     validation = subprocess.run(
         [
             sys.executable,
@@ -141,6 +159,105 @@ def test_merge_is_deterministic_and_deduplicates_interval_endpoints(tmp_path: Pa
         check=False,
     )
     assert validation.returncode == 0, validation.stderr
+
+
+def test_merge_round_trips_quoted_grid_reason_and_records_dual_provenance(tmp_path: Path) -> None:
+    shards = tmp_path / "shards"
+    reason = 'valid,unknown,"valid"\nreview'
+    write_shard(shards, "left", [-0.1, 0.0], grid_reason=reason)
+    write_shard(shards, "right", [0.1], grid_reason=reason)
+    output = tmp_path / "merged"
+
+    result = run_merge(
+        shards,
+        output,
+        extra_args=[
+            "--expected-calculation-git-commit",
+            "abc123",
+            "--postprocess-git-commit",
+            "def456",
+            "--source-workflow-run-id",
+            "12345",
+        ],
+    )
+    assert result.returncode == 0, result.stderr
+    with (output / f"phase_grid_convergence_{TAG}.csv").open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert {row["reason"] for row in rows} == {reason}
+    manifest = json.loads((output / f"phase_reference_{TAG}_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["provenance"] == {
+        "calculation_git_commit": "abc123",
+        "postprocess_git_commit": "def456",
+        "source_workflow_run_id": "12345",
+    }
+
+
+def test_merge_rejects_malformed_unquoted_grid_reason_at_read_boundary(tmp_path: Path) -> None:
+    shards = tmp_path / "shards"
+    write_shard(shards, "only", [-0.1, 0.0, 0.1])
+    grid_path = shards / "only" / f"phase_grid_convergence_{TAG}.csv"
+    grid_path.write_text(
+        ",".join(HEADERS["phase_grid_convergence"])
+        + "\n"
+        + "rho,0,100,1,0,1,1,0.01,0.001,0.00005,0,true,valid,unknown,valid\n",
+        encoding="utf-8",
+    )
+
+    result = run_merge(shards, tmp_path / "merged")
+    message = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert f"phase_grid_convergence_{TAG}.csv" in message
+    assert "ending at physical line 2" in message
+    assert "expected 13 fields, parsed 15" in message
+    assert "extra_values=['unknown', 'valid']" in message
+
+
+def test_validator_rejects_malformed_csv_before_manifest_checks(tmp_path: Path) -> None:
+    shards = tmp_path / "shards"
+    write_shard(shards, "only", [-0.1, 0.0, 0.1])
+    output = tmp_path / "merged"
+    result = run_merge(shards, output)
+    assert result.returncode == 0, result.stderr
+    grid_path = output / f"phase_grid_convergence_{TAG}.csv"
+    grid_path.write_text(
+        ",".join(HEADERS["phase_grid_convergence"])
+        + "\n"
+        + "rho,0,100,1,0,1,1,0.01,0.001,0.00005,0,true,valid,unknown,valid\n",
+        encoding="utf-8",
+    )
+
+    validation = subprocess.run(
+        [
+            sys.executable,
+            str(VALIDATOR),
+            "--reference-root",
+            str(output),
+            "--tag",
+            TAG,
+            "--expect-full-reference",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    message = validation.stdout + validation.stderr
+    assert validation.returncode != 0
+    assert f"phase_grid_convergence_{TAG}.csv" in message
+    assert "ending at physical line 2" in message
+    assert "expected 13 fields, parsed 15" in message
+
+
+def test_merge_rejects_unexpected_calculation_commit(tmp_path: Path) -> None:
+    shards = tmp_path / "shards"
+    write_shard(shards, "only", [-0.1, 0.0, 0.1])
+    result = run_merge(
+        shards,
+        tmp_path / "merged",
+        extra_args=["--expected-calculation-git-commit", "wrong"],
+    )
+    assert result.returncode != 0
+    assert "shard calculation commit mismatch: expected wrong, got abc123" in (result.stdout + result.stderr)
 
 
 def test_merge_rejects_conflicting_duplicate_endpoint(tmp_path: Path) -> None:

--- a/tests/unit/python/test_plan_dense_reference_action.py
+++ b/tests/unit/python/test_plan_dense_reference_action.py
@@ -10,6 +10,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[3]
 SCRIPT_PATH = PROJECT_ROOT / "scripts" / "pnjl" / "plan_dense_reference_action.py"
 WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "pnjl-dense-reference.yml"
 ASSESS_WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "pnjl-dense-reference-assess-xi.yml"
+REPLAY_WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "pnjl-dense-reference-replay.yml"
 
 
 def load_module():
@@ -95,3 +96,17 @@ def test_workflow_uses_reusable_one_xi_and_assessment_jobs():
     assert "advanced_config_json: `${{ inputs" not in workflow_text
     assert '"--expected-xi-list=${{ needs.plan.outputs.expected_xi_csv }}"' in workflow_text
     assert '--expected-xi-list="${{ inputs.expected_xi_csv }}"' in assess_workflow_text
+    assert '--expected-calculation-git-commit "${GITHUB_SHA}"' in workflow_text
+    assert '--postprocess-git-commit "${GITHUB_SHA}"' in workflow_text
+
+
+def test_postprocess_replay_uses_cross_run_artifacts_and_dual_provenance():
+    workflow_text = REPLAY_WORKFLOW_PATH.read_text(encoding="utf-8")
+    workflow = yaml.load(workflow_text, Loader=yaml.BaseLoader)
+    inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+    assert {"source_run_id", "source_calculation_sha", "tag", "expected_xi_list"} <= set(inputs)
+    assert "run-id: ${{ inputs.source_run_id }}" in workflow_text
+    assert "github-token: ${{ github.token }}" in workflow_text
+    assert '--expected-calculation-git-commit "${{ inputs.source_calculation_sha }}"' in workflow_text
+    assert '--postprocess-git-commit "${GITHUB_SHA}"' in workflow_text
+    assert "diagnostic replay only; no reference promotion" in workflow_text


### PR DESCRIPTION
## 背景

Issue #130 的 C0 run 29810188129 完成了 41 个 one-xi 数值 shard，但 level-1 assessment 两次确定性失败。审计定位到 xi=0.3 的 grid-convergence reason 含逗号，Julia writer 未做 CSV quoting，导致 13 列记录被解析为 15 列。

Refs #130.

## 修改

- 三条 grid-convergence writer 统一复用 RFC 4180 field escaping，覆盖逗号、双引号和换行。
- shard validator 与 merge 在读取边界拒绝列数不匹配，并报告文件、物理行号、期望/实际列数及 extra values。
- merged manifest/meta 区分 calculation_git_commit、postprocess_git_commit 与 source_workflow_run_id，并校验原计算 SHA。
- 新增 PNJL Dense Reference Postprocess Replay workflow：可从已完成 run 下载 shard artifacts，仅重放 merge/validator；不自动晋升 reference。
- 更新 phase SOP 和 active task，明确计算语义变化才重算，纯后处理修复允许 replay 的边界。

## 验证

- Python CSV/merge/validator/workflow contract: 20 passed
- Julia PhaseArtifacts: 26/26
- Julia dense-reference builder contract: 23/23
- Julia staged xi planner: 8/8
- Python syntax、docs consistency、active docs、SOP governance、script entrypoints、data output path guard、unit skip policy: passed
- git diff --check: passed

仓库外 diagnostic replay：原始 artifact 在 anchor-a016 第 2 物理行准确早失败（expected 13 fields, parsed 15）；只在独立副本中引用该唯一 reason 后，41 shard merge/validator 通过，level-1 20 个区间评估为 7 converged / 13 unconverged，并生成 26 个 level-2 midpoint 候选。该 replay 仅证明恢复合同，不晋升旧 C0。

## Production 边界

本 PR 不修改 solver、热积分、phase grid/refinement 物理语义、effective production 参数或 canonical reference。由于本次正式修复改到 shard writer，合并后仍从新 main SHA 重跑 C0；未来仅 merge/validator/Action 后处理修复时才可复用已锁定 artifacts。