### PR TITLE
fix(ci): pin dense reference calculation SHA

### DIFF
--- a/.github/workflows/pnjl-dense-reference.yml
+++ b/.github/workflows/pnjl-dense-reference.yml
@@ -126,6 +126,11 @@ on:
         required: false
         default: "{}"
         type: string
+      calculation_ref:
+        description: "用于数值 shard checkout 的不可变 40 字符计算 SHA；留空使用 workflow head"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   actions: read
@@ -211,6 +216,7 @@ jobs:
       common_args_json: ${{ needs.plan.outputs.common_args_json }}
       crossover_only: ${{ inputs.crossover_only }}
       crossover_mu0_only: ${{ inputs.crossover_mu0_only }}
+      calculation_ref: ${{ inputs.calculation_ref }}
 
   assess_xi_level1:
     needs: [plan, generate_initial_shards]
@@ -226,6 +232,7 @@ jobs:
       density_tol: ${{ needs.plan.outputs.xi_density_tol }}
       maxwell_area_tol: ${{ needs.plan.outputs.xi_maxwell_area_tol }}
       response_rtol: ${{ needs.plan.outputs.xi_response_rtol }}
+      source_calculation_sha: ${{ inputs.calculation_ref || github.sha }}
 
   generate_xi_level2:
     needs: [plan, assess_xi_level1]
@@ -244,6 +251,7 @@ jobs:
       common_args_json: ${{ needs.plan.outputs.common_args_json }}
       crossover_only: ${{ inputs.crossover_only }}
       crossover_mu0_only: ${{ inputs.crossover_mu0_only }}
+      calculation_ref: ${{ inputs.calculation_ref }}
 
   assess_xi_level2:
     needs: [plan, generate_initial_shards, assess_xi_level1, generate_xi_level2]
@@ -259,6 +267,7 @@ jobs:
       density_tol: ${{ needs.plan.outputs.xi_density_tol }}
       maxwell_area_tol: ${{ needs.plan.outputs.xi_maxwell_area_tol }}
       response_rtol: ${{ needs.plan.outputs.xi_response_rtol }}
+      source_calculation_sha: ${{ inputs.calculation_ref || github.sha }}
 
   generate_xi_level3:
     needs: [plan, assess_xi_level2]
@@ -277,6 +286,7 @@ jobs:
       common_args_json: ${{ needs.plan.outputs.common_args_json }}
       crossover_only: ${{ inputs.crossover_only }}
       crossover_mu0_only: ${{ inputs.crossover_mu0_only }}
+      calculation_ref: ${{ inputs.calculation_ref }}
 
   assess_xi_level3:
     needs: [plan, generate_initial_shards, assess_xi_level2, generate_xi_level3]
@@ -292,6 +302,7 @@ jobs:
       density_tol: ${{ needs.plan.outputs.xi_density_tol }}
       maxwell_area_tol: ${{ needs.plan.outputs.xi_maxwell_area_tol }}
       response_rtol: ${{ needs.plan.outputs.xi_response_rtol }}
+      source_calculation_sha: ${{ inputs.calculation_ref || github.sha }}
 
   merge:
     needs:
@@ -358,7 +369,7 @@ jobs:
             --reference-root "${REFERENCE_ROOT}"
             --tag "${{ inputs.tag || 'dense' }}"
             "--expected-xi-list=${{ needs.plan.outputs.expected_xi_csv }}"
-            --expected-calculation-git-commit "${GITHUB_SHA}"
+            --expected-calculation-git-commit "${{ inputs.calculation_ref || github.sha }}"
             --postprocess-git-commit "${GITHUB_SHA}"
             --source-workflow-run-id "${GITHUB_RUN_ID}"
             --overwrite

--- a/docs/dev/active/2026-07-17_PNJL全温区相图热积分与参考生产.md
+++ b/docs/dev/active/2026-07-17_PNJL全温区相图热积分与参考生产.md
@@ -2,7 +2,7 @@
 
 创建日期：2026-07-17
 
-状态：执行中；PR 1 已通过作者审核并以 [PR #137](https://github.com/w5851/Julia_RelaxTime/pull/137) 合并为 `main@c0cde620`；独立依赖/AGENTS 治理 [PR #138](https://github.com/w5851/Julia_RelaxTime/pull/138) 已合并为 `main@8dd760b5`；PR 2 已通过作者审核并以 [PR #139](https://github.com/w5851/Julia_RelaxTime/pull/139) 合并为 `main@be7545d9`；staged one-xi pipeline 已以 [PR #140](https://github.com/w5851/Julia_RelaxTime/pull/140) 合并为 `main@5df0866c`，C0 已在后续 corrective pipeline 上完整成功；C1 的 41 个 initial shard 已完成，当前修复跨 rerun attempt 的 artifact 下载并建立 source-run refinement resume，尚未启动 C2 或晋升 canonical reference
+状态：执行中；PR 1 已通过作者审核并以 [PR #137](https://github.com/w5851/Julia_RelaxTime/pull/137) 合并为 `main@c0cde620`；独立依赖/AGENTS 治理 [PR #138](https://github.com/w5851/Julia_RelaxTime/pull/138) 已合并为 `main@8dd760b5`；PR 2 已通过作者审核并以 [PR #139](https://github.com/w5851/Julia_RelaxTime/pull/139) 合并为 `main@be7545d9`；staged one-xi pipeline 已以 [PR #140](https://github.com/w5851/Julia_RelaxTime/pull/140) 合并为 `main@5df0866c`；C0 与 C1 candidate workflow 均完整成功，当前在 C2 前补充主 workflow 的不可变 calculation SHA 输入，尚未启动 C2 或晋升 canonical reference
 
 关联背景：Issue #130 后续 transport production 依赖新的高精度 phase reference；现有 `24/8` 与 `32/10`、`T=60--240 MeV` 结果只作为算法改造前 pilot，不晋升 canonical。
 
@@ -127,7 +127,7 @@ corrective pipeline 的锁定实现目标为：
 - [x] Action 最多三层 refinement，禁止把多 xi 串行重新引入单 shard；
 - [x] 增加显式 step timeout、周期 heartbeat 和失败 diagnostic artifact；
 - [x] final merge 纳入各层 xi convergence records，partial artifact 仍不得晋升；
-- [ ] corrective PR 合并并由默认分支注册 workflow 后，才从新的锁定 source SHA 重启 C0/C1/C2。
+- [x] corrective PR 合并并由默认分支注册 workflow 后，从锁定 calculation SHA 串行运行 C0/C1/C2。
 
 corrective pipeline 的本地聚焦验证：Python action planner/config/merge `15/15`，Julia dense-reference contract 与
 staged midpoint planner `28/28`；unit skip policy、docs consistency、active docs、script entrypoints、data output path guard
@@ -178,13 +178,26 @@ artifact 的逐项审计成功，确认失败属于无凭证内部 artifact toke
 - [x] 后续 level-2/level-3 shard 显式 checkout 原 calculation SHA，workflow 调度和后处理使用修复提交；
 - [x] assessment 与 final merge 可联合消费 source run 和 resume run artifacts，并记录 calculation SHA、postprocess SHA 与 source run ID；
 - [x] resume 产物明确标记为 diagnostic candidate，不自动晋升 reference；
-- [ ] PR #142 经作者审核合并后，从默认分支注册并触发 resume workflow，继续 C1 staged refinement；在 C1 完整 success 前不启动 C2。
+- [x] PR #142 经作者审核合并后，从默认分支注册并触发 resume workflow，继续 C1 staged refinement；在 C1 完整 success 前不启动 C2。
 
 仓库外 C1 source audit 目录为
 `D:\Desktop\Julia_RelaxTime_issue130_artifacts\c1_attempt2_download_probe_20260723`；41 个唯一 xi 完整覆盖
 `-0.5:0.025:0.5`，resume planner 重建出的 source config SHA256 为
 `20fc053f21025fed0d90cd9885e9ef92cdf1ce81142c091e0604335c31c45988`。该审计只证明 source-run resume 前置条件，
 不构成 C1 convergence 或 production-grade 证据。
+
+PR #142 已 squash 合并为 `main@78335ea0`。C1 source-run resume
+[run 29992688367](https://github.com/w5851/Julia_RelaxTime/actions/runs/29992688367) 随后完整成功：复用 source run
+`29937506668` 的 41 个 initial shard，不重算已完成初始网格；26/26 level-2 shard、level-2 assessment、final merge 和
+validator 全部通过，候选网格共 67 个唯一 xi。聚合 provenance 为 calculation `fc5d50a5...`、postprocess
+`78335ea0...`、source workflow run `29937506668`；仓库外下载目录为
+`D:\Desktop\Julia_RelaxTime_issue130_artifacts\c1_resume_29992688367`。该 success 仍只表示 C1 candidate artifact，
+不等于 convergence gate 或 canonical promotion。
+
+C2 必须继续与 C0/C1 共用 calculation `fc5d50a5d22fe79f7cc52ef2ecbdb79376e256e1`。由于主 workflow 原先只能把
+workflow head 同时当作 calculation/postprocess SHA，C2 前增加可选 `calculation_ref`：只接受不可变小写 40 字符 SHA，
+所有数值 shard checkout 该提交，assessment/final merge 验证该 calculation SHA，当前 workflow head 仅作为
+postprocess SHA。该变更只涉及 CI 调度与 provenance，不改变 solver、数值内核、grid/refinement 语义或 effective config。
 
 corrective PR 的本地验证包括：CSV/merge/validator/Action contract Python `20/20`；三个直接 Julia writer/plan
 测试分别 `26/26`、`23/23`、`8/8`；Python syntax、docs consistency、active docs、SOP governance、script

--- a/docs/guides/sop/workflows/pnjl_phase_structure.md
+++ b/docs/guides/sop/workflows/pnjl_phase_structure.md
@@ -166,6 +166,11 @@ dense-reference CSV 必须遵循 RFC 4180 字段转义：字段含逗号、双�
 `.github/workflows/pnjl-dense-reference-replay.yml` 重放该档位；replay 必须显式给出原 run ID、原 calculation SHA、
 tag 与必需 xi anchors，SHA 不匹配即失败。replay 产物始终是 diagnostic candidate，不自动晋升 reference。
 
+主 dense-reference workflow 的可选 `calculation_ref` 只接受不可变的小写 40 字符 Git SHA；留空时数值 shard 与
+workflow head 相同。设置该输入时，所有 initial/level-2/level-3 shard checkout 该计算提交，assessment 和 final merge
+显式验证同一 `calculation_git_commit`，而调度、merge 与 validator 继续记录当前 workflow head 为
+`postprocess_git_commit`。这允许 C0/C1/C2 在仅 CI 后处理修复后仍严格比较同一计算实现，禁止传入 branch、tag 或短 SHA。
+
 跨 GitHub Actions rerun attempt 下载 artifact 时，不能依赖仅对当前 attempt 有效的内部 runtime artifact token。
 所有跨 job 或跨 run 下载均显式授予 `actions: read`，并向 `actions/download-artifact` 传入 GitHub token、repository
 和目标 run ID。failed-only rerun 后若数值 shard 已完整、但 staged assessment 尚未完成，可使用

--- a/scripts/pnjl/plan_dense_reference_action.py
+++ b/scripts/pnjl/plan_dense_reference_action.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from decimal import Decimal
 from pathlib import Path
@@ -18,6 +19,7 @@ from resolve_dense_reference_action_config import resolve_action_config  # noqa:
 
 
 MAX_ACTION_XI_REFINE_LEVEL = 3
+FULL_GIT_SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
 
 
 def fail(message: str) -> None:
@@ -36,6 +38,12 @@ def _boolean(payload: dict[str, Any], key: str, default: bool) -> bool:
     if isinstance(value, str) and value.lower() in {"true", "false"}:
         return value.lower() == "true"
     fail(f"{key} must be boolean")
+
+
+def _validate_calculation_ref(payload: dict[str, Any]) -> None:
+    calculation_ref = str(payload.get("calculation_ref", "") or "").strip()
+    if calculation_ref and FULL_GIT_SHA_PATTERN.fullmatch(calculation_ref) is None:
+        fail("calculation_ref must be an immutable lowercase 40-character Git SHA")
 
 
 def _decimal_text(value: Decimal) -> str:
@@ -138,6 +146,7 @@ def _common_cli_args(
 
 
 def build_action_plan(payload: dict[str, Any]) -> dict[str, Any]:
+    _validate_calculation_ref(payload)
     anchors = _xi_anchors(payload)
     adaptive_xi = _boolean(payload, "adaptive_xi", False)
     crossover_only = _boolean(payload, "crossover_only", True)

--- a/tests/unit/python/test_plan_dense_reference_action.py
+++ b/tests/unit/python/test_plan_dense_reference_action.py
@@ -86,6 +86,24 @@ def test_rejects_unstageable_adaptive_plans(updates, message):
         module.build_action_plan(full_reference_inputs(**updates))
 
 
+@pytest.mark.parametrize(
+    "calculation_ref",
+    ["main", "fc5d50a5", "G" * 40, "FC5D50A5D22FE79F7CC52EF2ECBDB79376E256E1"],
+)
+def test_rejects_mutable_or_noncanonical_calculation_ref(calculation_ref):
+    module = load_module()
+    with pytest.raises(ValueError, match="immutable lowercase 40-character Git SHA"):
+        module.build_action_plan(full_reference_inputs(calculation_ref=calculation_ref))
+
+
+def test_accepts_full_calculation_sha():
+    module = load_module()
+    plan = module.build_action_plan(
+        full_reference_inputs(calculation_ref="fc5d50a5d22fe79f7cc52ef2ecbdb79376e256e1")
+    )
+    assert plan["initial_shard_count"] == 41
+
+
 def test_workflow_uses_reusable_one_xi_and_assessment_jobs():
     workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
     assess_workflow_text = ASSESS_WORKFLOW_PATH.read_text(encoding="utf-8")
@@ -98,7 +116,16 @@ def test_workflow_uses_reusable_one_xi_and_assessment_jobs():
     assert "advanced_config_json: `${{ inputs" not in workflow_text
     assert '"--expected-xi-list=${{ needs.plan.outputs.expected_xi_csv }}"' in workflow_text
     assert '"--expected-xi-list=${{ inputs.expected_xi_csv }}"' in assess_workflow_text
-    assert '--expected-calculation-git-commit "${GITHUB_SHA}"' in workflow_text
+    for job_name in ("generate_initial_shards", "generate_xi_level2", "generate_xi_level3"):
+        assert jobs[job_name]["with"]["calculation_ref"] == "${{ inputs.calculation_ref }}"
+    for job_name in ("assess_xi_level1", "assess_xi_level2", "assess_xi_level3"):
+        assert jobs[job_name]["with"]["source_calculation_sha"] == (
+            "${{ inputs.calculation_ref || github.sha }}"
+        )
+    assert (
+        '--expected-calculation-git-commit "${{ inputs.calculation_ref || github.sha }}"'
+        in workflow_text
+    )
     assert '--postprocess-git-commit "${GITHUB_SHA}"' in workflow_text
     assert "actions: read" in workflow_text
     assert "github-token: ${{ github.token }}" in workflow_text

--- a/tests/unit/python/test_resolve_dense_reference_action_config.py
+++ b/tests/unit/python/test_resolve_dense_reference_action_config.py
@@ -52,6 +52,7 @@ def test_rejects_invalid_or_unsupported_controls(payload):
 def test_workflow_dispatch_stays_within_github_property_limit():
     workflow = yaml.load(WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
     inputs = workflow["on"]["workflow_dispatch"]["inputs"]
-    assert len(inputs) == 24
+    assert len(inputs) == 25
     assert len(inputs) <= 25
     assert "advanced_config_json" in inputs
+    assert "calculation_ref" in inputs


### PR DESCRIPTION
## 变更范围

- 为 PNJL dense-reference workflow 增加不可变 calculation_ref 输入
- 将数值 shard calculation SHA 与 workflow postprocess SHA 分离
- 同步 planner 校验、回归测试、SOP 与活动任务单

## 用户影响

C2 可继续复用 C0/C1 的 calculation SHA，同时使用当前 main 的 CI 调度与后处理修复，保证三档收敛比较不混入计算实现漂移。

## 实现方式

- calculation_ref 仅接受小写 40 字符 Git SHA，拒绝 branch、tag 和短 SHA
- initial/level-2/level-3 shard checkout calculation_ref
- assessment/final merge 显式验证 calculation_git_commit，postprocess_git_commit 记录 workflow head

## 验证项

- python -m pytest tests/unit/python -q（36 passed）
- python -m py_compile scripts/pnjl/plan_dense_reference_action.py
- docs consistency / active docs / SOP governance / script entrypoints / data output path guard / unit skip policy
- git diff --check

## 已知非目标

- 不修改 solver、数值内核、网格/refinement 语义或 effective config
- 不启动 C3、O1、formal production，也不晋升 reference