### PR TITLE
fix(ci): resume dense reference refinement

### DIFF
--- a/.github/workflows/pnjl-dense-reference-assess-xi.yml
+++ b/.github/workflows/pnjl-dense-reference-assess-xi.yml
@@ -30,6 +30,18 @@ on:
       response_rtol:
         required: true
         type: string
+      source_run_id:
+        required: false
+        default: ""
+        type: string
+      source_calculation_sha:
+        required: false
+        default: ""
+        type: string
+      include_current_run_shards:
+        required: false
+        default: true
+        type: boolean
     outputs:
       matrix:
         value: ${{ jobs.assess.outputs.matrix }}
@@ -37,6 +49,12 @@ on:
         value: ${{ jobs.assess.outputs.intervals }}
       record_count:
         value: ${{ jobs.assess.outputs.record_count }}
+      next_xi_count:
+        value: ${{ jobs.assess.outputs.next_xi_count }}
+
+permissions:
+  actions: read
+  contents: read
 
 jobs:
   assess:
@@ -46,6 +64,7 @@ jobs:
       matrix: ${{ steps.publish.outputs.matrix }}
       intervals: ${{ steps.publish.outputs.intervals }}
       record_count: ${{ steps.publish.outputs.record_count }}
+      next_xi_count: ${{ steps.publish.outputs.next_xi_count }}
     env:
       ARTIFACT_RETENTION_DAYS: "30"
       SHARDS_ROOT: data/outputs/artifacts/pnjl_dense_reference/${{ github.run_id }}/assessment_level${{ inputs.level }}/downloaded_shards
@@ -60,9 +79,23 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Download completed one-xi shards
+      - name: Download source-run one-xi shards
+        if: ${{ inputs.source_run_id != '' }}
         uses: actions/download-artifact@v4
         with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_run_id }}
+          pattern: pnjl-dense-reference-shard-${{ inputs.tag }}-*
+          path: ${{ env.SHARDS_ROOT }}
+
+      - name: Download current-run one-xi shards
+        if: ${{ inputs.include_current_run_shards }}
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
           pattern: pnjl-dense-reference-shard-${{ inputs.tag }}-*
           path: ${{ env.SHARDS_ROOT }}
 
@@ -71,12 +104,22 @@ jobs:
         run: |
           rm -rf "${REFERENCE_ROOT}"
           mkdir -p "${REFERENCE_ROOT}" "${PLAN_ROOT}"
-          python scripts/pnjl/merge_dense_phase_reference_shards.py \
-            --shards-root "${SHARDS_ROOT}" \
-            --reference-root "${REFERENCE_ROOT}" \
-            --tag "${{ inputs.tag }}" \
-            --expected-xi-list="${{ inputs.expected_xi_csv }}" \
+          merge_cmd=(
+            python scripts/pnjl/merge_dense_phase_reference_shards.py
+            --shards-root "${SHARDS_ROOT}"
+            --reference-root "${REFERENCE_ROOT}"
+            --tag "${{ inputs.tag }}"
+            "--expected-xi-list=${{ inputs.expected_xi_csv }}"
+            --postprocess-git-commit "${GITHUB_SHA}"
             --overwrite
+          )
+          if [ -n "${{ inputs.source_calculation_sha }}" ]; then
+            merge_cmd+=(--expected-calculation-git-commit "${{ inputs.source_calculation_sha }}")
+          fi
+          if [ -n "${{ inputs.source_run_id }}" ]; then
+            merge_cmd+=(--source-workflow-run-id "${{ inputs.source_run_id }}")
+          fi
+          "${merge_cmd[@]}"
 
       - name: Setup Julia
         uses: julia-actions/setup-julia@v2
@@ -143,6 +186,7 @@ jobs:
               handle.write(f"matrix={json.dumps(matrix, separators=(',', ':'))}\n")
               handle.write(f"intervals={json.dumps(intervals, separators=(',', ':'))}\n")
               handle.write(f"record_count={summary['evaluated_interval_count']}\n")
+              handle.write(f"next_xi_count={summary['next_xi_count']}\n")
           PY
 
       - name: Upload xi refinement assessment

--- a/.github/workflows/pnjl-dense-reference-resume.yml
+++ b/.github/workflows/pnjl-dense-reference-resume.yml
@@ -42,7 +42,7 @@ jobs:
       crossover_mu0_only: ${{ steps.publish.outputs.crossover_mu0_only }}
     env:
       SOURCE_SHARDS_ROOT: data/outputs/artifacts/pnjl_dense_reference/resume_${{ github.run_id }}/source_shards
-      PLAN_PATH: ${{ runner.temp }}/dense_reference_resume_plan.json
+      PLAN_PATH: data/outputs/artifacts/pnjl_dense_reference/resume_${{ github.run_id }}/resume_plan.json
     steps:
       - name: Checkout resume workflow code
         uses: actions/checkout@v4

--- a/.github/workflows/pnjl-dense-reference-resume.yml
+++ b/.github/workflows/pnjl-dense-reference-resume.yml
@@ -1,0 +1,334 @@
+name: PNJL Dense Reference Source Resume
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: "包含完整 initial staged shard artifacts 的源 run ID"
+        required: true
+        type: string
+      source_calculation_sha:
+        description: "源 shard 数值计算提交 SHA"
+        required: true
+        type: string
+      tag:
+        description: "源 artifact 标签后缀"
+        required: true
+        type: string
+      expected_xi_list:
+        description: "源 run 的初始 xi 锚点（逗号分隔，不含 level-1 midpoint）"
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      expected_xi_csv: ${{ steps.publish.outputs.expected_xi_csv }}
+      initial_intervals: ${{ steps.publish.outputs.initial_intervals }}
+      source_shard_count: ${{ steps.publish.outputs.source_shard_count }}
+      source_config_sha256: ${{ steps.publish.outputs.source_config_sha256 }}
+      xi_refine_levels: ${{ steps.publish.outputs.xi_refine_levels }}
+      xi_position_tol: ${{ steps.publish.outputs.xi_position_tol }}
+      xi_density_tol: ${{ steps.publish.outputs.xi_density_tol }}
+      xi_maxwell_area_tol: ${{ steps.publish.outputs.xi_maxwell_area_tol }}
+      xi_response_rtol: ${{ steps.publish.outputs.xi_response_rtol }}
+      common_args_json: ${{ steps.publish.outputs.common_args_json }}
+      crossover_only: ${{ steps.publish.outputs.crossover_only }}
+      crossover_mu0_only: ${{ steps.publish.outputs.crossover_mu0_only }}
+    env:
+      SOURCE_SHARDS_ROOT: data/outputs/artifacts/pnjl_dense_reference/resume_${{ github.run_id }}/source_shards
+      PLAN_PATH: ${{ runner.temp }}/dense_reference_resume_plan.json
+    steps:
+      - name: Checkout resume workflow code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Download source initial shards
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_run_id }}
+          pattern: pnjl-dense-reference-shard-${{ inputs.tag }}-*
+          path: ${{ env.SOURCE_SHARDS_ROOT }}
+
+      - name: Validate source grid and reconstruct effective plan
+        shell: bash
+        run: |
+          python scripts/pnjl/plan_dense_reference_resume.py \
+            --shards-root "${SOURCE_SHARDS_ROOT}" \
+            --tag "${{ inputs.tag }}" \
+            --source-calculation-sha "${{ inputs.source_calculation_sha }}" \
+            --expected-xi-list="${{ inputs.expected_xi_list }}" \
+            --output "${PLAN_PATH}"
+
+      - name: Publish resume plan
+        id: publish
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          plan = json.loads(Path(os.environ["PLAN_PATH"]).read_text(encoding="utf-8"))
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as handle:
+              for key in (
+                  "expected_xi_csv",
+                  "source_shard_count",
+                  "source_config_sha256",
+                  "xi_refine_levels",
+                  "xi_position_tol",
+                  "xi_density_tol",
+                  "xi_maxwell_area_tol",
+                  "xi_response_rtol",
+              ):
+                  handle.write(f"{key}={plan[key]}\n")
+              handle.write(
+                  f"initial_intervals={json.dumps(plan['initial_intervals'], separators=(',', ':'))}\n"
+              )
+              handle.write(
+                  f"common_args_json={json.dumps(plan['common_args'], separators=(',', ':'))}\n"
+              )
+              handle.write(f"crossover_only={str(plan['crossover_only']).lower()}\n")
+              handle.write(
+                  f"crossover_mu0_only={str(plan['crossover_mu0_only']).lower()}\n"
+              )
+          PY
+
+  assess_xi_level1:
+    needs: prepare
+    if: ${{ fromJSON(needs.prepare.outputs.xi_refine_levels) >= 1 }}
+    uses: ./.github/workflows/pnjl-dense-reference-assess-xi.yml
+    with:
+      tag: ${{ inputs.tag }}
+      level: 1
+      max_refine_level: ${{ fromJSON(needs.prepare.outputs.xi_refine_levels) }}
+      intervals_json: ${{ needs.prepare.outputs.initial_intervals }}
+      expected_xi_csv: ${{ needs.prepare.outputs.expected_xi_csv }}
+      position_tol: ${{ needs.prepare.outputs.xi_position_tol }}
+      density_tol: ${{ needs.prepare.outputs.xi_density_tol }}
+      maxwell_area_tol: ${{ needs.prepare.outputs.xi_maxwell_area_tol }}
+      response_rtol: ${{ needs.prepare.outputs.xi_response_rtol }}
+      source_run_id: ${{ inputs.source_run_id }}
+      source_calculation_sha: ${{ inputs.source_calculation_sha }}
+      include_current_run_shards: false
+
+  generate_xi_level2:
+    needs: [prepare, assess_xi_level1]
+    if: ${{ fromJSON(needs.prepare.outputs.xi_refine_levels) >= 2 }}
+    strategy:
+      fail-fast: false
+      max-parallel: 20
+      matrix: ${{ fromJSON(needs.assess_xi_level1.outputs.matrix) }}
+    uses: ./.github/workflows/pnjl-dense-reference-shard.yml
+    with:
+      tag: ${{ inputs.tag }}
+      stage: ${{ matrix.stage }}
+      shard_id: ${{ matrix.shard_id }}
+      xi: ${{ matrix.xi }}
+      enabled: ${{ matrix.enabled }}
+      common_args_json: ${{ needs.prepare.outputs.common_args_json }}
+      crossover_only: ${{ fromJSON(needs.prepare.outputs.crossover_only) }}
+      crossover_mu0_only: ${{ fromJSON(needs.prepare.outputs.crossover_mu0_only) }}
+      calculation_ref: ${{ inputs.source_calculation_sha }}
+
+  assess_xi_level2:
+    needs: [prepare, assess_xi_level1, generate_xi_level2]
+    if: ${{ fromJSON(needs.prepare.outputs.xi_refine_levels) >= 2 }}
+    uses: ./.github/workflows/pnjl-dense-reference-assess-xi.yml
+    with:
+      tag: ${{ inputs.tag }}
+      level: 2
+      max_refine_level: ${{ fromJSON(needs.prepare.outputs.xi_refine_levels) }}
+      intervals_json: ${{ needs.assess_xi_level1.outputs.intervals }}
+      expected_xi_csv: ${{ needs.prepare.outputs.expected_xi_csv }}
+      position_tol: ${{ needs.prepare.outputs.xi_position_tol }}
+      density_tol: ${{ needs.prepare.outputs.xi_density_tol }}
+      maxwell_area_tol: ${{ needs.prepare.outputs.xi_maxwell_area_tol }}
+      response_rtol: ${{ needs.prepare.outputs.xi_response_rtol }}
+      source_run_id: ${{ inputs.source_run_id }}
+      source_calculation_sha: ${{ inputs.source_calculation_sha }}
+      include_current_run_shards: ${{ fromJSON(needs.assess_xi_level1.outputs.next_xi_count) > 0 }}
+
+  generate_xi_level3:
+    needs: [prepare, assess_xi_level2]
+    if: ${{ fromJSON(needs.prepare.outputs.xi_refine_levels) >= 3 }}
+    strategy:
+      fail-fast: false
+      max-parallel: 20
+      matrix: ${{ fromJSON(needs.assess_xi_level2.outputs.matrix) }}
+    uses: ./.github/workflows/pnjl-dense-reference-shard.yml
+    with:
+      tag: ${{ inputs.tag }}
+      stage: ${{ matrix.stage }}
+      shard_id: ${{ matrix.shard_id }}
+      xi: ${{ matrix.xi }}
+      enabled: ${{ matrix.enabled }}
+      common_args_json: ${{ needs.prepare.outputs.common_args_json }}
+      crossover_only: ${{ fromJSON(needs.prepare.outputs.crossover_only) }}
+      crossover_mu0_only: ${{ fromJSON(needs.prepare.outputs.crossover_mu0_only) }}
+      calculation_ref: ${{ inputs.source_calculation_sha }}
+
+  assess_xi_level3:
+    needs: [prepare, assess_xi_level1, assess_xi_level2, generate_xi_level3]
+    if: ${{ fromJSON(needs.prepare.outputs.xi_refine_levels) >= 3 }}
+    uses: ./.github/workflows/pnjl-dense-reference-assess-xi.yml
+    with:
+      tag: ${{ inputs.tag }}
+      level: 3
+      max_refine_level: ${{ fromJSON(needs.prepare.outputs.xi_refine_levels) }}
+      intervals_json: ${{ needs.assess_xi_level2.outputs.intervals }}
+      expected_xi_csv: ${{ needs.prepare.outputs.expected_xi_csv }}
+      position_tol: ${{ needs.prepare.outputs.xi_position_tol }}
+      density_tol: ${{ needs.prepare.outputs.xi_density_tol }}
+      maxwell_area_tol: ${{ needs.prepare.outputs.xi_maxwell_area_tol }}
+      response_rtol: ${{ needs.prepare.outputs.xi_response_rtol }}
+      source_run_id: ${{ inputs.source_run_id }}
+      source_calculation_sha: ${{ inputs.source_calculation_sha }}
+      include_current_run_shards: ${{ fromJSON(needs.assess_xi_level2.outputs.next_xi_count) > 0 }}
+
+  merge:
+    needs:
+      - prepare
+      - assess_xi_level1
+      - generate_xi_level2
+      - assess_xi_level2
+      - generate_xi_level3
+      - assess_xi_level3
+    if: >-
+      ${{
+        always() &&
+        needs.prepare.result == 'success' &&
+        needs.assess_xi_level1.result == 'success' &&
+        (fromJSON(needs.prepare.outputs.xi_refine_levels) < 2 ||
+          (needs.generate_xi_level2.result == 'success' && needs.assess_xi_level2.result == 'success')) &&
+        (fromJSON(needs.prepare.outputs.xi_refine_levels) < 3 ||
+          (needs.generate_xi_level3.result == 'success' && needs.assess_xi_level3.result == 'success'))
+      }}
+    runs-on: ubuntu-latest
+    env:
+      ARTIFACT_RETENTION_DAYS: "30"
+      SHARDS_ROOT: data/outputs/artifacts/pnjl_dense_reference/resume_${{ github.run_id }}/downloaded_shards
+      XI_PLAN_ROOT: data/outputs/artifacts/pnjl_dense_reference/resume_${{ github.run_id }}/downloaded_xi_plans
+      REFERENCE_ROOT: data/outputs/artifacts/pnjl_dense_reference/resume_${{ github.run_id }}/reference
+      REPORT_PATH: data/outputs/artifacts/pnjl_dense_reference/resume_${{ github.run_id }}/validation_report.json
+    steps:
+      - name: Checkout postprocess code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Download source initial shards
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_run_id }}
+          pattern: pnjl-dense-reference-shard-${{ inputs.tag }}-*
+          path: ${{ env.SHARDS_ROOT }}
+
+      - name: Download resumed refinement shards
+        if: ${{ fromJSON(needs.assess_xi_level1.outputs.next_xi_count) > 0 }}
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
+          pattern: pnjl-dense-reference-shard-${{ inputs.tag }}-*
+          path: ${{ env.SHARDS_ROOT }}
+
+      - name: Download resumed xi convergence records
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
+          pattern: pnjl-dense-reference-xi-plan-${{ inputs.tag }}-level*
+          path: ${{ env.XI_PLAN_ROOT }}
+
+      - name: Deterministically merge source and resumed shards
+        shell: bash
+        run: |
+          rm -rf "${REFERENCE_ROOT}"
+          mkdir -p "${REFERENCE_ROOT}"
+          python scripts/pnjl/merge_dense_phase_reference_shards.py \
+            --shards-root "${SHARDS_ROOT}" \
+            --xi-convergence-root "${XI_PLAN_ROOT}" \
+            --reference-root "${REFERENCE_ROOT}" \
+            --tag "${{ inputs.tag }}" \
+            "--expected-xi-list=${{ needs.prepare.outputs.expected_xi_csv }}" \
+            --expected-calculation-git-commit "${{ inputs.source_calculation_sha }}" \
+            --postprocess-git-commit "${GITHUB_SHA}" \
+            --source-workflow-run-id "${{ inputs.source_run_id }}" \
+            --overwrite
+
+      - name: Validate resumed dense reference artifact
+        shell: bash
+        run: |
+          validate_cmd=(
+            python scripts/pnjl/validate_dense_reference_artifact.py
+            --reference-root "${REFERENCE_ROOT}"
+            --tag "${{ inputs.tag }}"
+            --min-crossover-rows 1
+            --report-path "${REPORT_PATH}"
+          )
+          if [ "${{ needs.prepare.outputs.crossover_only }}" = "true" ]; then
+            validate_cmd+=(--expect-crossover-only)
+          else
+            validate_cmd+=(--expect-full-reference)
+          fi
+          if [ "${{ needs.prepare.outputs.crossover_mu0_only }}" = "true" ]; then
+            validate_cmd+=(--expect-mu0-only)
+          fi
+          "${validate_cmd[@]}"
+
+      - name: Record resumed candidate status
+        shell: bash
+        run: |
+          cat > "${REFERENCE_ROOT}/resume_candidate_status.md" <<EOF
+          # Resumed dense-reference candidate
+
+          - status: diagnostic candidate only; no reference promotion
+          - source workflow run: ${{ inputs.source_run_id }}
+          - calculation SHA: ${{ inputs.source_calculation_sha }}
+          - postprocess SHA: ${GITHUB_SHA}
+          - source configuration SHA256: ${{ needs.prepare.outputs.source_config_sha256 }}
+          - source shard count: ${{ needs.prepare.outputs.source_shard_count }}
+          EOF
+
+          cat >> "${GITHUB_STEP_SUMMARY}" <<EOF
+          ## PNJL Dense Reference Source Resume
+
+          - status: diagnostic candidate only; no reference promotion
+          - source workflow run: ${{ inputs.source_run_id }}
+          - calculation SHA: ${{ inputs.source_calculation_sha }}
+          - postprocess SHA: ${GITHUB_SHA}
+          - source configuration SHA256: ${{ needs.prepare.outputs.source_config_sha256 }}
+          - source shard count: ${{ needs.prepare.outputs.source_shard_count }}
+          EOF
+
+      - name: Upload resumed dense reference candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: pnjl-dense-reference-resume-${{ inputs.tag }}-source-${{ inputs.source_run_id }}
+          path: |
+            ${{ env.REFERENCE_ROOT }}/*_${{ inputs.tag }}.csv
+            ${{ env.REFERENCE_ROOT }}/*_${{ inputs.tag }}.meta.json
+            ${{ env.REFERENCE_ROOT }}/phase_reference_${{ inputs.tag }}_manifest.json
+            ${{ env.REFERENCE_ROOT }}/resume_candidate_status.md
+            ${{ env.REPORT_PATH }}
+          retention-days: ${{ fromJson(env.ARTIFACT_RETENTION_DAYS) }}
+          if-no-files-found: error

--- a/.github/workflows/pnjl-dense-reference-shard.yml
+++ b/.github/workflows/pnjl-dense-reference-shard.yml
@@ -28,6 +28,10 @@ on:
       crossover_mu0_only:
         required: true
         type: boolean
+      calculation_ref:
+        required: false
+        default: ""
+        type: string
 
 jobs:
   phase-shard:
@@ -48,6 +52,8 @@ jobs:
       - name: Checkout
         if: ${{ inputs.enabled }}
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.calculation_ref || github.sha }}
 
       - name: Setup Julia
         if: ${{ inputs.enabled }}

--- a/.github/workflows/pnjl-dense-reference.yml
+++ b/.github/workflows/pnjl-dense-reference.yml
@@ -127,6 +127,10 @@ on:
         default: "{}"
         type: string
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   plan:
     runs-on: ubuntu-latest
@@ -327,6 +331,9 @@ jobs:
       - name: Download all successful xi shards
         uses: actions/download-artifact@v4
         with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
           pattern: pnjl-dense-reference-shard-${{ inputs.tag || 'dense' }}-*
           path: ${{ env.SHARDS_ROOT }}
 
@@ -334,6 +341,9 @@ jobs:
         if: ${{ fromJSON(needs.plan.outputs.xi_refine_levels) >= 1 }}
         uses: actions/download-artifact@v4
         with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
           pattern: pnjl-dense-reference-xi-plan-${{ inputs.tag || 'dense' }}-level*
           path: ${{ env.XI_PLAN_ROOT }}
 

--- a/docs/dev/active/2026-07-17_PNJL全温区相图热积分与参考生产.md
+++ b/docs/dev/active/2026-07-17_PNJL全温区相图热积分与参考生产.md
@@ -2,7 +2,7 @@
 
 创建日期：2026-07-17
 
-状态：执行中；PR 1 已通过作者审核并以 [PR #137](https://github.com/w5851/Julia_RelaxTime/pull/137) 合并为 `main@c0cde620`；独立依赖/AGENTS 治理 [PR #138](https://github.com/w5851/Julia_RelaxTime/pull/138) 已合并为 `main@8dd760b5`；PR 2 已通过作者审核并以 [PR #139](https://github.com/w5851/Julia_RelaxTime/pull/139) 合并为 `main@be7545d9`；staged one-xi pipeline 已以 [PR #140](https://github.com/w5851/Julia_RelaxTime/pull/140) 合并为 `main@5df0866c`，C0 的 41 个数值 shard 全部完成但 level-1 assessment 暴露 CSV 转义合同缺口，当前正在独立 corrective PR 修复并建立后处理 replay 合同，尚未晋升 canonical reference
+状态：执行中；PR 1 已通过作者审核并以 [PR #137](https://github.com/w5851/Julia_RelaxTime/pull/137) 合并为 `main@c0cde620`；独立依赖/AGENTS 治理 [PR #138](https://github.com/w5851/Julia_RelaxTime/pull/138) 已合并为 `main@8dd760b5`；PR 2 已通过作者审核并以 [PR #139](https://github.com/w5851/Julia_RelaxTime/pull/139) 合并为 `main@be7545d9`；staged one-xi pipeline 已以 [PR #140](https://github.com/w5851/Julia_RelaxTime/pull/140) 合并为 `main@5df0866c`，C0 已在后续 corrective pipeline 上完整成功；C1 的 41 个 initial shard 已完成，当前修复跨 rerun attempt 的 artifact 下载并建立 source-run refinement resume，尚未启动 C2 或晋升 canonical reference
 
 关联背景：Issue #130 后续 transport production 依赖新的高精度 phase reference；现有 `24/8` 与 `32/10`、`T=60--240 MeV` 结果只作为算法改造前 pilot，不晋升 canonical。
 
@@ -160,6 +160,31 @@ convergence success。
 C0。只要 solver、数值内核、grid/refinement 语义和 effective config 均未变化，就冻结原 shard artifact，使用
 `.github/workflows/pnjl-dense-reference-replay.yml` 重放相应档位，并以双 SHA provenance 审计。若上述任何计算语义
 发生变化，则 replay 不适用，必须从受影响的最早收敛档位重新计算。
+
+corrective pipeline 合并后的 C0 [run 29896085769](https://github.com/w5851/Julia_RelaxTime/actions/runs/29896085769)
+已在 `main@fc5d50a5` 完成 staged assessment、必要 refinement、final merge 与 validator，状态为 candidate artifact
+success，不等于 convergence gate 通过。随后串行启动的 C1
+[run 29937506668](https://github.com/w5851/Julia_RelaxTime/actions/runs/29937506668) 同样绑定
+`fc5d50a5`：attempt 1 仅 `xi=-0.075` 的 level-1 shard 达到 300 min timeout，failed-only rerun 后该 shard 成功，
+至此 41 个 initial shard 已全部完成。attempt 2 的 `assess_xi_level1` 在下载这些跨 attempt artifacts 时收到
+`Failed to GetSignedArtifactURL: 404 workflow run not found`；仓库外通过 GitHub REST/`gh run download` 对全部 41 个
+artifact 的逐项审计成功，确认失败属于无凭证内部 artifact token 的 attempt 作用域，不是数值或 artifact 缺失。
+
+本轮 source-run resume corrective PR 的合同为：
+
+- [x] 主 workflow、assessment 与 final merge 的 artifact 下载显式使用 `actions: read`、GitHub token、repository 和 run ID；
+- [x] 新增 source-run resume planner，要求源 artifacts 精确覆盖 initial anchors 与 level-1 midpoints，并验证统一 calculation SHA、tag 和 effective config；
+- [x] 从源 manifest 重建后续 shard 的完整 CLI 参数，不接受调用者重新手填一套可能漂移的数值配置；
+- [x] 后续 level-2/level-3 shard 显式 checkout 原 calculation SHA，workflow 调度和后处理使用修复提交；
+- [x] assessment 与 final merge 可联合消费 source run 和 resume run artifacts，并记录 calculation SHA、postprocess SHA 与 source run ID；
+- [x] resume 产物明确标记为 diagnostic candidate，不自动晋升 reference；
+- [ ] corrective PR 经作者审核合并后，从默认分支注册并触发 resume workflow，继续 C1 staged refinement；在 C1 完整 success 前不启动 C2。
+
+仓库外 C1 source audit 目录为
+`D:\Desktop\Julia_RelaxTime_issue130_artifacts\c1_attempt2_download_probe_20260723`；41 个唯一 xi 完整覆盖
+`-0.5:0.025:0.5`，resume planner 重建出的 source config SHA256 为
+`20fc053f21025fed0d90cd9885e9ef92cdf1ce81142c091e0604335c31c45988`。该审计只证明 source-run resume 前置条件，
+不构成 C1 convergence 或 production-grade 证据。
 
 corrective PR 的本地验证包括：CSV/merge/validator/Action contract Python `20/20`；三个直接 Julia writer/plan
 测试分别 `26/26`、`23/23`、`8/8`；Python syntax、docs consistency、active docs、SOP governance、script

--- a/docs/dev/active/2026-07-17_PNJL全温区相图热积分与参考生产.md
+++ b/docs/dev/active/2026-07-17_PNJL全温区相图热积分与参考生产.md
@@ -170,7 +170,7 @@ success，不等于 convergence gate 通过。随后串行启动的 C1
 `Failed to GetSignedArtifactURL: 404 workflow run not found`；仓库外通过 GitHub REST/`gh run download` 对全部 41 个
 artifact 的逐项审计成功，确认失败属于无凭证内部 artifact token 的 attempt 作用域，不是数值或 artifact 缺失。
 
-本轮 source-run resume corrective PR 的合同为：
+本轮 source-run resume corrective [PR #142](https://github.com/w5851/Julia_RelaxTime/pull/142) 的合同为：
 
 - [x] 主 workflow、assessment 与 final merge 的 artifact 下载显式使用 `actions: read`、GitHub token、repository 和 run ID；
 - [x] 新增 source-run resume planner，要求源 artifacts 精确覆盖 initial anchors 与 level-1 midpoints，并验证统一 calculation SHA、tag 和 effective config；
@@ -178,7 +178,7 @@ artifact 的逐项审计成功，确认失败属于无凭证内部 artifact toke
 - [x] 后续 level-2/level-3 shard 显式 checkout 原 calculation SHA，workflow 调度和后处理使用修复提交；
 - [x] assessment 与 final merge 可联合消费 source run 和 resume run artifacts，并记录 calculation SHA、postprocess SHA 与 source run ID；
 - [x] resume 产物明确标记为 diagnostic candidate，不自动晋升 reference；
-- [ ] corrective PR 经作者审核合并后，从默认分支注册并触发 resume workflow，继续 C1 staged refinement；在 C1 完整 success 前不启动 C2。
+- [ ] PR #142 经作者审核合并后，从默认分支注册并触发 resume workflow，继续 C1 staged refinement；在 C1 完整 success 前不启动 C2。
 
 仓库外 C1 source audit 目录为
 `D:\Desktop\Julia_RelaxTime_issue130_artifacts\c1_attempt2_download_probe_20260723`；41 个唯一 xi 完整覆盖

--- a/docs/guides/sop/workflows/pnjl_phase_structure.md
+++ b/docs/guides/sop/workflows/pnjl_phase_structure.md
@@ -166,6 +166,18 @@ dense-reference CSV 必须遵循 RFC 4180 字段转义：字段含逗号、双�
 `.github/workflows/pnjl-dense-reference-replay.yml` 重放该档位；replay 必须显式给出原 run ID、原 calculation SHA、
 tag 与必需 xi anchors，SHA 不匹配即失败。replay 产物始终是 diagnostic candidate，不自动晋升 reference。
 
+跨 GitHub Actions rerun attempt 下载 artifact 时，不能依赖仅对当前 attempt 有效的内部 runtime artifact token。
+所有跨 job 或跨 run 下载均显式授予 `actions: read`，并向 `actions/download-artifact` 传入 GitHub token、repository
+和目标 run ID。failed-only rerun 后若数值 shard 已完整、但 staged assessment 尚未完成，可使用
+`.github/workflows/pnjl-dense-reference-resume.yml` 从源 run 恢复后续 xi refinement；该入口只接受 source run ID、
+source calculation SHA、tag 和 initial xi anchors。resume planner 必须从 source manifest 重建 effective CLI config，
+验证源 grid 精确包含 anchors 与 level-1 midpoints，并拒绝 calculation SHA、tag、配置或 grid 不一致。
+
+resume 新生成的 level-2/level-3 shard 必须 checkout 原 calculation SHA；修复提交只提供 workflow 调度与后处理代码。
+最终 manifest 同时记录原 calculation SHA、新 postprocess SHA 和 source workflow run ID。resume 输出始终是
+diagnostic candidate，不自动晋升 reference；若 solver、数值内核、grid/refinement 语义或 effective config 已改变，
+禁止使用 resume，必须从受影响的最早档位重新计算。
+
 ## 11. Regression / Validation 验收
 
 最小层级：
@@ -183,6 +195,8 @@ tag 与必需 xi anchors，SHA 不匹配即失败。replay 产物始终是 diagn
 - solver unknown 或失败比例异常时保留 `phase_summary.json` 和 report，不直接删点；
 - 改变网格或求解策略时使用新 case 目录；
 - 后处理修复优先重放已完成且 SHA 已核验的 shard artifacts；不得用 replay 掩盖数值代码或 effective config 变化；
+- failed-only rerun 后 assessment 因跨 attempt 下载失败时，先用 tokenized REST 路径核验 source artifacts，再按上述
+  source-run resume 合同恢复 refinement；不得为纯下载故障机械重算完整 initial grid；
 - 不在已有正式目录上用不同 effective config 覆盖运行；
 - CEP 未找到不自动等价于“物理上不存在 CEP”，必须结合扫描覆盖和诊断字段判断。
 

--- a/scripts/pnjl/plan_dense_reference_resume.py
+++ b/scripts/pnjl/plan_dense_reference_resume.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+MAX_ACTION_XI_REFINE_LEVEL = 3
+IGNORED_CONFIG_FIELDS = {"xi_values", "requested_xi_values"}
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def parse_xi_list(raw: str) -> list[float]:
+    values = sorted({_xi_key(float(token.strip())) for token in raw.split(",") if token.strip()})
+    if not values:
+        fail("expected xi list is empty")
+    if len(values) < 2:
+        fail("expected xi list must contain at least two anchors")
+    if values[0] <= -1 or any(not math.isfinite(value) for value in values):
+        fail("expected xi values must be finite and satisfy xi > -1")
+    return values
+
+
+def _xi_key(value: float) -> float:
+    return round(value, 12)
+
+
+def _xi_text(value: float) -> str:
+    rendered = format(_xi_key(value), ".12g")
+    return "0" if rendered == "-0" else rendered
+
+
+def _number(config: dict[str, Any], key: str) -> int | float:
+    value = config.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        fail(f"source config field {key} must be numeric")
+    number = float(value)
+    if not math.isfinite(number):
+        fail(f"source config field {key} must be finite")
+    return value
+
+
+def _integer(config: dict[str, Any], key: str) -> int:
+    value = _number(config, key)
+    if int(value) != value:
+        fail(f"source config field {key} must be an integer")
+    return int(value)
+
+
+def _boolean(config: dict[str, Any], key: str) -> bool:
+    value = config.get(key)
+    if not isinstance(value, bool):
+        fail(f"source config field {key} must be boolean")
+    return value
+
+
+def _text(value: Any) -> str:
+    if isinstance(value, bool):
+        fail("boolean cannot be rendered as a numeric CLI value")
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            fail("non-finite CLI value")
+        return format(value, ".17g")
+    return str(value)
+
+
+def normalize_config(config: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in config.items() if key not in IGNORED_CONFIG_FIELDS}
+
+
+def common_cli_args(config: dict[str, Any]) -> list[str]:
+    if config.get("mode") != "production":
+        fail("source shard mode must be production")
+    if not _boolean(config, "compute_crossover"):
+        fail("source shard must include crossover results")
+    if config.get("crossover_method") != "peak" or config.get("crossover_variable") != "phi_u":
+        fail("source crossover method/variable is not supported by staged resume")
+
+    args = [
+        "--T-min", _text(_number(config, "T_min_MeV")),
+        "--T-max", _text(_number(config, "T_max_MeV")),
+        "--T-step", _text(_number(config, "T_step_MeV")),
+        "--T-refine-levels", _text(_integer(config, "temperature_max_refine_level")),
+        "--T-position-tol", _text(_number(config, "temperature_position_tol_MeV")),
+        "--T-density-tol", _text(_number(config, "temperature_density_tol")),
+        "--T-maxwell-area-tol", _text(_number(config, "temperature_maxwell_area_tol")),
+        "--rho-min", _text(_number(config, "rho_min")),
+        "--rho-max", _text(_number(config, "rho_max")),
+        "--rho-step", _text(_number(config, "rho_step")),
+        "--rho-position-tol", _text(_number(config, "rho_position_tol_MeV")),
+        "--rho-density-tol", _text(_number(config, "rho_density_tol")),
+        "--rho-maxwell-area-tol", _text(_number(config, "rho_maxwell_area_tol")),
+        "--cep-tol", _text(_number(config, "cep_tol_MeV")),
+        "--p-num", _text(_integer(config, "p_num")),
+        "--t-num", _text(_integer(config, "t_num")),
+        "--thermo-quadrature-policy", str(config["thermo_quadrature_policy"]),
+        "--thermo-quadrature-rtol", _text(_number(config, "thermo_quadrature_rtol")),
+        "--thermo-quadrature-atol", _text(_number(config, "thermo_quadrature_atol")),
+        "--thermo-quadrature-maxevals", _text(_integer(config, "thermo_quadrature_maxevals")),
+        "--iterations", _text(_integer(config, "iterations")),
+        "--crossover-n-mu", _text(_integer(config, "crossover_n_mu")),
+        "--crossover-mu-max", _text(_number(config, "crossover_mu_max_MeV")),
+    ]
+    if _boolean(config, "adaptive_xi"):
+        args.extend([
+            "--adaptive-xi",
+            "--xi-refine-levels", _text(_integer(config, "xi_max_refine_level")),
+            "--xi-position-tol", _text(_number(config, "xi_position_tol_MeV")),
+            "--xi-density-tol", _text(_number(config, "xi_density_tol")),
+            "--xi-maxwell-area-tol", _text(_number(config, "xi_maxwell_area_tol")),
+            "--xi-response-rtol", _text(_number(config, "xi_response_rtol")),
+        ])
+    if not _boolean(config, "adaptive_temperature"):
+        args.append("--no-adaptive-T")
+    if not _boolean(config, "rho_geometry_convergence"):
+        args.append("--no-rho-geometry-convergence")
+    if _boolean(config, "crossover_only"):
+        args.append("--crossover-only")
+    if _boolean(config, "crossover_mu0_only"):
+        args.append("--crossover-mu0-only")
+    crossover_T_max = config.get("crossover_T_max_MeV")
+    if crossover_T_max is not None:
+        args.extend(["--crossover-T-max", _text(_number(config, "crossover_T_max_MeV"))])
+    args.append("--overwrite")
+    return args
+
+
+def build_resume_plan(
+    shards_root: Path,
+    tag: str,
+    source_calculation_sha: str,
+    expected_xi_list: str,
+) -> dict[str, Any]:
+    manifests = sorted(shards_root.rglob(f"phase_reference_{tag}_manifest.json"))
+    if not manifests:
+        fail(f"no source shard manifests found below {shards_root}")
+
+    payloads = [json.loads(path.read_text(encoding="utf-8")) for path in manifests]
+    commits = {payload.get("generator", {}).get("git_commit") for payload in payloads}
+    if commits != {source_calculation_sha}:
+        fail(f"source shard calculation commits differ from {source_calculation_sha}: {sorted(map(str, commits))}")
+
+    configs = [payload.get("config") for payload in payloads]
+    if any(not isinstance(config, dict) for config in configs):
+        fail("source shard manifest lacks a config object")
+    normalized = [normalize_config(config) for config in configs]
+    if any(config != normalized[0] for config in normalized[1:]):
+        fail("source shard configuration mismatch outside xi sampling fields")
+    config = normalized[0]
+    if config.get("tag") != tag:
+        fail(f"source shard tag mismatch: expected {tag}, got {config.get('tag')}")
+    if not _boolean(config, "adaptive_xi"):
+        fail("source shard config must enable adaptive_xi")
+    xi_refine_levels = _integer(config, "xi_max_refine_level")
+    if not 1 <= xi_refine_levels <= MAX_ACTION_XI_REFINE_LEVEL:
+        fail(f"source xi refinement level must be in [1, {MAX_ACTION_XI_REFINE_LEVEL}]")
+
+    anchors = parse_xi_list(expected_xi_list)
+    intervals = list(zip(anchors, anchors[1:]))
+    level1 = [_xi_key(0.5 * (left + right)) for left, right in intervals]
+    expected_initial = sorted(set(anchors + level1))
+    resolved: list[float] = []
+    for source_config in configs:
+        values = source_config.get("xi_values")
+        if not isinstance(values, list) or len(values) != 1:
+            fail("each source shard must contain exactly one xi value")
+        resolved.append(_xi_key(float(values[0])))
+    if len(resolved) != len(set(resolved)):
+        fail("source run contains duplicate xi shard manifests")
+    missing = sorted(set(expected_initial) - set(resolved))
+    unexpected = sorted(set(resolved) - set(expected_initial))
+    if missing or unexpected:
+        fail(f"source run is not an initial staged grid: missing={missing}, unexpected={unexpected}")
+
+    config_digest = hashlib.sha256(
+        (json.dumps(config, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+    ).hexdigest()
+    return {
+        "expected_xi_csv": ",".join(_xi_text(value) for value in anchors),
+        "initial_intervals": [[_xi_text(left), _xi_text(right)] for left, right in intervals],
+        "source_shard_count": len(manifests),
+        "source_xi_values": sorted(resolved),
+        "source_config_sha256": config_digest,
+        "xi_refine_levels": xi_refine_levels,
+        "xi_position_tol": _text(_number(config, "xi_position_tol_MeV")),
+        "xi_density_tol": _text(_number(config, "xi_density_tol")),
+        "xi_maxwell_area_tol": _text(_number(config, "xi_maxwell_area_tol")),
+        "xi_response_rtol": _text(_number(config, "xi_response_rtol")),
+        "common_args": common_cli_args(config),
+        "crossover_only": _boolean(config, "crossover_only"),
+        "crossover_mu0_only": _boolean(config, "crossover_mu0_only"),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Plan a PNJL dense-reference staged source-run resume.")
+    parser.add_argument("--shards-root", type=Path, required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--source-calculation-sha", required=True)
+    parser.add_argument("--expected-xi-list", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        plan = build_resume_plan(
+            args.shards_root,
+            args.tag,
+            args.source_calculation_sha,
+            args.expected_xi_list,
+        )
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"[dense-reference-resume-plan] {exc}") from exc
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/python/test_plan_dense_reference_action.py
+++ b/tests/unit/python/test_plan_dense_reference_action.py
@@ -119,6 +119,7 @@ def test_resume_workflow_reuses_source_shards_and_keeps_calculation_sha():
     assert "source and resumed shards" in workflow_text
     assert "diagnostic candidate only; no reference promotion" in workflow_text
     assert "include_current_run_shards: ${{ fromJSON(needs.assess_xi_level2.outputs.next_xi_count) > 0 }}" in workflow_text
+    assert "runner.temp" not in workflow_text
     assert "calculation_ref:" in shard_workflow_text
     assert "ref: ${{ inputs.calculation_ref || github.sha }}" in shard_workflow_text
 

--- a/tests/unit/python/test_plan_dense_reference_action.py
+++ b/tests/unit/python/test_plan_dense_reference_action.py
@@ -10,7 +10,9 @@ PROJECT_ROOT = Path(__file__).resolve().parents[3]
 SCRIPT_PATH = PROJECT_ROOT / "scripts" / "pnjl" / "plan_dense_reference_action.py"
 WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "pnjl-dense-reference.yml"
 ASSESS_WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "pnjl-dense-reference-assess-xi.yml"
+SHARD_WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "pnjl-dense-reference-shard.yml"
 REPLAY_WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "pnjl-dense-reference-replay.yml"
+RESUME_WORKFLOW_PATH = PROJECT_ROOT / ".github" / "workflows" / "pnjl-dense-reference-resume.yml"
 
 
 def load_module():
@@ -95,9 +97,30 @@ def test_workflow_uses_reusable_one_xi_and_assessment_jobs():
     assert "os.environ['ADVANCED_CONFIG_JSON']" in workflow_text
     assert "advanced_config_json: `${{ inputs" not in workflow_text
     assert '"--expected-xi-list=${{ needs.plan.outputs.expected_xi_csv }}"' in workflow_text
-    assert '--expected-xi-list="${{ inputs.expected_xi_csv }}"' in assess_workflow_text
+    assert '"--expected-xi-list=${{ inputs.expected_xi_csv }}"' in assess_workflow_text
     assert '--expected-calculation-git-commit "${GITHUB_SHA}"' in workflow_text
     assert '--postprocess-git-commit "${GITHUB_SHA}"' in workflow_text
+    assert "actions: read" in workflow_text
+    assert "github-token: ${{ github.token }}" in workflow_text
+    assert "run-id: ${{ github.run_id }}" in workflow_text
+    assert "github-token: ${{ github.token }}" in assess_workflow_text
+    assert "run-id: ${{ github.run_id }}" in assess_workflow_text
+    assert "next_xi_count" in assess_workflow_text
+
+
+def test_resume_workflow_reuses_source_shards_and_keeps_calculation_sha():
+    workflow_text = RESUME_WORKFLOW_PATH.read_text(encoding="utf-8")
+    shard_workflow_text = SHARD_WORKFLOW_PATH.read_text(encoding="utf-8")
+    workflow = yaml.load(workflow_text, Loader=yaml.BaseLoader)
+    inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+    assert set(inputs) == {"source_run_id", "source_calculation_sha", "tag", "expected_xi_list"}
+    assert "run-id: ${{ inputs.source_run_id }}" in workflow_text
+    assert "calculation_ref: ${{ inputs.source_calculation_sha }}" in workflow_text
+    assert "source and resumed shards" in workflow_text
+    assert "diagnostic candidate only; no reference promotion" in workflow_text
+    assert "include_current_run_shards: ${{ fromJSON(needs.assess_xi_level2.outputs.next_xi_count) > 0 }}" in workflow_text
+    assert "calculation_ref:" in shard_workflow_text
+    assert "ref: ${{ inputs.calculation_ref || github.sha }}" in shard_workflow_text
 
 
 def test_postprocess_replay_uses_cross_run_artifacts_and_dual_provenance():

--- a/tests/unit/python/test_plan_dense_reference_resume.py
+++ b/tests/unit/python/test_plan_dense_reference_resume.py
@@ -1,0 +1,136 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "pnjl" / "plan_dense_reference_resume.py"
+TAG = "resume-test"
+SHA = "a" * 40
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("dense_reference_resume", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def base_config():
+    return {
+        "tag": TAG,
+        "mode": "production",
+        "compute_crossover": True,
+        "crossover_method": "peak",
+        "crossover_variable": "phi_u",
+        "adaptive_xi": True,
+        "adaptive_temperature": True,
+        "rho_geometry_convergence": True,
+        "crossover_only": False,
+        "crossover_mu0_only": False,
+        "T_min_MeV": 1.0,
+        "T_max_MeV": 240.0,
+        "T_step_MeV": 5.0,
+        "temperature_max_refine_level": 3,
+        "temperature_position_tol_MeV": 0.05,
+        "temperature_density_tol": 0.005,
+        "temperature_maxwell_area_tol": 5e-5,
+        "rho_min": 0.0,
+        "rho_max": 4.0,
+        "rho_step": 0.05,
+        "rho_position_tol_MeV": 0.025,
+        "rho_density_tol": 0.0025,
+        "rho_maxwell_area_tol": 5e-5,
+        "cep_tol_MeV": 0.05,
+        "p_num": 24,
+        "t_num": 8,
+        "thermo_quadrature_policy": "rs_reduced_adaptive",
+        "thermo_quadrature_rtol": 1e-10,
+        "thermo_quadrature_atol": 1e-12,
+        "thermo_quadrature_maxevals": 20_000_000,
+        "iterations": 80,
+        "crossover_n_mu": 16,
+        "crossover_mu_max_MeV": 450.0,
+        "crossover_T_max_MeV": 240.0,
+        "xi_max_refine_level": 2,
+        "xi_position_tol_MeV": 0.05,
+        "xi_density_tol": 0.005,
+        "xi_maxwell_area_tol": 5e-5,
+        "xi_response_rtol": 0.025,
+        "xi_values": [],
+        "requested_xi_values": [],
+    }
+
+
+def write_source_manifests(root: Path, values, *, config=None, commits=None):
+    config = config or base_config()
+    commits = commits or [SHA] * len(values)
+    for index, (xi, commit) in enumerate(zip(values, commits)):
+        payload = {
+            "generator": {"git_commit": commit},
+            "config": {**config, "xi_values": [xi], "requested_xi_values": [xi]},
+        }
+        path = root / f"shard-{index}" / f"phase_reference_{TAG}_manifest.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_builds_plan_for_anchors_and_level1_midpoints(tmp_path: Path):
+    module = load_module()
+    write_source_manifests(tmp_path, [-0.5, -0.25, 0.0, 0.25, 0.5])
+
+    plan = module.build_resume_plan(tmp_path, TAG, SHA, "-0.5,0,0.5")
+
+    assert plan["source_shard_count"] == 5
+    assert plan["expected_xi_csv"] == "-0.5,0,0.5"
+    assert plan["initial_intervals"] == [["-0.5", "0"], ["0", "0.5"]]
+    assert plan["common_args"][:6] == ["--T-min", "1", "--T-max", "240", "--T-step", "5"]
+    assert "--p-num" in plan["common_args"]
+    assert "--thermo-quadrature-policy" in plan["common_args"]
+
+
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        ({"source_calculation_sha": "b" * 40}, "calculation commits differ"),
+        ({"values": [-0.5, 0.0, 0.5]}, "not an initial staged grid"),
+    ],
+)
+def test_rejects_sha_or_grid_mismatch(tmp_path: Path, kwargs, message):
+    module = load_module()
+    values = kwargs.get("values", [-0.5, -0.25, 0.0, 0.25, 0.5])
+    write_source_manifests(tmp_path, values)
+    with pytest.raises(ValueError, match=message):
+        module.build_resume_plan(tmp_path, TAG, kwargs.get("source_calculation_sha", SHA), "-0.5,0,0.5")
+
+
+def test_rejects_configuration_mismatch(tmp_path: Path):
+    module = load_module()
+    config = base_config()
+    write_source_manifests(tmp_path, [-0.5, -0.25, 0.0, 0.25, 0.5], config=config)
+    second = tmp_path / "shard-1" / f"phase_reference_{TAG}_manifest.json"
+    payload = json.loads(second.read_text(encoding="utf-8"))
+    payload["config"]["p_num"] = 32
+    second.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="configuration mismatch"):
+        module.build_resume_plan(tmp_path, TAG, SHA, "-0.5,0,0.5")
+
+
+def test_rejects_duplicate_xi(tmp_path: Path):
+    module = load_module()
+    write_source_manifests(tmp_path, [-0.5, -0.25, 0.0, 0.25, 0.25])
+
+    with pytest.raises(ValueError, match="duplicate xi"):
+        module.build_resume_plan(tmp_path, TAG, SHA, "-0.5,0,0.5")
+
+
+def test_rejects_single_anchor(tmp_path: Path):
+    module = load_module()
+    write_source_manifests(tmp_path, [0.0])
+
+    with pytest.raises(ValueError, match="at least two anchors"):
+        module.build_resume_plan(tmp_path, TAG, SHA, "0")


### PR DESCRIPTION
## 变更范围

- 修复 dense-reference 主 workflow 与 xi assessment 在 failed-only rerun 后跨 attempt 下载 artifact 的认证路径。
- 新增 source-run resume workflow 与 planner，从已完成的 initial shards 继续 staged xi refinement。
- 更新 PNJL phase SOP、活动任务单和 workflow 合同测试。

## 用户影响

C1 run `29937506668` 已完成的 41 个 initial shards 无需重算。PR 合并后可从原 run 恢复 level-1 assessment，并仅计算后续需要的 level-2/level-3 midpoint shards；C0 不重跑，C2 不由本 PR 自动启动。

## 实现方式

- 所有相关 `actions/download-artifact` 调用显式使用 `actions: read`、GitHub token、repository 和 run ID，避免无凭证 runtime artifact token 的 rerun-attempt 作用域问题。
- resume planner 验证 source calculation SHA、tag、统一 effective config，以及 initial anchors + level-1 midpoints 的精确覆盖，再从 manifest 重建 common CLI args。
- 新 refinement shards 显式 checkout 原 calculation SHA；merge/validator 使用本 PR 的 postprocess SHA，并记录双 SHA 与 source run ID。
- resume 输出明确标记为 diagnostic candidate，不晋升 reference。

## 验证项

- `python -m pytest tests/unit/python -q`：31 passed。
- `julia --project=. -e 'include("tests/unit/pnjl/test_dense_reference_xi_refinement_plan.jl")'`：8/8 passed。
- Python syntax、5 个 dense-reference workflow YAML 解析和 `git diff --check` 通过。
- docs consistency、active docs、SOP governance、script entrypoints、data output path guard、unit skip policy 全部通过。
- 对 C1 仓库外 41-shard audit 目录实测 planner 通过：覆盖 `-0.5:0.025:0.5`，source config SHA256 为 `20fc053f21025fed0d90cd9885e9ef92cdf1ce81142c091e0604335c31c45988`。

## 已知非目标

- 不修改 PNJL solver、数值内核、grid/refinement 物理语义或 effective config。
- 不在本机运行完整 phase production，不启动 C2/C3/O1/formal production。
- workflow success 仍只表示 candidate artifact，不等于 convergence gate 或 production-grade。
- 不覆盖、不晋升任何既有 reference 或 figure。

Closes no issue; continues #130.