### PR TITLE
fix(ci): paginate dense reference artifacts

### DIFF
--- a/.github/workflows/pnjl-dense-reference-assess-xi.yml
+++ b/.github/workflows/pnjl-dense-reference-assess-xi.yml
@@ -67,6 +67,8 @@ jobs:
       next_xi_count: ${{ steps.publish.outputs.next_xi_count }}
     env:
       ARTIFACT_RETENTION_DAYS: "30"
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
       SHARDS_ROOT: data/outputs/artifacts/pnjl_dense_reference/${{ github.run_id }}/assessment_level${{ inputs.level }}/downloaded_shards
       REFERENCE_ROOT: data/outputs/artifacts/pnjl_dense_reference/${{ github.run_id }}/assessment_level${{ inputs.level }}/reference
       PLAN_ROOT: data/outputs/artifacts/pnjl_dense_reference/${{ github.run_id }}/assessment_level${{ inputs.level }}/plan
@@ -81,23 +83,21 @@ jobs:
 
       - name: Download source-run one-xi shards
         if: ${{ inputs.source_run_id != '' }}
-        uses: actions/download-artifact@v4
-        with:
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ inputs.source_run_id }}
-          pattern: pnjl-dense-reference-shard-${{ inputs.tag }}-*
-          path: ${{ env.SHARDS_ROOT }}
+        shell: bash
+        run: |
+          mkdir -p "${SHARDS_ROOT}"
+          gh run download "${{ inputs.source_run_id }}" \
+            --pattern "pnjl-dense-reference-shard-${{ inputs.tag }}-*" \
+            --dir "${SHARDS_ROOT}"
 
       - name: Download current-run one-xi shards
         if: ${{ inputs.include_current_run_shards }}
-        uses: actions/download-artifact@v4
-        with:
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ github.run_id }}
-          pattern: pnjl-dense-reference-shard-${{ inputs.tag }}-*
-          path: ${{ env.SHARDS_ROOT }}
+        shell: bash
+        run: |
+          mkdir -p "${SHARDS_ROOT}"
+          gh run download "${{ github.run_id }}" \
+            --pattern "pnjl-dense-reference-shard-${{ inputs.tag }}-*" \
+            --dir "${SHARDS_ROOT}"
 
       - name: Merge currently resolved xi values
         shell: bash

--- a/.github/workflows/pnjl-dense-reference-replay.yml
+++ b/.github/workflows/pnjl-dense-reference-replay.yml
@@ -24,6 +24,36 @@ on:
         required: false
         default: true
         type: boolean
+      final_assessment_level:
+        description: "可选：补做最终 ξ assessment level；0 表示仅重放 merge"
+        required: false
+        default: "0"
+        type: string
+      final_assessment_intervals_json:
+        description: "最终 assessment 的 intervals JSON；level > 0 时必填"
+        required: false
+        default: "[]"
+        type: string
+      final_assessment_position_tol:
+        description: "最终 assessment 的 ξ 位置容差"
+        required: false
+        default: "0.1"
+        type: string
+      final_assessment_density_tol:
+        description: "最终 assessment 的密度跳变容差"
+        required: false
+        default: "0.01"
+        type: string
+      final_assessment_maxwell_area_tol:
+        description: "最终 assessment 的 Maxwell 面积容差"
+        required: false
+        default: "0.0001"
+        type: string
+      final_assessment_response_rtol:
+        description: "最终 assessment 的响应量相对容差"
+        required: false
+        default: "0.05"
+        type: string
       crossover_only:
         description: "原 run 是否仅生成 crossover reference"
         required: false
@@ -40,11 +70,36 @@ permissions:
   contents: read
 
 jobs:
+  assess_final:
+    if: ${{ fromJSON(inputs.final_assessment_level) > 0 }}
+    uses: ./.github/workflows/pnjl-dense-reference-assess-xi.yml
+    with:
+      tag: ${{ inputs.tag }}
+      level: ${{ fromJSON(inputs.final_assessment_level) }}
+      max_refine_level: ${{ fromJSON(inputs.final_assessment_level) }}
+      intervals_json: ${{ inputs.final_assessment_intervals_json }}
+      expected_xi_csv: ${{ inputs.expected_xi_list }}
+      position_tol: ${{ inputs.final_assessment_position_tol }}
+      density_tol: ${{ inputs.final_assessment_density_tol }}
+      maxwell_area_tol: ${{ inputs.final_assessment_maxwell_area_tol }}
+      response_rtol: ${{ inputs.final_assessment_response_rtol }}
+      source_run_id: ${{ inputs.source_run_id }}
+      source_calculation_sha: ${{ inputs.source_calculation_sha }}
+      include_current_run_shards: false
+
   replay:
+    needs: assess_final
+    if: >-
+      ${{
+        always() &&
+        (fromJSON(inputs.final_assessment_level) == 0 || needs.assess_final.result == 'success')
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       ARTIFACT_RETENTION_DAYS: "30"
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
       SHARDS_ROOT: data/outputs/artifacts/pnjl_dense_reference/replay_${{ github.run_id }}/downloaded_shards
       XI_PLAN_ROOT: data/outputs/artifacts/pnjl_dense_reference/replay_${{ github.run_id }}/downloaded_xi_plans
       REFERENCE_ROOT: data/outputs/artifacts/pnjl_dense_reference/replay_${{ github.run_id }}/reference
@@ -59,23 +114,30 @@ jobs:
           python-version: "3.11"
 
       - name: Download source xi shards
-        uses: actions/download-artifact@v4
-        with:
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ inputs.source_run_id }}
-          pattern: pnjl-dense-reference-shard-${{ inputs.tag }}-*
-          path: ${{ env.SHARDS_ROOT }}
+        shell: bash
+        run: |
+          mkdir -p "${SHARDS_ROOT}"
+          gh run download "${{ inputs.source_run_id }}" \
+            --pattern "pnjl-dense-reference-shard-${{ inputs.tag }}-*" \
+            --dir "${SHARDS_ROOT}"
 
       - name: Download source xi convergence records
         if: ${{ inputs.include_xi_convergence_records }}
-        uses: actions/download-artifact@v4
-        with:
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ inputs.source_run_id }}
-          pattern: pnjl-dense-reference-xi-plan-${{ inputs.tag }}-level*
-          path: ${{ env.XI_PLAN_ROOT }}
+        shell: bash
+        run: |
+          mkdir -p "${XI_PLAN_ROOT}"
+          gh run download "${{ inputs.source_run_id }}" \
+            --pattern "pnjl-dense-reference-xi-plan-${{ inputs.tag }}-level*" \
+            --dir "${XI_PLAN_ROOT}"
+
+      - name: Download replayed final xi convergence record
+        if: ${{ fromJSON(inputs.final_assessment_level) > 0 }}
+        shell: bash
+        run: |
+          mkdir -p "${XI_PLAN_ROOT}"
+          gh run download "${{ github.run_id }}" \
+            --pattern "pnjl-dense-reference-xi-plan-${{ inputs.tag }}-level${{ inputs.final_assessment_level }}" \
+            --dir "${XI_PLAN_ROOT}"
 
       - name: Replay deterministic merge
         shell: bash
@@ -93,7 +155,8 @@ jobs:
             --source-workflow-run-id "${{ inputs.source_run_id }}"
             --overwrite
           )
-          if [ "${{ inputs.include_xi_convergence_records }}" = "true" ]; then
+          if [ "${{ inputs.include_xi_convergence_records }}" = "true" ] || \
+             [ "${{ inputs.final_assessment_level }}" != "0" ]; then
             merge_cmd+=(--xi-convergence-root "${XI_PLAN_ROOT}")
           fi
           "${merge_cmd[@]}"
@@ -145,5 +208,6 @@ jobs:
               handle.write(f"- calculation SHA: `{report['calculation_git_commit']}`\n")
               handle.write(f"- postprocess SHA: `{report['postprocess_git_commit']}`\n")
               handle.write(f"- resolved xi values: `{report['xi_values']}`\n")
+              handle.write(f"- replayed final assessment level: `${{ inputs.final_assessment_level }}`\n")
               handle.write("- status: diagnostic replay only; no reference promotion\n")
           PY

--- a/.github/workflows/pnjl-dense-reference-resume.yml
+++ b/.github/workflows/pnjl-dense-reference-resume.yml
@@ -41,6 +41,8 @@ jobs:
       crossover_only: ${{ steps.publish.outputs.crossover_only }}
       crossover_mu0_only: ${{ steps.publish.outputs.crossover_mu0_only }}
     env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
       SOURCE_SHARDS_ROOT: data/outputs/artifacts/pnjl_dense_reference/resume_${{ github.run_id }}/source_shards
       PLAN_PATH: data/outputs/artifacts/pnjl_dense_reference/resume_${{ github.run_id }}/resume_plan.json
     steps:
@@ -53,13 +55,12 @@ jobs:
           python-version: "3.11"
 
       - name: Download source initial shards
-        uses: actions/download-artifact@v4
-        with:
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ inputs.source_run_id }}
-          pattern: pnjl-dense-reference-shard-${{ inputs.tag }}-*
-          path: ${{ env.SOURCE_SHARDS_ROOT }}
+        shell: bash
+        run: |
+          mkdir -p "${SOURCE_SHARDS_ROOT}"
+          gh run download "${{ inputs.source_run_id }}" \
+            --pattern "pnjl-dense-reference-shard-${{ inputs.tag }}-*" \
+            --dir "${SOURCE_SHARDS_ROOT}"
 
       - name: Validate source grid and reconstruct effective plan
         shell: bash
@@ -218,6 +219,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ARTIFACT_RETENTION_DAYS: "30"
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
       SHARDS_ROOT: data/outputs/artifacts/pnjl_dense_reference/resume_${{ github.run_id }}/downloaded_shards
       XI_PLAN_ROOT: data/outputs/artifacts/pnjl_dense_reference/resume_${{ github.run_id }}/downloaded_xi_plans
       REFERENCE_ROOT: data/outputs/artifacts/pnjl_dense_reference/resume_${{ github.run_id }}/reference
@@ -232,32 +235,29 @@ jobs:
           python-version: "3.11"
 
       - name: Download source initial shards
-        uses: actions/download-artifact@v4
-        with:
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ inputs.source_run_id }}
-          pattern: pnjl-dense-reference-shard-${{ inputs.tag }}-*
-          path: ${{ env.SHARDS_ROOT }}
+        shell: bash
+        run: |
+          mkdir -p "${SHARDS_ROOT}"
+          gh run download "${{ inputs.source_run_id }}" \
+            --pattern "pnjl-dense-reference-shard-${{ inputs.tag }}-*" \
+            --dir "${SHARDS_ROOT}"
 
       - name: Download resumed refinement shards
         if: ${{ fromJSON(needs.assess_xi_level1.outputs.next_xi_count) > 0 }}
-        uses: actions/download-artifact@v4
-        with:
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ github.run_id }}
-          pattern: pnjl-dense-reference-shard-${{ inputs.tag }}-*
-          path: ${{ env.SHARDS_ROOT }}
+        shell: bash
+        run: |
+          mkdir -p "${SHARDS_ROOT}"
+          gh run download "${{ github.run_id }}" \
+            --pattern "pnjl-dense-reference-shard-${{ inputs.tag }}-*" \
+            --dir "${SHARDS_ROOT}"
 
       - name: Download resumed xi convergence records
-        uses: actions/download-artifact@v4
-        with:
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ github.run_id }}
-          pattern: pnjl-dense-reference-xi-plan-${{ inputs.tag }}-level*
-          path: ${{ env.XI_PLAN_ROOT }}
+        shell: bash
+        run: |
+          mkdir -p "${XI_PLAN_ROOT}"
+          gh run download "${{ github.run_id }}" \
+            --pattern "pnjl-dense-reference-xi-plan-${{ inputs.tag }}-level*" \
+            --dir "${XI_PLAN_ROOT}"
 
       - name: Deterministically merge source and resumed shards
         shell: bash

--- a/.github/workflows/pnjl-dense-reference.yml
+++ b/.github/workflows/pnjl-dense-reference.yml
@@ -326,6 +326,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ARTIFACT_RETENTION_DAYS: "30"
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
       SHARDS_ROOT: data/outputs/artifacts/pnjl_dense_reference/${{ github.run_id }}/downloaded_shards
       XI_PLAN_ROOT: data/outputs/artifacts/pnjl_dense_reference/${{ github.run_id }}/downloaded_xi_plans
       REFERENCE_ROOT: data/outputs/artifacts/pnjl_dense_reference/${{ github.run_id }}/reference
@@ -340,23 +342,21 @@ jobs:
           python-version: "3.11"
 
       - name: Download all successful xi shards
-        uses: actions/download-artifact@v4
-        with:
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ github.run_id }}
-          pattern: pnjl-dense-reference-shard-${{ inputs.tag || 'dense' }}-*
-          path: ${{ env.SHARDS_ROOT }}
+        shell: bash
+        run: |
+          mkdir -p "${SHARDS_ROOT}"
+          gh run download "${{ github.run_id }}" \
+            --pattern "pnjl-dense-reference-shard-${{ inputs.tag || 'dense' }}-*" \
+            --dir "${SHARDS_ROOT}"
 
       - name: Download staged xi convergence records
         if: ${{ fromJSON(needs.plan.outputs.xi_refine_levels) >= 1 }}
-        uses: actions/download-artifact@v4
-        with:
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ github.run_id }}
-          pattern: pnjl-dense-reference-xi-plan-${{ inputs.tag || 'dense' }}-level*
-          path: ${{ env.XI_PLAN_ROOT }}
+        shell: bash
+        run: |
+          mkdir -p "${XI_PLAN_ROOT}"
+          gh run download "${{ github.run_id }}" \
+            --pattern "pnjl-dense-reference-xi-plan-${{ inputs.tag || 'dense' }}-level*" \
+            --dir "${XI_PLAN_ROOT}"
 
       - name: Deterministically merge xi shards
         shell: bash

--- a/docs/dev/active/2026-07-17_PNJL全温区相图热积分与参考生产.md
+++ b/docs/dev/active/2026-07-17_PNJL全温区相图热积分与参考生产.md
@@ -208,6 +208,24 @@ level-2 midpoint 候选；把 level-1 convergence records 合并后共 5623 条 
 calculation `5df0866c...`、postprocess `diagnostic-working-tree`、source run `29810188129`。这些结果只验证合同与
 后处理可恢复性，不晋升旧 C0，也不替代修复合并后的正式 C0 重跑。
 
+C2 [run 30073342572](https://github.com/w5851/Julia_RelaxTime/actions/runs/30073342572) 绑定 workflow/postprocess
+`8916a240c87889ff4ab95a62cf698e86d106c148` 与 calculation
+`fc5d50a5d22fe79f7cc52ef2ecbdb79376e256e1`，41 个 initial、40 个 level-2 和 80 个 level-3 数值 shard 共
+161/161 全部成功；唯一失败为 `assess_xi_level3`。attempt 1 与 failed-only attempt 2 都只下载到 99 个 shard
+artifact，随后把 21 个 initial anchors 误报为缺失。仓库外 `gh run download` 获取完整 161 个 shard 并完成
+deterministic merge，证明这是 artifact 枚举超过 100 后的单页下载缺陷，不是数值或物理网格失败。
+
+本轮分页下载 corrective 合同为：
+
+- [x] assessment、主 merge、source resume 和 postprocess replay 的跨 job/run pattern 下载统一使用带
+  `GH_TOKEN`/`GH_REPO` 的 `gh run download`，完整分页枚举 artifact；
+- [x] shard 与 staged xi convergence plan 两类 artifact 使用同一下载合同；
+- [x] replay 可选补做 final assessment，并显式接收 level、intervals JSON 与 position/density/Maxwell/response 容差；
+- [x] replay final merge 联合消费 source run 的 161 个 shard、source level-1/level-2 records 和 replay 新生成的
+  level-3 record；输出保持 diagnostic candidate，不自动晋升 reference；
+- [ ] corrective PR 合并后，从 source run `30073342572` 补做 level-3 assessment、merge 和 validator；禁止重算
+  已完成的 161 个数值 shard。
+
 ### PR 4：transport production
 
 - [ ] 显式绑定新 phase-reference tag、manifest SHA、热积分策略和容差。

--- a/docs/guides/sop/workflows/pnjl_phase_structure.md
+++ b/docs/guides/sop/workflows/pnjl_phase_structure.md
@@ -172,8 +172,9 @@ workflow head 相同。设置该输入时，所有 initial/level-2/level-3 shard
 `postprocess_git_commit`。这允许 C0/C1/C2 在仅 CI 后处理修复后仍严格比较同一计算实现，禁止传入 branch、tag 或短 SHA。
 
 跨 GitHub Actions rerun attempt 下载 artifact 时，不能依赖仅对当前 attempt 有效的内部 runtime artifact token。
-所有跨 job 或跨 run 下载均显式授予 `actions: read`，并向 `actions/download-artifact` 传入 GitHub token、repository
-和目标 run ID。failed-only rerun 后若数值 shard 已完整、但 staged assessment 尚未完成，可使用
+所有跨 job 或跨 run 的 pattern 下载均显式授予 `actions: read`，设置 `GH_TOKEN`/`GH_REPO`，并通过
+`gh run download <run-id> --pattern <pattern>` 获取 artifact。该 CLI 路径会分页枚举整个 run，不能退回只覆盖前/后
+100 个 artifact 的单页下载实现。failed-only rerun 后若数值 shard 已完整、但 staged assessment 尚未完成，可使用
 `.github/workflows/pnjl-dense-reference-resume.yml` 从源 run 恢复后续 xi refinement；该入口只接受 source run ID、
 source calculation SHA、tag 和 initial xi anchors。resume planner 必须从 source manifest 重建 effective CLI config，
 验证源 grid 精确包含 anchors 与 level-1 midpoints，并拒绝 calculation SHA、tag、配置或 grid 不一致。
@@ -182,6 +183,11 @@ resume 新生成的 level-2/level-3 shard 必须 checkout 原 calculation SHA；
 最终 manifest 同时记录原 calculation SHA、新 postprocess SHA 和 source workflow run ID。resume 输出始终是
 diagnostic candidate，不自动晋升 reference；若 solver、数值内核、grid/refinement 语义或 effective config 已改变，
 禁止使用 resume，必须从受影响的最早档位重新计算。
+
+若完整 source run 已生成所有数值 shard、仅最后一级 assessment/merge/validator 未完成，优先使用 postprocess replay
+的可选 final-assessment 输入：显式给出 assessment level、intervals JSON 和原档位四项 xi 容差。replay 的 assessment
+只读取 source run shard，随后 final merge 同时读取 source run 已有 convergence records 与 replay run 新生成的最终
+record；不得在 replay 中生成新数值 shard。输出继续标记为 diagnostic candidate，并保留 calculation/postprocess 双 SHA。
 
 ## 11. Regression / Validation 验收
 
@@ -202,6 +208,8 @@ diagnostic candidate，不自动晋升 reference；若 solver、数值内核、g
 - 后处理修复优先重放已完成且 SHA 已核验的 shard artifacts；不得用 replay 掩盖数值代码或 effective config 变化；
 - failed-only rerun 后 assessment 因跨 attempt 下载失败时，先用 tokenized REST 路径核验 source artifacts，再按上述
   source-run resume 合同恢复 refinement；不得为纯下载故障机械重算完整 initial grid；
+- run 内 artifact 数量超过 100 时，检查下载日志中的实际 artifact 目录数；若与 GitHub run artifact 总数不符，先按
+  分页 `gh run download` 合同修复/重放后处理，不得把缺页误判为物理网格缺失；
 - 不在已有正式目录上用不同 effective config 覆盖运行；
 - CEP 未找到不自动等价于“物理上不存在 CEP”，必须结合扫描覆盖和诊断字段判断。
 

--- a/tests/unit/python/test_plan_dense_reference_action.py
+++ b/tests/unit/python/test_plan_dense_reference_action.py
@@ -128,10 +128,10 @@ def test_workflow_uses_reusable_one_xi_and_assessment_jobs():
     )
     assert '--postprocess-git-commit "${GITHUB_SHA}"' in workflow_text
     assert "actions: read" in workflow_text
-    assert "github-token: ${{ github.token }}" in workflow_text
-    assert "run-id: ${{ github.run_id }}" in workflow_text
-    assert "github-token: ${{ github.token }}" in assess_workflow_text
-    assert "run-id: ${{ github.run_id }}" in assess_workflow_text
+    assert "GH_TOKEN: ${{ github.token }}" in workflow_text
+    assert 'gh run download "${{ github.run_id }}"' in workflow_text
+    assert "GH_TOKEN: ${{ github.token }}" in assess_workflow_text
+    assert 'gh run download "${{ github.run_id }}"' in assess_workflow_text
     assert "next_xi_count" in assess_workflow_text
 
 
@@ -141,7 +141,8 @@ def test_resume_workflow_reuses_source_shards_and_keeps_calculation_sha():
     workflow = yaml.load(workflow_text, Loader=yaml.BaseLoader)
     inputs = workflow["on"]["workflow_dispatch"]["inputs"]
     assert set(inputs) == {"source_run_id", "source_calculation_sha", "tag", "expected_xi_list"}
-    assert "run-id: ${{ inputs.source_run_id }}" in workflow_text
+    assert 'gh run download "${{ inputs.source_run_id }}"' in workflow_text
+    assert "actions/download-artifact@v4" not in workflow_text
     assert "calculation_ref: ${{ inputs.source_calculation_sha }}" in workflow_text
     assert "source and resumed shards" in workflow_text
     assert "diagnostic candidate only; no reference promotion" in workflow_text
@@ -156,8 +157,38 @@ def test_postprocess_replay_uses_cross_run_artifacts_and_dual_provenance():
     workflow = yaml.load(workflow_text, Loader=yaml.BaseLoader)
     inputs = workflow["on"]["workflow_dispatch"]["inputs"]
     assert {"source_run_id", "source_calculation_sha", "tag", "expected_xi_list"} <= set(inputs)
-    assert "run-id: ${{ inputs.source_run_id }}" in workflow_text
-    assert "github-token: ${{ github.token }}" in workflow_text
+    assert {
+        "final_assessment_level",
+        "final_assessment_intervals_json",
+        "final_assessment_position_tol",
+        "final_assessment_density_tol",
+        "final_assessment_maxwell_area_tol",
+        "final_assessment_response_rtol",
+    } <= set(inputs)
+    assert 'gh run download "${{ inputs.source_run_id }}"' in workflow_text
+    assert 'gh run download "${{ github.run_id }}"' in workflow_text
+    assert "GH_TOKEN: ${{ github.token }}" in workflow_text
+    assert "actions/download-artifact@v4" not in workflow_text
+    jobs = workflow["jobs"]
+    assert jobs["assess_final"]["uses"] == "./.github/workflows/pnjl-dense-reference-assess-xi.yml"
+    assert jobs["assess_final"]["with"]["source_calculation_sha"] == "${{ inputs.source_calculation_sha }}"
+    assert jobs["assess_final"]["with"]["include_current_run_shards"] == "false"
+    assert "needs.assess_final.result == 'success'" in workflow_text
+    assert "replayed final xi convergence record" in workflow_text
     assert '--expected-calculation-git-commit "${{ inputs.source_calculation_sha }}"' in workflow_text
     assert '--postprocess-git-commit "${GITHUB_SHA}"' in workflow_text
     assert "diagnostic replay only; no reference promotion" in workflow_text
+
+
+def test_dense_reference_cross_job_downloads_use_paginated_gh_cli():
+    for path in (
+        WORKFLOW_PATH,
+        ASSESS_WORKFLOW_PATH,
+        REPLAY_WORKFLOW_PATH,
+        RESUME_WORKFLOW_PATH,
+    ):
+        workflow_text = path.read_text(encoding="utf-8")
+        assert "actions/download-artifact@v4" not in workflow_text
+        assert "gh run download" in workflow_text
+        assert "GH_TOKEN: ${{ github.token }}" in workflow_text
+        assert "GH_REPO: ${{ github.repository }}" in workflow_text


### PR DESCRIPTION
## Summary
- replace dense-reference cross-job/run pattern downloads with token-authenticated gh run download, avoiding the 100-artifact enumeration ceiling
- allow postprocess replay to reconstruct a final xi assessment before merge/validation
- document the C2 failure diagnosis and no-recompute recovery contract

## Numerical scope
- no solver, numerical kernel, grid/refinement semantics, or effective-config changes
- C2 calculation SHA remains c5d50a5d22fe79f7cc52ef2ecbdb79376e256e1`n- replay remains diagnostic candidate only

## Validation
- python -m pytest tests/unit/python/test_plan_dense_reference_action.py tests/unit/python/test_plan_dense_reference_resume.py tests/unit/python/test_merge_dense_phase_reference_shards.py -q (26 passed)
- Python script syntax check
- docs consistency, SOP governance, active-doc governance
- script entrypoint, data-output-path, and unit-skip policy checks